### PR TITLE
fix: torchvisionの非推奨警告を修正

### DIFF
--- a/pochitrain/models/pochi_models.py
+++ b/pochitrain/models/pochi_models.py
@@ -36,8 +36,9 @@ class PochiModel(nn.Module):
                 f"サポートされているモデル: {list(supported_models.keys())}"
             )
 
-        # モデルの作成
-        self.model = supported_models[model_name](pretrained=pretrained)
+        # モデルの作成 - 新しいweights APIを使用
+        weights = "DEFAULT" if pretrained else None
+        self.model = supported_models[model_name](weights=weights)
 
         # 最終層を置き換え
         if hasattr(self.model, "fc"):


### PR DESCRIPTION
- pretrained=パラメータをweights=パラメータに更新
- pretrained=True → weights='DEFAULT'
- pretrained=False → weights=None
- torchvision 0.13以降の推奨APIに対応
- 警告が完全に解消されテストも全て通過