### PR TITLE
feat: データセットファイルパス出力機能を追加

### DIFF
--- a/pochi.py
+++ b/pochi.py
@@ -110,6 +110,10 @@ def main():
         scheduler_params=config.get("scheduler_params"),
     )
 
+    # データセットパスの保存
+    print("\nデータセットパスを保存しています...")
+    trainer.save_dataset_paths(train_loader, val_loader)
+
     # 訓練実行
     print("\n訓練を開始します...")
     trainer.train(

--- a/pochitrain/pochi_dataset.py
+++ b/pochitrain/pochi_dataset.py
@@ -99,11 +99,20 @@ class PochiImageDataset(Dataset):
         return self.classes
 
     def get_class_counts(self) -> dict:
-        """各クラスのサンプル数を取得."""
+        """各クラスの画像数を取得."""
         counts = {}
-        for cls_name in self.classes:
-            counts[cls_name] = self.labels.count(self.classes.index(cls_name))
+        for class_name in self.classes:
+            counts[class_name] = self.labels.count(self.classes.index(class_name))
         return counts
+
+    def get_file_paths(self) -> List[str]:
+        """
+        データセット内のすべてのファイルパスを取得.
+
+        Returns:
+            List[str]: ファイルパスのリスト
+        """
+        return [str(path) for path in self.image_paths]
 
 
 def get_basic_transforms(

--- a/pochitrain/pochi_trainer.py
+++ b/pochitrain/pochi_trainer.py
@@ -398,3 +398,44 @@ class PochiTrainer:
             Path: 保存されたファイルのパス
         """
         return self.workspace_manager.save_image_list(image_paths)
+
+    def save_dataset_paths(
+        self, train_loader: DataLoader, val_loader: Optional[DataLoader] = None
+    ) -> Tuple[Path, Optional[Path]]:
+        """
+        訓練・検証データのファイルパスを保存.
+
+        Args:
+            train_loader (DataLoader): 訓練データローダー
+            val_loader (DataLoader, optional): 検証データローダー
+
+        Returns:
+            Tuple[Path, Optional[Path]]: 保存されたファイルのパス (train.txt, val.txt)
+        """
+        # 訓練データのパスを取得
+        train_paths = []
+        if hasattr(train_loader.dataset, "get_file_paths"):
+            train_paths = train_loader.dataset.get_file_paths()
+        else:
+            self.logger.warning("訓練データセットにget_file_pathsメソッドがありません")
+
+        # 検証データのパスを取得
+        val_paths: Optional[list] = None
+        if val_loader is not None:
+            if hasattr(val_loader.dataset, "get_file_paths"):
+                val_paths = val_loader.dataset.get_file_paths()
+            else:
+                self.logger.warning(
+                    "検証データセットにget_file_pathsメソッドがありません"
+                )
+
+        # パスを保存
+        train_file_path, val_file_path = self.workspace_manager.save_dataset_paths(
+            train_paths, val_paths
+        )
+
+        self.logger.info(f"訓練データパスを保存: {train_file_path}")
+        if val_file_path is not None:
+            self.logger.info(f"検証データパスを保存: {val_file_path}")
+
+        return train_file_path, val_file_path


### PR DESCRIPTION
- ワークスペースにpathsディレクトリを自動作成
- 訓練・検証データのファイルパスをtrain.txt、val.txt として出力
- 実験の再現性向上のためのパス記録機能を実装