### PR TITLE
feat: 設定ファイルからのデータ変換制御機能を追加

### DIFF
--- a/configs/pochi_config.py
+++ b/configs/pochi_config.py
@@ -1,17 +1,19 @@
 """pochitrain Pochi設定ファイル."""
 
+import torchvision.transforms as transforms
+
 # pochitrain Pochi設定ファイル
 
 # モデル設定
 model_name = "resnet18"  # 'resnet18', 'resnet34', 'resnet50'
-num_classes = 10  # 分類クラス数
+num_classes = 4  # 分類クラス数
 pretrained = True  # 事前学習済みモデルを使用
 
 # データ設定
 train_data_root = "data/train"  # 訓練データのパス
 val_data_root = "data/val"  # 検証データのパス（Noneの場合は検証なし）
 image_size = 224  # 画像サイズ
-batch_size = 2  # バッチサイズ
+batch_size = 16  # バッチサイズ
 num_workers = 4  # データローダーのワーカー数
 
 # 訓練設定
@@ -26,3 +28,36 @@ scheduler_params = {"step_size": 30, "gamma": 0.1}
 # その他設定
 work_dir = "work_dirs"  # 作業ディレクトリ
 device = None  # デバイス (None で自動選択)
+
+# === データ変換設定 ===
+# 基本パラメータ
+mean = [0.485, 0.456, 0.406]  # ImageNet標準値
+std = [0.229, 0.224, 0.225]  # ImageNet標準値
+
+# 訓練用変換（最小限構成）
+train_transform = transforms.Compose(
+    [
+        transforms.ToTensor(),
+        transforms.Normalize(mean=mean, std=std),
+    ]
+)
+
+# 検証用変換（リサイズあり）
+val_transform = transforms.Compose(
+    [
+        transforms.Resize(256),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=mean, std=std),
+    ]
+)
+
+# リサイズなしの例（コメントアウト）
+# train_transform = transforms.Compose([
+#     transforms.ToTensor(),
+#     transforms.Normalize(mean=mean, std=std),
+# ])
+#
+# val_transform = transforms.Compose([
+#     transforms.ToTensor(),
+#     transforms.Normalize(mean=mean, std=std),
+# ])

--- a/pochi.py
+++ b/pochi.py
@@ -77,6 +77,8 @@ def main():
             batch_size=config["batch_size"],
             image_size=config["image_size"],
             num_workers=config["num_workers"],
+            train_transform=config.get("train_transform"),
+            val_transform=config.get("val_transform"),
         )
 
         logger.info(f"クラス数: {len(classes)}")

--- a/pochitrain/pochi_dataset.py
+++ b/pochitrain/pochi_dataset.py
@@ -165,6 +165,8 @@ def create_data_loaders(
     image_size: int = 224,
     num_workers: int = 4,
     pin_memory: bool = True,
+    train_transform=None,
+    val_transform=None,
 ) -> Tuple[DataLoader, Optional[DataLoader], List[str]]:
     """
     データローダーを作成.
@@ -176,12 +178,15 @@ def create_data_loaders(
         image_size (int): 画像サイズ
         num_workers (int): ワーカー数
         pin_memory (bool): メモリピニング
+        train_transform (transforms.Compose, optional): 訓練用変換
+        val_transform (transforms.Compose, optional): 検証用変換
 
     Returns:
         Tuple[DataLoader, Optional[DataLoader], List[str]]: (訓練ローダー, 検証ローダー, クラス名)
     """
     # 訓練データセット
-    train_transform = get_basic_transforms(image_size, is_training=True)
+    if train_transform is None:
+        train_transform = get_basic_transforms(image_size, is_training=True)
     train_dataset = PochiImageDataset(train_root, transform=train_transform)
 
     train_loader = DataLoader(
@@ -195,7 +200,8 @@ def create_data_loaders(
     # 検証データセット
     val_loader = None
     if val_root:
-        val_transform = get_basic_transforms(image_size, is_training=False)
+        if val_transform is None:
+            val_transform = get_basic_transforms(image_size, is_training=False)
         val_dataset = PochiImageDataset(val_root, transform=val_transform)
 
         val_loader = DataLoader(


### PR DESCRIPTION
- create_data_loaders関数にtrain_transform/val_transformパラメータを追加
- pochi.pyで設定ファイルからtransformを読み込んで渡すように修正
- pochi_config.pyでtorchvision.transformsを直接定義可能に
- importlib.utilの利点を活かしたPythonコードベースの設定を実現
- 最小限のtransform構成（ToTensor + Normalize + 任意のResize）をサポート