### PR TITLE
feat: 検証データを必須化し、データローダー作成を統一

### DIFF
--- a/pochi.py
+++ b/pochi.py
@@ -74,7 +74,7 @@ def main():
     try:
         train_loader, val_loader, classes = create_data_loaders(
             train_root=config["train_data_root"],
-            val_root=config.get("val_data_root"),
+            val_root=config["val_data_root"],  # 必須に変更
             batch_size=config["batch_size"],
             num_workers=config["num_workers"],
             train_transform=config.get("train_transform"),
@@ -84,8 +84,7 @@ def main():
         logger.info(f"クラス数: {len(classes)}")
         logger.info(f"クラス名: {classes}")
         logger.info(f"訓練バッチ数: {len(train_loader)}")
-        if val_loader:
-            logger.info(f"検証バッチ数: {len(val_loader)}")
+        logger.info(f"検証バッチ数: {len(val_loader)}")
 
         # 設定のクラス数を更新
         config["num_classes"] = len(classes)

--- a/pochitrain/pochi_dataset.py
+++ b/pochitrain/pochi_dataset.py
@@ -160,27 +160,27 @@ def get_basic_transforms(
 
 def create_data_loaders(
     train_root: str,
-    val_root: Optional[str] = None,
+    val_root: str,
     batch_size: int = 32,
     num_workers: int = 4,
     pin_memory: bool = True,
     train_transform=None,
     val_transform=None,
-) -> Tuple[DataLoader, Optional[DataLoader], List[str]]:
+) -> Tuple[DataLoader, DataLoader, List[str]]:
     """
     データローダーを作成.
 
     Args:
         train_root (str): 訓練データのルートディレクトリ
-        val_root (str, optional): 検証データのルートディレクトリ
+        val_root (str): 検証データのルートディレクトリ（必須）
         batch_size (int): バッチサイズ
         num_workers (int): ワーカー数
         pin_memory (bool): メモリピニング
         train_transform (transforms.Compose): 訓練用変換（必須）
-        val_transform (transforms.Compose): 検証用変換（val_root指定時は必須）
+        val_transform (transforms.Compose): 検証用変換（必須）
 
     Returns:
-        Tuple[DataLoader, Optional[DataLoader], List[str]]: (訓練ローダー, 検証ローダー, クラス名)
+        Tuple[DataLoader, DataLoader, List[str]]: (訓練ローダー, 検証ローダー, クラス名)
     """
     # Transform必須バリデーション
     if train_transform is None:
@@ -189,11 +189,10 @@ def create_data_loaders(
             "transforms.Compose([...]) を train_transform として定義してください。"
         )
 
-    if val_root is not None and val_transform is None:
+    if val_transform is None:
         raise ValueError(
-            "検証データが指定されている場合、val_transform が必須です。"
-            "configs/pochi_config.py で transforms.Compose([...]) を "
-            "val_transform として定義してください。"
+            "val_transform が必須です。configs/pochi_config.py で "
+            "transforms.Compose([...]) を val_transform として定義してください。"
         )
 
     # 訓練データセット
@@ -208,17 +207,15 @@ def create_data_loaders(
     )
 
     # 検証データセット
-    val_loader = None
-    if val_root:
-        val_dataset = PochiImageDataset(val_root, transform=val_transform)
+    val_dataset = PochiImageDataset(val_root, transform=val_transform)
 
-        val_loader = DataLoader(
-            val_dataset,
-            batch_size=batch_size,
-            shuffle=False,
-            num_workers=num_workers,
-            pin_memory=pin_memory,
-        )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+    )
 
     return train_loader, val_loader, train_dataset.get_classes()
 


### PR DESCRIPTION
- create_data_loadersで検証データ(val_root)を必須パラメータに変更
- 戻り値型をTuple[DataLoader, Optional[DataLoader], List[str]]からTuple[DataLoader, DataLoader, List[str]]に変更
- 検証データセット作成の条件分岐(if val_root:)を削除し、訓練データセットと同様の処理に統一
- val_transformのバリデーションを常に必須に変更
- テストコードを更新して新しい必須要件に対応
- pochi.pyでのval_data_root参照をconfig.get()から直接参照に変更