### PR TITLE
feat: スケジューラー設定の明示化とバリデーション機能を追加

### DIFF
--- a/pochi.py
+++ b/pochi.py
@@ -76,6 +76,24 @@ def main():
         logger.error("設定にエラーがあります。修正してください。")
         return
 
+    # バリデーション成功後の設定ログ出力（SchedulerValidatorで出力済みだが、再確認用）
+    logger.info("=== 設定確認 ===")
+    logger.info(f"モデル: {config['model_name']}")
+    logger.info(f"デバイス: {config['device']}")
+    logger.info(f"学習率: {config['learning_rate']}")
+    logger.info(f"オプティマイザー: {config['optimizer']}")
+
+    # スケジューラー設定の明示的ログ出力
+    scheduler_name = config.get("scheduler")
+    if scheduler_name is None:
+        logger.info("スケジューラー: なし（固定学習率）")
+    else:
+        logger.info(f"スケジューラー: {scheduler_name}")
+        scheduler_params = config.get("scheduler_params", {})
+        logger.info(f"スケジューラーパラメータ: {scheduler_params}")
+
+    logger.info("==================")
+
     # データローダーの作成
     logger.info("データローダーを作成しています...")
     try:

--- a/pochitrain/validation/config_validator.py
+++ b/pochitrain/validation/config_validator.py
@@ -7,7 +7,12 @@
 import logging
 from typing import Any, Dict, Protocol
 
-from .validators import DataValidator, DeviceValidator, TransformValidator
+from .validators import (
+    DataValidator,
+    DeviceValidator,
+    SchedulerValidator,
+    TransformValidator,
+)
 
 
 class ValidatorProtocol(Protocol):
@@ -32,6 +37,7 @@ class ConfigValidator:
         self.device_validator = DeviceValidator()
         self.transform_validator = TransformValidator()
         self.data_validator = DataValidator()
+        self.scheduler_validator = SchedulerValidator()
 
     def validate(self, config: Dict[str, Any]) -> bool:
         """
@@ -48,6 +54,7 @@ class ConfigValidator:
             self.data_validator,  # データパス（最初にチェック）
             self.transform_validator,  # Transform設定
             self.device_validator,  # デバイス設定
+            self.scheduler_validator,  # スケジューラー設定
         ]
 
         for validator in validators:

--- a/pochitrain/validation/validators/__init__.py
+++ b/pochitrain/validation/validators/__init__.py
@@ -6,6 +6,12 @@ pochitrain.validation.validators: 個別バリデーターモジュール.
 
 from .data_validator import DataValidator
 from .device_validator import DeviceValidator
+from .scheduler_validator import SchedulerValidator
 from .transform_validator import TransformValidator
 
-__all__ = ["DeviceValidator", "TransformValidator", "DataValidator"]
+__all__ = [
+    "DeviceValidator",
+    "TransformValidator",
+    "DataValidator",
+    "SchedulerValidator",
+]

--- a/pochitrain/validation/validators/scheduler_validator.py
+++ b/pochitrain/validation/validators/scheduler_validator.py
@@ -1,0 +1,251 @@
+"""スケジューラー設定のバリデーションを行うモジュール."""
+
+import logging
+from typing import Any, Dict
+
+
+class SchedulerValidator:
+    """
+    スケジューラー設定のバリデーションを行うクラス.
+
+    サポートするスケジューラー:
+    - 'StepLR': step_size (int) が必須
+    - 'MultiStepLR': milestones (List[int]) が必須
+    - 'CosineAnnealingLR': T_max (int) が必須
+    - None: スケジューラーなし（固定学習率）
+    """
+
+    def __init__(self) -> None:
+        """SchedulerValidatorを初期化."""
+        # サポートするスケジューラーの必須パラメータ定義
+        self.supported_schedulers = {
+            "StepLR": ["step_size"],
+            "MultiStepLR": ["milestones"],
+            "CosineAnnealingLR": ["T_max"],
+        }
+
+    def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
+        """
+        スケジューラー設定をバリデーション.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        scheduler = config.get("scheduler")
+        scheduler_params = config.get("scheduler_params")
+
+        # scheduler設定の確認
+        if scheduler is None:
+            logger.info("スケジューラー: なし（固定学習率）")
+            return True
+
+        # 未サポートスケジューラーのチェック
+        if scheduler not in self.supported_schedulers:
+            supported_list = list(self.supported_schedulers.keys()) + ["None"]
+            logger.error(
+                f"未サポートのスケジューラーです: {scheduler}. "
+                f"サポート対象: {supported_list}"
+            )
+            return False
+
+        # scheduler_paramsの存在確認
+        if scheduler_params is None:
+            logger.error(
+                f"スケジューラー '{scheduler}' を使用する場合、"
+                f"scheduler_paramsが必須です"
+            )
+            return False
+
+        if not isinstance(scheduler_params, dict):
+            logger.error(
+                f"scheduler_paramsは辞書型である必要があります。"
+                f"現在の型: {type(scheduler_params)}"
+            )
+            return False
+
+        # 必須パラメータの確認
+        required_params = self.supported_schedulers[scheduler]
+        missing_params = []
+
+        for param in required_params:
+            if param not in scheduler_params:
+                missing_params.append(param)
+
+        if missing_params:
+            logger.error(
+                f"スケジューラー '{scheduler}' に必須パラメータが不足しています: "
+                f"{missing_params}"
+            )
+            return False
+
+        # パラメータ値の型・範囲検証
+        if not self._validate_scheduler_params(scheduler, scheduler_params, logger):
+            return False
+
+        # 成功時のログ出力
+        logger.info(f"スケジューラー: {scheduler}")
+        logger.info(f"スケジューラーパラメータ: {scheduler_params}")
+
+        return True
+
+    def _validate_scheduler_params(
+        self, scheduler: str, params: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """
+        スケジューラー別のパラメータ詳細検証.
+
+        Args:
+            scheduler (str): スケジューラー名
+            params (Dict[str, Any]): パラメータ辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: 検証成功時True、失敗時False
+        """
+        if scheduler == "StepLR":
+            return self._validate_step_lr_params(params, logger)
+        elif scheduler == "MultiStepLR":
+            return self._validate_multi_step_lr_params(params, logger)
+        elif scheduler == "CosineAnnealingLR":
+            return self._validate_cosine_annealing_lr_params(params, logger)
+        else:
+            return True
+
+    def _validate_step_lr_params(
+        self, params: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """StepLRのパラメータ検証."""
+        step_size = params.get("step_size")
+
+        if not isinstance(step_size, int):
+            logger.error(
+                f"StepLRのstep_sizeは整数である必要があります。"
+                f"現在の値: {step_size} (型: {type(step_size)})"
+            )
+            return False
+
+        if step_size <= 0:
+            logger.error(
+                f"StepLRのstep_sizeは正の整数である必要があります。"
+                f"現在の値: {step_size}"
+            )
+            return False
+
+        # gammaパラメータがある場合の検証（オプション）
+        gamma = params.get("gamma", 0.1)  # デフォルト値
+        if not isinstance(gamma, (int, float)):
+            logger.error(
+                f"StepLRのgammaは数値である必要があります。"
+                f"現在の値: {gamma} (型: {type(gamma)})"
+            )
+            return False
+
+        if gamma <= 0 or gamma >= 1:
+            logger.error(
+                f"StepLRのgammaは0〜1の範囲である必要があります。" f"現在の値: {gamma}"
+            )
+            return False
+
+        return True
+
+    def _validate_multi_step_lr_params(
+        self, params: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """MultiStepLRのパラメータ検証."""
+        milestones = params.get("milestones")
+
+        if not isinstance(milestones, list):
+            logger.error(
+                f"MultiStepLRのmilestonesはリストである必要があります。"
+                f"現在の型: {type(milestones)}"
+            )
+            return False
+
+        if not milestones:
+            logger.error("MultiStepLRのmilestonesは空リストにできません")
+            return False
+
+        # 各要素の型確認
+        for i, milestone in enumerate(milestones):
+            if not isinstance(milestone, int):
+                logger.error(
+                    f"MultiStepLRのmilestones[{i}]は整数である必要があります。"
+                    f"現在の値: {milestone} (型: {type(milestone)})"
+                )
+                return False
+
+            if milestone <= 0:
+                logger.error(
+                    f"MultiStepLRのmilestones[{i}]は正の整数である必要があります。"
+                    f"現在の値: {milestone}"
+                )
+                return False
+
+        # 昇順確認
+        sorted_milestones = sorted(milestones)
+        if milestones != sorted_milestones:
+            logger.error(
+                f"MultiStepLRのmilestonesは昇順である必要があります。"
+                f"現在: {milestones}, 期待: {sorted_milestones}"
+            )
+            return False
+
+        # gammaパラメータがある場合の検証（オプション）
+        gamma = params.get("gamma", 0.1)  # デフォルト値
+        if not isinstance(gamma, (int, float)):
+            logger.error(
+                f"MultiStepLRのgammaは数値である必要があります。"
+                f"現在の値: {gamma} (型: {type(gamma)})"
+            )
+            return False
+
+        if gamma <= 0 or gamma >= 1:
+            logger.error(
+                f"MultiStepLRのgammaは0〜1の範囲である必要があります。"
+                f"現在の値: {gamma}"
+            )
+            return False
+
+        return True
+
+    def _validate_cosine_annealing_lr_params(
+        self, params: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """CosineAnnealingLRのパラメータ検証."""
+        T_max = params.get("T_max")
+
+        if not isinstance(T_max, int):
+            logger.error(
+                f"CosineAnnealingLRのT_maxは整数である必要があります。"
+                f"現在の値: {T_max} (型: {type(T_max)})"
+            )
+            return False
+
+        if T_max <= 0:
+            logger.error(
+                f"CosineAnnealingLRのT_maxは正の整数である必要があります。"
+                f"現在の値: {T_max}"
+            )
+            return False
+
+        # eta_minパラメータがある場合の検証（オプション）
+        eta_min = params.get("eta_min", 0)  # デフォルト値
+        if not isinstance(eta_min, (int, float)):
+            logger.error(
+                f"CosineAnnealingLRのeta_minは数値である必要があります。"
+                f"現在の値: {eta_min} (型: {type(eta_min)})"
+            )
+            return False
+
+        if eta_min < 0:
+            logger.error(
+                f"CosineAnnealingLRのeta_minは非負の値である必要があります。"
+                f"現在の値: {eta_min}"
+            )
+            return False
+
+        return True

--- a/tests/unit/test_validation/test_validators/test_scheduler_validator.py
+++ b/tests/unit/test_validation/test_validators/test_scheduler_validator.py
@@ -1,0 +1,243 @@
+"""
+SchedulerValidatorのユニットテスト.
+"""
+
+import logging
+import unittest
+from unittest.mock import Mock
+
+from pochitrain.validation.validators.scheduler_validator import SchedulerValidator
+
+
+class TestSchedulerValidator(unittest.TestCase):
+    """SchedulerValidatorのテストクラス."""
+
+    def setUp(self):
+        """テストセットアップ."""
+        self.mock_logger = Mock(spec=logging.Logger)
+        self.validator = SchedulerValidator()
+
+    def test_scheduler_none_success(self):
+        """scheduler=Noneでバリデーション成功."""
+        config = {"scheduler": None}
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertTrue(result)
+        self.mock_logger.info.assert_called_with("スケジューラー: なし（固定学習率）")
+
+    def test_scheduler_missing_success(self):
+        """schedulerキーなしでバリデーション成功."""
+        config = {}
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertTrue(result)
+        self.mock_logger.info.assert_called_with("スケジューラー: なし（固定学習率）")
+
+    def test_unsupported_scheduler_failure(self):
+        """未サポートスケジューラーでバリデーション失敗."""
+        config = {"scheduler": "UnsupportedLR"}
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_scheduler_params_missing_failure(self):
+        """scheduler_params未設定でバリデーション失敗."""
+        config = {"scheduler": "StepLR"}
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_scheduler_params_none_failure(self):
+        """scheduler_params=Noneでバリデーション失敗."""
+        config = {"scheduler": "StepLR", "scheduler_params": None}
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_scheduler_params_invalid_type_failure(self):
+        """scheduler_paramsが辞書型でない場合バリデーション失敗."""
+        config = {"scheduler": "StepLR", "scheduler_params": "invalid"}
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    # StepLRのテスト
+    def test_step_lr_valid_success(self):
+        """StepLRの有効なパラメータでバリデーション成功."""
+        config = {
+            "scheduler": "StepLR",
+            "scheduler_params": {"step_size": 30, "gamma": 0.1},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertTrue(result)
+        self.mock_logger.info.assert_any_call("スケジューラー: StepLR")
+
+    def test_step_lr_missing_step_size_failure(self):
+        """StepLRでstep_size未設定でバリデーション失敗."""
+        config = {"scheduler": "StepLR", "scheduler_params": {"gamma": 0.1}}
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_step_lr_invalid_step_size_type_failure(self):
+        """StepLRでstep_sizeが整数でない場合バリデーション失敗."""
+        config = {
+            "scheduler": "StepLR",
+            "scheduler_params": {"step_size": "30", "gamma": 0.1},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_step_lr_negative_step_size_failure(self):
+        """StepLRでstep_sizeが負の値の場合バリデーション失敗."""
+        config = {
+            "scheduler": "StepLR",
+            "scheduler_params": {"step_size": -5, "gamma": 0.1},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_step_lr_invalid_gamma_failure(self):
+        """StepLRでgammaが範囲外の場合バリデーション失敗."""
+        config = {
+            "scheduler": "StepLR",
+            "scheduler_params": {"step_size": 30, "gamma": 1.5},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    # MultiStepLRのテスト
+    def test_multi_step_lr_valid_success(self):
+        """MultiStepLRの有効なパラメータでバリデーション成功."""
+        config = {
+            "scheduler": "MultiStepLR",
+            "scheduler_params": {"milestones": [30, 60, 90], "gamma": 0.1},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertTrue(result)
+        self.mock_logger.info.assert_any_call("スケジューラー: MultiStepLR")
+
+    def test_multi_step_lr_missing_milestones_failure(self):
+        """MultiStepLRでmilestones未設定でバリデーション失敗."""
+        config = {"scheduler": "MultiStepLR", "scheduler_params": {"gamma": 0.1}}
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_multi_step_lr_empty_milestones_failure(self):
+        """MultiStepLRでmilestonesが空リストの場合バリデーション失敗."""
+        config = {
+            "scheduler": "MultiStepLR",
+            "scheduler_params": {"milestones": [], "gamma": 0.1},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_multi_step_lr_invalid_milestones_type_failure(self):
+        """MultiStepLRでmilestonesがリストでない場合バリデーション失敗."""
+        config = {
+            "scheduler": "MultiStepLR",
+            "scheduler_params": {"milestones": "30,60,90", "gamma": 0.1},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_multi_step_lr_unsorted_milestones_failure(self):
+        """MultiStepLRでmilestonesが昇順でない場合バリデーション失敗."""
+        config = {
+            "scheduler": "MultiStepLR",
+            "scheduler_params": {"milestones": [60, 30, 90], "gamma": 0.1},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_multi_step_lr_negative_milestone_failure(self):
+        """MultiStepLRでmilestonesに負の値が含まれる場合バリデーション失敗."""
+        config = {
+            "scheduler": "MultiStepLR",
+            "scheduler_params": {"milestones": [-10, 30, 60], "gamma": 0.1},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    # CosineAnnealingLRのテスト
+    def test_cosine_annealing_lr_valid_success(self):
+        """CosineAnnealingLRの有効なパラメータでバリデーション成功."""
+        config = {
+            "scheduler": "CosineAnnealingLR",
+            "scheduler_params": {"T_max": 100, "eta_min": 0.001},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertTrue(result)
+        self.mock_logger.info.assert_any_call("スケジューラー: CosineAnnealingLR")
+
+    def test_cosine_annealing_lr_missing_t_max_failure(self):
+        """CosineAnnealingLRでT_max未設定でバリデーション失敗."""
+        config = {
+            "scheduler": "CosineAnnealingLR",
+            "scheduler_params": {"eta_min": 0.001},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_cosine_annealing_lr_invalid_t_max_type_failure(self):
+        """CosineAnnealingLRでT_maxが整数でない場合バリデーション失敗."""
+        config = {
+            "scheduler": "CosineAnnealingLR",
+            "scheduler_params": {"T_max": "100", "eta_min": 0.001},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_cosine_annealing_lr_negative_t_max_failure(self):
+        """CosineAnnealingLRでT_maxが負の値の場合バリデーション失敗."""
+        config = {
+            "scheduler": "CosineAnnealingLR",
+            "scheduler_params": {"T_max": -50, "eta_min": 0.001},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+    def test_cosine_annealing_lr_negative_eta_min_failure(self):
+        """CosineAnnealingLRでeta_minが負の値の場合バリデーション失敗."""
+        config = {
+            "scheduler": "CosineAnnealingLR",
+            "scheduler_params": {"T_max": 100, "eta_min": -0.001},
+        }
+        result = self.validator.validate(config, self.mock_logger)
+
+        self.assertFalse(result)
+        self.mock_logger.error.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* SchedulerValidatorクラスを新規作成
  - StepLR, MultiStepLR, CosineAnnealingLR, Noneをサポート
  - 必須パラメータと値の範囲を厳密に検証
  - 詳細なエラーメッセージで修正方法を明示

* ConfigValidatorにスケジューラー検証を統合
  - 既存のData/Transform/Device検証と連携
  - バリデーション失敗時は起動前に停止

* 設定透明性の向上
  - 起動時ログでスケジューラー設定内容を明示出力
  - None指定時は「固定学習率」であることを明確化

* 包括的テストスイート追加
  - SchedulerValidator単体テスト（16ケース）
  - ConfigValidator統合テスト更新