### PR TITLE
feat: クラス重み設定の明示化とバリデーション追加

### DIFF
--- a/pochi.py
+++ b/pochi.py
@@ -92,6 +92,13 @@ def main():
         scheduler_params = config.get("scheduler_params", {})
         logger.info(f"スケジューラーパラメータ: {scheduler_params}")
 
+    # クラス重み設定の明示的ログ出力
+    class_weights = config.get("class_weights")
+    if class_weights is None:
+        logger.info("クラス重み: なし（均等扱い）")
+    else:
+        logger.info(f"クラス重み: {class_weights}")
+
     logger.info("==================")
 
     # データローダーの作成

--- a/pochitrain/validation/config_validator.py
+++ b/pochitrain/validation/config_validator.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any, Dict, Protocol
 
 from .validators import (
+    ClassWeightsValidator,
     DataValidator,
     DeviceValidator,
     SchedulerValidator,
@@ -34,10 +35,11 @@ class ConfigValidator:
             logger (logging.Logger): ロガーインスタンス
         """
         self.logger = logger
-        self.device_validator = DeviceValidator()
-        self.transform_validator = TransformValidator()
+        self.class_weights_validator = ClassWeightsValidator()
         self.data_validator = DataValidator()
+        self.device_validator = DeviceValidator()
         self.scheduler_validator = SchedulerValidator()
+        self.transform_validator = TransformValidator()
 
     def validate(self, config: Dict[str, Any]) -> bool:
         """
@@ -52,6 +54,7 @@ class ConfigValidator:
         # 個別バリデーターを順次実行
         validators: list[ValidatorProtocol] = [
             self.data_validator,  # データパス（最初にチェック）
+            self.class_weights_validator,  # クラス重み設定
             self.transform_validator,  # Transform設定
             self.device_validator,  # デバイス設定
             self.scheduler_validator,  # スケジューラー設定

--- a/pochitrain/validation/validators/__init__.py
+++ b/pochitrain/validation/validators/__init__.py
@@ -4,14 +4,16 @@ pochitrain.validation.validators: 個別バリデーターモジュール.
 各設定項目専用のバリデーター機能を提供します。
 """
 
+from .class_weights_validator import ClassWeightsValidator
 from .data_validator import DataValidator
 from .device_validator import DeviceValidator
 from .scheduler_validator import SchedulerValidator
 from .transform_validator import TransformValidator
 
 __all__ = [
-    "DeviceValidator",
-    "TransformValidator",
+    "ClassWeightsValidator",
     "DataValidator",
+    "DeviceValidator",
     "SchedulerValidator",
+    "TransformValidator",
 ]

--- a/pochitrain/validation/validators/class_weights_validator.py
+++ b/pochitrain/validation/validators/class_weights_validator.py
@@ -1,0 +1,85 @@
+"""
+クラス重み設定のバリデーター.
+
+クラス重み設定の明示化とバリデーション機能を提供します。
+"""
+
+import logging
+from typing import Any, Dict
+
+
+class ClassWeightsValidator:
+    """クラス重み設定のバリデーションクラス."""
+
+    def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
+        """
+        クラス重み設定のバリデーション.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        class_weights = config.get("class_weights")
+        num_classes = config.get("num_classes")
+
+        # num_classesの必須チェック
+        if num_classes is None:
+            logger.error(
+                "num_classes が設定されていません。configs/pochi_config.py で "
+                "クラス数を設定してください。"
+            )
+            return False
+
+        # num_classesの型と値チェック
+        if not isinstance(num_classes, int) or num_classes <= 0:
+            logger.error(
+                f"num_classes は正の整数である必要があります。現在の値: {num_classes}"
+            )
+            return False
+
+        # class_weightsがNoneの場合は正常（クラス重みなし）
+        if class_weights is None:
+            logger.info("クラス重み: なし（均等扱い）")
+            return True
+
+        # class_weightsの型チェック
+        if not isinstance(class_weights, (list, tuple)):
+            logger.error(
+                f"class_weights はリスト形式で設定してください。現在の型: {type(class_weights)}"
+            )
+            return False
+
+        # class_weightsをリストに変換（tupleの場合）
+        weights_list = list(class_weights)
+
+        # 要素数チェック（num_classesとの一致）
+        if len(weights_list) != num_classes:
+            logger.error(
+                f"class_weights の要素数がnum_classesと一致しません。"
+                f"class_weights: {len(weights_list)}要素, num_classes: {num_classes}"
+            )
+            return False
+
+        # 各要素の型と値チェック
+        for i, weight in enumerate(weights_list):
+            if not isinstance(weight, (int, float)):
+                logger.error(
+                    f"class_weights[{i}] は数値である必要があります。"
+                    f"現在の値: {weight} (型: {type(weight)})"
+                )
+                return False
+
+            if weight <= 0:
+                logger.error(
+                    f"class_weights[{i}] は正の値である必要があります。"
+                    f"現在の値: {weight}"
+                )
+                return False
+
+        # バリデーション成功時のログ出力
+        logger.info(f"クラス重み: {weights_list}")
+
+        return True

--- a/tests/unit/test_validation/test_config_validator.py
+++ b/tests/unit/test_validation/test_config_validator.py
@@ -31,10 +31,12 @@ class TestConfigValidator(unittest.TestCase):
     @patch("pochitrain.validation.config_validator.SchedulerValidator")
     @patch("pochitrain.validation.config_validator.DeviceValidator")
     @patch("pochitrain.validation.config_validator.TransformValidator")
+    @patch("pochitrain.validation.config_validator.ClassWeightsValidator")
     @patch("pochitrain.validation.config_validator.DataValidator")
     def test_validation_success(
         self,
         mock_data_validator_class,
+        mock_class_weights_validator_class,
         mock_transform_validator_class,
         mock_device_validator_class,
         mock_scheduler_validator_class,
@@ -44,6 +46,10 @@ class TestConfigValidator(unittest.TestCase):
         mock_data_validator = Mock()
         mock_data_validator.validate.return_value = True
         mock_data_validator_class.return_value = mock_data_validator
+
+        mock_class_weights_validator = Mock()
+        mock_class_weights_validator.validate.return_value = True
+        mock_class_weights_validator_class.return_value = mock_class_weights_validator
 
         mock_transform_validator = Mock()
         mock_transform_validator.validate.return_value = True
@@ -66,6 +72,9 @@ class TestConfigValidator(unittest.TestCase):
         assert result is True
         # 全てのバリデーターが呼ばれることを確認
         mock_data_validator.validate.assert_called_once_with(config, self.mock_logger)
+        mock_class_weights_validator.validate.assert_called_once_with(
+            config, self.mock_logger
+        )
         mock_transform_validator.validate.assert_called_once_with(
             config, self.mock_logger
         )
@@ -77,10 +86,12 @@ class TestConfigValidator(unittest.TestCase):
     @patch("pochitrain.validation.config_validator.SchedulerValidator")
     @patch("pochitrain.validation.config_validator.DeviceValidator")
     @patch("pochitrain.validation.config_validator.TransformValidator")
+    @patch("pochitrain.validation.config_validator.ClassWeightsValidator")
     @patch("pochitrain.validation.config_validator.DataValidator")
     def test_validation_failure(
         self,
         mock_data_validator_class,
+        mock_class_weights_validator_class,
         mock_transform_validator_class,
         mock_device_validator_class,
         mock_scheduler_validator_class,
@@ -90,6 +101,10 @@ class TestConfigValidator(unittest.TestCase):
         mock_data_validator = Mock()
         mock_data_validator.validate.return_value = False
         mock_data_validator_class.return_value = mock_data_validator
+
+        mock_class_weights_validator = Mock()
+        mock_class_weights_validator.validate.return_value = True
+        mock_class_weights_validator_class.return_value = mock_class_weights_validator
 
         mock_transform_validator = Mock()
         mock_transform_validator.validate.return_value = True
@@ -113,6 +128,7 @@ class TestConfigValidator(unittest.TestCase):
         # 最初のバリデーター（DataValidator）だけが呼ばれることを確認
         mock_data_validator.validate.assert_called_once_with(config, self.mock_logger)
         # 失敗したため、後続のバリデーターは呼ばれない
+        mock_class_weights_validator.validate.assert_not_called()
         mock_transform_validator.validate.assert_not_called()
         mock_device_validator.validate.assert_not_called()
         mock_scheduler_validator.validate.assert_not_called()
@@ -122,6 +138,8 @@ class TestConfigValidator(unittest.TestCase):
         # 成功ケース
         config_success = {
             "device": "cuda",
+            "num_classes": 4,
+            "class_weights": None,
             "train_data_root": str(self.valid_train_path),
             "val_data_root": str(self.valid_val_path),
             "train_transform": "valid_train_transform",
@@ -135,6 +153,8 @@ class TestConfigValidator(unittest.TestCase):
         # 失敗ケース（device=None）
         config_failure_device = {
             "device": None,
+            "num_classes": 4,
+            "class_weights": None,
             "train_data_root": str(self.valid_train_path),
             "val_data_root": str(self.valid_val_path),
             "train_transform": "valid_train_transform",
@@ -147,6 +167,8 @@ class TestConfigValidator(unittest.TestCase):
         # 失敗ケース（transform=None）
         config_failure_transform = {
             "device": "cuda",
+            "num_classes": 4,
+            "class_weights": None,
             "train_data_root": str(self.valid_train_path),
             "val_data_root": str(self.valid_val_path),
             "train_transform": None,
@@ -159,6 +181,8 @@ class TestConfigValidator(unittest.TestCase):
         # 失敗ケース（scheduler設定エラー）
         config_failure_scheduler = {
             "device": "cuda",
+            "num_classes": 4,
+            "class_weights": None,
             "train_data_root": str(self.valid_train_path),
             "val_data_root": str(self.valid_val_path),
             "train_transform": "valid_train_transform",

--- a/tests/unit/test_validation/test_validators/test_class_weights_validator.py
+++ b/tests/unit/test_validation/test_validators/test_class_weights_validator.py
@@ -1,0 +1,199 @@
+"""
+ClassWeightsValidatorのテスト.
+"""
+
+import unittest
+from unittest.mock import Mock
+
+from pochitrain.validation.validators.class_weights_validator import (
+    ClassWeightsValidator,
+)
+
+
+class TestClassWeightsValidator(unittest.TestCase):
+    """ClassWeightsValidatorのテストクラス."""
+
+    def setUp(self):
+        """テストの前処理."""
+        self.validator = ClassWeightsValidator()
+        self.mock_logger = Mock()
+
+    def test_num_classes_missing_validation_fails(self):
+        """num_classesが設定されていない場合はバリデーションが失敗することをテスト."""
+        config = {"class_weights": [1.0, 2.0]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "num_classes が設定されていません。configs/pochi_config.py で "
+            "クラス数を設定してください。"
+        )
+
+    def test_num_classes_none_validation_fails(self):
+        """num_classesがNoneの場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": None, "class_weights": [1.0, 2.0]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "num_classes が設定されていません。configs/pochi_config.py で "
+            "クラス数を設定してください。"
+        )
+
+    def test_num_classes_invalid_type_validation_fails(self):
+        """num_classesが整数でない場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": "4", "class_weights": [1.0, 2.0]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "num_classes は正の整数である必要があります。現在の値: 4"
+        )
+
+    def test_num_classes_negative_validation_fails(self):
+        """num_classesが負の値の場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": -1, "class_weights": [1.0, 2.0]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "num_classes は正の整数である必要があります。現在の値: -1"
+        )
+
+    def test_num_classes_zero_validation_fails(self):
+        """num_classesが0の場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": 0, "class_weights": [1.0, 2.0]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "num_classes は正の整数である必要があります。現在の値: 0"
+        )
+
+    def test_class_weights_none_validation_succeeds(self):
+        """class_weightsがNoneの場合はバリデーションが成功することをテスト."""
+        config = {"num_classes": 4, "class_weights": None}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is True
+        self.mock_logger.info.assert_called_once_with("クラス重み: なし（均等扱い）")
+
+    def test_class_weights_invalid_type_validation_fails(self):
+        """class_weightsがリスト/タプル以外の場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": 4, "class_weights": "invalid"}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "class_weights はリスト形式で設定してください。現在の型: <class 'str'>"
+        )
+
+    def test_class_weights_length_mismatch_validation_fails(self):
+        """class_weightsの要素数がnum_classesと一致しない場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": 4, "class_weights": [1.0, 2.0]}  # 2要素、4クラス
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "class_weights の要素数がnum_classesと一致しません。"
+            "class_weights: 2要素, num_classes: 4"
+        )
+
+    def test_class_weights_invalid_element_type_validation_fails(self):
+        """class_weightsの要素に数値以外が含まれる場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": 3, "class_weights": [1.0, "invalid", 3.0]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "class_weights[1] は数値である必要があります。"
+            "現在の値: invalid (型: <class 'str'>)"
+        )
+
+    def test_class_weights_negative_value_validation_fails(self):
+        """class_weightsの要素に負の値が含まれる場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": 3, "class_weights": [1.0, -2.0, 3.0]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "class_weights[1] は正の値である必要があります。現在の値: -2.0"
+        )
+
+    def test_class_weights_zero_value_validation_fails(self):
+        """class_weightsの要素に0が含まれる場合はバリデーションが失敗することをテスト."""
+        config = {"num_classes": 3, "class_weights": [1.0, 0.0, 3.0]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is False
+        self.mock_logger.error.assert_called_once_with(
+            "class_weights[1] は正の値である必要があります。現在の値: 0.0"
+        )
+
+    def test_class_weights_list_valid_validation_succeeds(self):
+        """class_weightsがリスト形式で有効な場合はバリデーションが成功することをテスト."""
+        config = {"num_classes": 3, "class_weights": [1.0, 2.5, 0.8]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is True
+        self.mock_logger.info.assert_called_once_with("クラス重み: [1.0, 2.5, 0.8]")
+
+    def test_class_weights_tuple_valid_validation_succeeds(self):
+        """class_weightsがタプル形式で有効な場合はバリデーションが成功することをテスト."""
+        config = {"num_classes": 4, "class_weights": (1.0, 2.0, 1.5, 3.0)}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is True
+        self.mock_logger.info.assert_called_once_with(
+            "クラス重み: [1.0, 2.0, 1.5, 3.0]"
+        )
+
+    def test_class_weights_integer_values_validation_succeeds(self):
+        """class_weightsが整数値で有効な場合はバリデーションが成功することをテスト."""
+        config = {"num_classes": 2, "class_weights": [1, 3]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is True
+        self.mock_logger.info.assert_called_once_with("クラス重み: [1, 3]")
+
+    def test_class_weights_mixed_number_types_validation_succeeds(self):
+        """class_weightsが整数と浮動小数点の混合で有効な場合はバリデーションが成功することをテスト."""
+        config = {"num_classes": 3, "class_weights": [1, 2.5, 3]}
+
+        result = self.validator.validate(config, self.mock_logger)
+
+        # アサーション
+        assert result is True
+        self.mock_logger.info.assert_called_once_with("クラス重み: [1, 2.5, 3]")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- ClassWeightsValidatorを新規作成し、class_weights設定の包括的な検証を実装
- num_classesとclass_weightsの要素数一致検証により設定ミスを防止
- 型チェック（List[float] | None）と値の妥当性検証（正の数値）を追加
- ConfigValidatorにClassWeightsValidatorを統合し、バリデーション順序を最適化
- pochi.py起動時にclass_weights設定内容を明示的にログ出力
- None時は「クラス重み: なし（均等扱い）」、設定時は実際の重み値を表示
- ClassWeightsValidatorの包括的テストケース（15パターン）を作成
- 既存のConfigValidatorテストを更新してClassWeightsValidatorに対応

これにより不均衡データセット対応のつもりが通常の損失関数で訓練される
リスクを排除し、class_weights使用の明示化を実現