### PR TITLE
refactor: バリデーター設計をABCモジュールベースに改善

### DIFF
--- a/pochitrain/validation/base_validator.py
+++ b/pochitrain/validation/base_validator.py
@@ -1,0 +1,27 @@
+"""
+バリデーターの抽象基底クラス.
+
+全てのバリデーターが実装すべきインターフェースを定義します。
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class BaseValidator(ABC):
+    """バリデーターの抽象基底クラス."""
+
+    @abstractmethod
+    def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
+        """
+        設定のバリデーションを実行する.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        pass

--- a/pochitrain/validation/config_validator.py
+++ b/pochitrain/validation/config_validator.py
@@ -5,8 +5,9 @@
 """
 
 import logging
-from typing import Any, Dict, Protocol
+from typing import Any, Dict
 
+from .base_validator import BaseValidator
 from .validators import (
     ClassWeightsValidator,
     DataValidator,
@@ -14,14 +15,6 @@ from .validators import (
     SchedulerValidator,
     TransformValidator,
 )
-
-
-class ValidatorProtocol(Protocol):
-    """バリデータープロトコル."""
-
-    def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
-        """バリデーション実行."""
-        ...
 
 
 class ConfigValidator:
@@ -52,7 +45,7 @@ class ConfigValidator:
             bool: 全てのバリデーションが成功した場合True、いずれかが失敗した場合False
         """
         # 個別バリデーターを順次実行
-        validators: list[ValidatorProtocol] = [
+        validators: list[BaseValidator] = [
             self.data_validator,  # データパス（最初にチェック）
             self.class_weights_validator,  # クラス重み設定
             self.transform_validator,  # Transform設定

--- a/pochitrain/validation/validators/class_weights_validator.py
+++ b/pochitrain/validation/validators/class_weights_validator.py
@@ -7,8 +7,10 @@
 import logging
 from typing import Any, Dict
 
+from ..base_validator import BaseValidator
 
-class ClassWeightsValidator:
+
+class ClassWeightsValidator(BaseValidator):
     """クラス重み設定のバリデーションクラス."""
 
     def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:

--- a/pochitrain/validation/validators/data_validator.py
+++ b/pochitrain/validation/validators/data_validator.py
@@ -8,8 +8,10 @@ import logging
 from pathlib import Path
 from typing import Any, Dict
 
+from ..base_validator import BaseValidator
 
-class DataValidator:
+
+class DataValidator(BaseValidator):
     """データパス設定のバリデーションクラス."""
 
     def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:

--- a/pochitrain/validation/validators/device_validator.py
+++ b/pochitrain/validation/validators/device_validator.py
@@ -7,8 +7,10 @@ GPU/CPU設定の意図しない動作を防止します。
 import logging
 from typing import Any, Dict
 
+from ..base_validator import BaseValidator
 
-class DeviceValidator:
+
+class DeviceValidator(BaseValidator):
     """デバイス設定のバリデーションクラス."""
 
     def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:

--- a/pochitrain/validation/validators/scheduler_validator.py
+++ b/pochitrain/validation/validators/scheduler_validator.py
@@ -3,8 +3,10 @@
 import logging
 from typing import Any, Dict
 
+from ..base_validator import BaseValidator
 
-class SchedulerValidator:
+
+class SchedulerValidator(BaseValidator):
     """
     スケジューラー設定のバリデーションを行うクラス.
 

--- a/pochitrain/validation/validators/transform_validator.py
+++ b/pochitrain/validation/validators/transform_validator.py
@@ -7,8 +7,10 @@ Transform設定のバリデーター.
 import logging
 from typing import Any, Dict
 
+from ..base_validator import BaseValidator
 
-class TransformValidator:
+
+class TransformValidator(BaseValidator):
     """Transform設定のバリデーションクラス."""
 
     def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:

--- a/tests/unit/test_validation/test_base_validator.py
+++ b/tests/unit/test_validation/test_base_validator.py
@@ -1,0 +1,55 @@
+"""
+BaseValidatorのテスト.
+"""
+
+import unittest
+from unittest.mock import Mock
+
+from pochitrain.validation.base_validator import BaseValidator
+
+
+class ConcreteValidator(BaseValidator):
+    """テスト用の具象バリデータークラス."""
+
+    def validate(self, config, logger):
+        """テスト用のvalidate実装."""
+        return True
+
+
+class TestBaseValidator(unittest.TestCase):
+    """BaseValidatorのテストクラス."""
+
+    def test_abstract_class_cannot_be_instantiated(self):
+        """BaseValidatorは抽象クラスなので直接インスタンス化できないことをテスト."""
+        with self.assertRaises(TypeError):
+            BaseValidator()
+
+    def test_concrete_validator_can_be_instantiated(self):
+        """validateメソッドを実装した具象クラスはインスタンス化できることをテスト."""
+        validator = ConcreteValidator()
+        self.assertIsInstance(validator, BaseValidator)
+
+    def test_concrete_validator_validates(self):
+        """具象バリデーターのvalidateメソッドが正常に動作することをテスト."""
+        validator = ConcreteValidator()
+        mock_logger = Mock()
+        config = {"test": "value"}
+
+        result = validator.validate(config, mock_logger)
+
+        self.assertTrue(result)
+
+    def test_incomplete_validator_cannot_be_instantiated(self):
+        """validateメソッドを実装していないクラスはインスタンス化できないことをテスト."""
+
+        class IncompleteValidator(BaseValidator):
+            """validateメソッドを実装していない不完全なバリデーター."""
+
+            pass
+
+        with self.assertRaises(TypeError):
+            IncompleteValidator()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_validation/test_config_validator.py
+++ b/tests/unit/test_validation/test_config_validator.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+from pochitrain.validation.base_validator import BaseValidator
 from pochitrain.validation.config_validator import ConfigValidator
 
 
@@ -192,6 +193,15 @@ class TestConfigValidator(unittest.TestCase):
         }
         result_failure_scheduler = self.validator.validate(config_failure_scheduler)
         assert result_failure_scheduler is False
+
+    def test_all_validators_inherit_base_validator(self):
+        """全てのバリデーターがBaseValidatorを継承していることをテスト."""
+        # ConfigValidatorのバリデーターインスタンスを確認
+        assert isinstance(self.validator.data_validator, BaseValidator)
+        assert isinstance(self.validator.class_weights_validator, BaseValidator)
+        assert isinstance(self.validator.transform_validator, BaseValidator)
+        assert isinstance(self.validator.device_validator, BaseValidator)
+        assert isinstance(self.validator.scheduler_validator, BaseValidator)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- BaseValidatorクラスを新規作成（abc.ABCを継承した抽象基底クラス）
- validateメソッドを@abstractmethodで抽象化し、実装強制を実現
- 全5つのバリデーター（ClassWeights, Data, Device, Scheduler, Transform）をBaseValidator継承に変更
- ConfigValidatorのValidatorProtocolをBaseValidatorに置き換え、型安全性を向上
- 抽象メソッド未実装時に実行時TypeError発生により実装漏れを防止
- isinstance(validator, BaseValidator)による明示的な型チェックが可能
- BaseValidator専用テストケース（4項目）と継承確認テストを追加
- 全61テストがパスし、既存機能への影響なし

これにより新しいバリデーター作成時の実装漏れリスクを排除し、
より堅牢で拡張しやすいバリデーター設計を実現