### PR TITLE
fix: スケジューラーパラメータのサイレントデフォルト防止でバリデーション一貫性を確保

### DIFF
--- a/pochi.py
+++ b/pochi.py
@@ -89,7 +89,7 @@ def main():
         logger.info("スケジューラー: なし（固定学習率）")
     else:
         logger.info(f"スケジューラー: {scheduler_name}")
-        scheduler_params = config.get("scheduler_params", {})
+        scheduler_params = config.get("scheduler_params")
         logger.info(f"スケジューラーパラメータ: {scheduler_params}")
 
     # クラス重み設定の明示的ログ出力
@@ -141,7 +141,9 @@ def main():
         learning_rate=config["learning_rate"],
         optimizer_name=config["optimizer"],
         scheduler_name=config.get("scheduler"),
-        scheduler_params=config.get("scheduler_params"),
+        scheduler_params=config.get(
+            "scheduler_params"
+        ),  # バリデーション済みなのでscheduler使用時は必ず存在
         class_weights=config.get("class_weights"),
         num_classes=len(classes),
     )

--- a/pochitrain/pochi_trainer.py
+++ b/pochitrain/pochi_trainer.py
@@ -126,20 +126,25 @@ class PochiTrainer:
         else:
             raise ValueError(f"サポートされていない最適化器: {optimizer_name}")
 
-        # スケジューラーの設定
+        # スケジューラーの設定（バリデーション済みパラメータを使用）
         if scheduler_name:
+            if scheduler_params is None:
+                raise ValueError(
+                    f"スケジューラー '{scheduler_name}' を使用する場合、"
+                    f"scheduler_paramsが必須です。configs/pochi_config.pyで設定してください。"
+                )
+
             if scheduler_name == "StepLR":
-                params = scheduler_params or {"step_size": 30, "gamma": 0.1}
-                self.scheduler = optim.lr_scheduler.StepLR(self.optimizer, **params)
+                self.scheduler = optim.lr_scheduler.StepLR(
+                    self.optimizer, **scheduler_params
+                )
             elif scheduler_name == "MultiStepLR":
-                params = scheduler_params or {"milestones": [30, 60, 90], "gamma": 0.1}
                 self.scheduler = optim.lr_scheduler.MultiStepLR(
-                    self.optimizer, **params
+                    self.optimizer, **scheduler_params
                 )
             elif scheduler_name == "CosineAnnealingLR":
-                params = scheduler_params or {"T_max": 100}
                 self.scheduler = optim.lr_scheduler.CosineAnnealingLR(
-                    self.optimizer, **params
+                    self.optimizer, **scheduler_params
                 )
             else:
                 raise ValueError(


### PR DESCRIPTION
- PochiTrainer.setup_training()のデフォルト値自動設定ロジックを削除
- scheduler_params=None時にSchedulerValidatorと同じエラーを発生
- バリデーター通過後の設定のみを受け入れる設計に統一
- サイレントフォールバックによる意図しない学習実行を完全防止