### PR TITLE
refactor: unittestからpytestへ移行

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ rich>=10.0.0
 
 # Development dependencies
 pytest>=6.0.0
+pytest-mock>=3.6.0
 flake8>=3.8.0
 black>=21.0.0
 isort>=5.8.0

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,7 +4,6 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import torchvision.transforms as transforms
@@ -159,9 +158,9 @@ device = "cpu"
             assert len(train_batch) == 2  # (images, labels)
             assert len(val_batch) == 2
 
-    @patch("pochitrain.PochiTrainer")
-    def test_trainer_creation_workflow(self, mock_trainer_class):
+    def test_trainer_creation_workflow(self, mocker):
         """トレーナー作成ワークフローのテスト"""
+        mock_trainer_class = mocker.patch("pochitrain.PochiTrainer")
         with tempfile.TemporaryDirectory() as temp_dir:
             train_root, val_root = self.create_test_data_structure(temp_dir)
             config_path = self.create_test_config_file(temp_dir, train_root, val_root)

--- a/tests/unit/test_logging/test_logger_manager.py
+++ b/tests/unit/test_logging/test_logger_manager.py
@@ -3,7 +3,6 @@ LoggerManagerのテスト
 """
 
 import logging
-from unittest.mock import patch
 
 from pochitrain.logging import LoggerManager
 from pochitrain.logging.logger_manager import LogLevel
@@ -90,9 +89,11 @@ class TestLoggerManager:
         logger = manager.get_logger("default_level_test")
         assert logger.level == logging.WARNING
 
-    @patch("pochitrain.logging.logger_manager.COLORLOG_AVAILABLE", False)
-    def test_fallback_when_colorlog_unavailable(self):
+    def test_fallback_when_colorlog_unavailable(self, mocker):
         """colorlogが利用できない場合のフォールバック機能テスト"""
+        # colorlogが利用できない状態をモック
+        mocker.patch("pochitrain.logging.logger_manager.COLORLOG_AVAILABLE", False)
+
         # 新しいマネージャーを作成（colorlogが無効な状態で）
         LoggerManager.reset()
         manager = LoggerManager()
@@ -102,9 +103,11 @@ class TestLoggerManager:
         assert len(logger.handlers) > 0
         assert isinstance(logger.handlers[0], logging.StreamHandler)
 
-    @patch("pochitrain.logging.logger_manager.COLORLOG_AVAILABLE", True)
-    def test_colorlog_when_available(self):
+    def test_colorlog_when_available(self, mocker):
         """colorlogが利用可能な場合のテスト"""
+        # colorlogが利用可能な状態をモック
+        mocker.patch("pochitrain.logging.logger_manager.COLORLOG_AVAILABLE", True)
+
         LoggerManager.reset()
         manager = LoggerManager()
 

--- a/tests/unit/test_validation/test_base_validator.py
+++ b/tests/unit/test_validation/test_base_validator.py
@@ -2,8 +2,7 @@
 BaseValidatorのテスト.
 """
 
-import unittest
-from unittest.mock import Mock
+import pytest
 
 from pochitrain.validation.base_validator import BaseValidator
 
@@ -16,40 +15,36 @@ class ConcreteValidator(BaseValidator):
         return True
 
 
-class TestBaseValidator(unittest.TestCase):
-    """BaseValidatorのテストクラス."""
-
-    def test_abstract_class_cannot_be_instantiated(self):
-        """BaseValidatorは抽象クラスなので直接インスタンス化できないことをテスト."""
-        with self.assertRaises(TypeError):
-            BaseValidator()
-
-    def test_concrete_validator_can_be_instantiated(self):
-        """validateメソッドを実装した具象クラスはインスタンス化できることをテスト."""
-        validator = ConcreteValidator()
-        self.assertIsInstance(validator, BaseValidator)
-
-    def test_concrete_validator_validates(self):
-        """具象バリデーターのvalidateメソッドが正常に動作することをテスト."""
-        validator = ConcreteValidator()
-        mock_logger = Mock()
-        config = {"test": "value"}
-
-        result = validator.validate(config, mock_logger)
-
-        self.assertTrue(result)
-
-    def test_incomplete_validator_cannot_be_instantiated(self):
-        """validateメソッドを実装していないクラスはインスタンス化できないことをテスト."""
-
-        class IncompleteValidator(BaseValidator):
-            """validateメソッドを実装していない不完全なバリデーター."""
-
-            pass
-
-        with self.assertRaises(TypeError):
-            IncompleteValidator()
+def test_abstract_class_cannot_be_instantiated():
+    """BaseValidatorは抽象クラスなので直接インスタンス化できないことをテスト."""
+    with pytest.raises(TypeError):
+        BaseValidator()
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_concrete_validator_can_be_instantiated():
+    """validateメソッドを実装した具象クラスはインスタンス化できることをテスト."""
+    validator = ConcreteValidator()
+    assert isinstance(validator, BaseValidator)
+
+
+def test_concrete_validator_validates(mocker):
+    """具象バリデーターのvalidateメソッドが正常に動作することをテスト."""
+    validator = ConcreteValidator()
+    mock_logger = mocker.Mock()
+    config = {"test": "value"}
+
+    result = validator.validate(config, mock_logger)
+
+    assert result is True
+
+
+def test_incomplete_validator_cannot_be_instantiated():
+    """validateメソッドを実装していないクラスはインスタンス化できないことをテスト."""
+
+    class IncompleteValidator(BaseValidator):
+        """validateメソッドを実装していない不完全なバリデーター."""
+
+        pass
+
+    with pytest.raises(TypeError):
+        IncompleteValidator()

--- a/tests/unit/test_validation/test_config_validator.py
+++ b/tests/unit/test_validation/test_config_validator.py
@@ -1,21 +1,16 @@
 """ConfigValidatorのテスト."""
 
 import tempfile
-import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
 
 from pochitrain.validation.config_validator import ConfigValidator
 
 
-class TestConfigValidator(unittest.TestCase):
+class TestConfigValidator:
     """ConfigValidatorのテストクラス."""
 
-    def setUp(self):
+    def setup_method(self):
         """テストの初期化."""
-        self.mock_logger = MagicMock()
-        self.validator = ConfigValidator(self.mock_logger)
-
         # テスト用の一時ディレクトリ
         self.temp_dir = tempfile.mkdtemp()
         self.temp_path = Path(self.temp_dir)
@@ -24,118 +19,124 @@ class TestConfigValidator(unittest.TestCase):
         self.valid_train_path.mkdir()
         self.valid_val_path.mkdir()
 
-    @patch("pochitrain.validation.config_validator.SchedulerValidator")
-    @patch("pochitrain.validation.config_validator.OptimizerValidator")
-    @patch("pochitrain.validation.config_validator.DeviceValidator")
-    @patch("pochitrain.validation.config_validator.TransformValidator")
-    @patch("pochitrain.validation.config_validator.ClassWeightsValidator")
-    @patch("pochitrain.validation.config_validator.DataValidator")
-    def test_validation_success(
-        self,
-        mock_data_validator_class,
-        mock_class_weights_validator_class,
-        mock_transform_validator_class,
-        mock_device_validator_class,
-        mock_optimizer_validator_class,
-        mock_scheduler_validator_class,
-    ):
+    def test_validation_success(self, mocker):
         """全てのバリデーションが成功する場合のテスト."""
+        mock_logger = mocker.MagicMock()
+
         # モックの設定
-        mock_data_validator = Mock()
+        mock_data_validator = mocker.Mock()
         mock_data_validator.validate.return_value = True
+        mock_data_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.DataValidator"
+        )
         mock_data_validator_class.return_value = mock_data_validator
 
-        mock_class_weights_validator = Mock()
+        mock_class_weights_validator = mocker.Mock()
         mock_class_weights_validator.validate.return_value = True
+        mock_class_weights_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.ClassWeightsValidator"
+        )
         mock_class_weights_validator_class.return_value = mock_class_weights_validator
 
-        mock_transform_validator = Mock()
+        mock_transform_validator = mocker.Mock()
         mock_transform_validator.validate.return_value = True
+        mock_transform_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.TransformValidator"
+        )
         mock_transform_validator_class.return_value = mock_transform_validator
 
-        mock_device_validator = Mock()
+        mock_device_validator = mocker.Mock()
         mock_device_validator.validate.return_value = True
+        mock_device_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.DeviceValidator"
+        )
         mock_device_validator_class.return_value = mock_device_validator
 
-        mock_optimizer_validator = Mock()
+        mock_optimizer_validator = mocker.Mock()
         mock_optimizer_validator.validate.return_value = True
+        mock_optimizer_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.OptimizerValidator"
+        )
         mock_optimizer_validator_class.return_value = mock_optimizer_validator
 
-        mock_scheduler_validator = Mock()
+        mock_scheduler_validator = mocker.Mock()
         mock_scheduler_validator.validate.return_value = True
+        mock_scheduler_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.SchedulerValidator"
+        )
         mock_scheduler_validator_class.return_value = mock_scheduler_validator
 
         # テスト実行
-        validator = ConfigValidator(self.mock_logger)
+        validator = ConfigValidator(mock_logger)
         config = {"device": "cuda"}
         result = validator.validate(config)
 
         # アサーション
         assert result is True
-        mock_data_validator.validate.assert_called_once_with(config, self.mock_logger)
+        mock_data_validator.validate.assert_called_once_with(config, mock_logger)
         mock_class_weights_validator.validate.assert_called_once_with(
-            config, self.mock_logger
+            config, mock_logger
         )
-        mock_transform_validator.validate.assert_called_once_with(
-            config, self.mock_logger
-        )
-        mock_device_validator.validate.assert_called_once_with(config, self.mock_logger)
-        mock_optimizer_validator.validate.assert_called_once_with(
-            config, self.mock_logger
-        )
-        mock_scheduler_validator.validate.assert_called_once_with(
-            config, self.mock_logger
-        )
+        mock_transform_validator.validate.assert_called_once_with(config, mock_logger)
+        mock_device_validator.validate.assert_called_once_with(config, mock_logger)
+        mock_optimizer_validator.validate.assert_called_once_with(config, mock_logger)
+        mock_scheduler_validator.validate.assert_called_once_with(config, mock_logger)
 
-    @patch("pochitrain.validation.config_validator.SchedulerValidator")
-    @patch("pochitrain.validation.config_validator.OptimizerValidator")
-    @patch("pochitrain.validation.config_validator.DeviceValidator")
-    @patch("pochitrain.validation.config_validator.TransformValidator")
-    @patch("pochitrain.validation.config_validator.ClassWeightsValidator")
-    @patch("pochitrain.validation.config_validator.DataValidator")
-    def test_validation_failure(
-        self,
-        mock_data_validator_class,
-        mock_class_weights_validator_class,
-        mock_transform_validator_class,
-        mock_device_validator_class,
-        mock_optimizer_validator_class,
-        mock_scheduler_validator_class,
-    ):
+    def test_validation_failure(self, mocker):
         """いずれかのバリデーションが失敗する場合のテスト."""
+        mock_logger = mocker.MagicMock()
+
         # モックの設定（DataValidatorが失敗）
-        mock_data_validator = Mock()
+        mock_data_validator = mocker.Mock()
         mock_data_validator.validate.return_value = False
+        mock_data_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.DataValidator"
+        )
         mock_data_validator_class.return_value = mock_data_validator
 
-        mock_class_weights_validator = Mock()
+        mock_class_weights_validator = mocker.Mock()
         mock_class_weights_validator.validate.return_value = True
+        mock_class_weights_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.ClassWeightsValidator"
+        )
         mock_class_weights_validator_class.return_value = mock_class_weights_validator
 
-        mock_transform_validator = Mock()
+        mock_transform_validator = mocker.Mock()
         mock_transform_validator.validate.return_value = True
+        mock_transform_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.TransformValidator"
+        )
         mock_transform_validator_class.return_value = mock_transform_validator
 
-        mock_device_validator = Mock()
+        mock_device_validator = mocker.Mock()
         mock_device_validator.validate.return_value = True
+        mock_device_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.DeviceValidator"
+        )
         mock_device_validator_class.return_value = mock_device_validator
 
-        mock_optimizer_validator = Mock()
+        mock_optimizer_validator = mocker.Mock()
         mock_optimizer_validator.validate.return_value = True
+        mock_optimizer_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.OptimizerValidator"
+        )
         mock_optimizer_validator_class.return_value = mock_optimizer_validator
 
-        mock_scheduler_validator = Mock()
+        mock_scheduler_validator = mocker.Mock()
         mock_scheduler_validator.validate.return_value = True
+        mock_scheduler_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.SchedulerValidator"
+        )
         mock_scheduler_validator_class.return_value = mock_scheduler_validator
 
         # テスト実行
-        validator = ConfigValidator(self.mock_logger)
+        validator = ConfigValidator(mock_logger)
         config = {"device": "cuda"}
         result = validator.validate(config)
 
         # アサーション
         assert result is False
-        mock_data_validator.validate.assert_called_once_with(config, self.mock_logger)
+        mock_data_validator.validate.assert_called_once_with(config, mock_logger)
         # 最初のバリデーターが失敗したので、後続は実行されない
         mock_class_weights_validator.validate.assert_not_called()
         mock_transform_validator.validate.assert_not_called()
@@ -143,19 +144,25 @@ class TestConfigValidator(unittest.TestCase):
         mock_optimizer_validator.validate.assert_not_called()
         mock_scheduler_validator.validate.assert_not_called()
 
-    def test_all_validators_inherit_base_validator(self):
+    def test_all_validators_inherit_base_validator(self, mocker):
         """全てのバリデーターがBaseValidatorを継承していることをテスト."""
         from pochitrain.validation.base_validator import BaseValidator
 
-        assert isinstance(self.validator.data_validator, BaseValidator)
-        assert isinstance(self.validator.class_weights_validator, BaseValidator)
-        assert isinstance(self.validator.transform_validator, BaseValidator)
-        assert isinstance(self.validator.device_validator, BaseValidator)
-        assert isinstance(self.validator.optimizer_validator, BaseValidator)
-        assert isinstance(self.validator.scheduler_validator, BaseValidator)
+        mock_logger = mocker.MagicMock()
+        validator = ConfigValidator(mock_logger)
 
-    def test_validation_with_real_validators(self):
+        assert isinstance(validator.data_validator, BaseValidator)
+        assert isinstance(validator.class_weights_validator, BaseValidator)
+        assert isinstance(validator.transform_validator, BaseValidator)
+        assert isinstance(validator.device_validator, BaseValidator)
+        assert isinstance(validator.optimizer_validator, BaseValidator)
+        assert isinstance(validator.scheduler_validator, BaseValidator)
+
+    def test_validation_with_real_validators(self, mocker):
         """実際のバリデーターを使った統合テスト."""
+        mock_logger = mocker.MagicMock()
+        validator = ConfigValidator(mock_logger)
+
         # 成功ケース
         config_success = {
             "device": "cuda",
@@ -170,7 +177,7 @@ class TestConfigValidator(unittest.TestCase):
             "scheduler": "StepLR",
             "scheduler_params": {"step_size": 30, "gamma": 0.1},
         }
-        result_success = self.validator.validate(config_success)
+        result_success = validator.validate(config_success)
         assert result_success is True
 
         # 失敗ケース（device=None）
@@ -186,7 +193,7 @@ class TestConfigValidator(unittest.TestCase):
             "optimizer": "Adam",
             "scheduler": None,
         }
-        result_failure_device = self.validator.validate(config_failure_device)
+        result_failure_device = validator.validate(config_failure_device)
         assert result_failure_device is False
 
         # 失敗ケース（transform=None）
@@ -202,7 +209,7 @@ class TestConfigValidator(unittest.TestCase):
             "optimizer": "Adam",
             "scheduler": None,
         }
-        result_failure_transform = self.validator.validate(config_failure_transform)
+        result_failure_transform = validator.validate(config_failure_transform)
         assert result_failure_transform is False
 
         # 失敗ケース（scheduler設定エラー）
@@ -219,7 +226,7 @@ class TestConfigValidator(unittest.TestCase):
             "scheduler": "StepLR",
             "scheduler_params": None,  # scheduler_params がNone
         }
-        result_failure_scheduler = self.validator.validate(config_failure_scheduler)
+        result_failure_scheduler = validator.validate(config_failure_scheduler)
         assert result_failure_scheduler is False
 
         # 失敗ケース（optimizer設定エラー）
@@ -235,9 +242,5 @@ class TestConfigValidator(unittest.TestCase):
             "optimizer": "InvalidOptimizer",  # サポート外optimizer
             "scheduler": None,
         }
-        result_failure_optimizer = self.validator.validate(config_failure_optimizer)
+        result_failure_optimizer = validator.validate(config_failure_optimizer)
         assert result_failure_optimizer is False
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/test_validation/test_validators/test_data_validator.py
+++ b/tests/unit/test_validation/test_validators/test_data_validator.py
@@ -3,128 +3,150 @@ DataValidatorのテスト.
 """
 
 import tempfile
-import unittest
 from pathlib import Path
-from unittest.mock import Mock
+
+import pytest
 
 from pochitrain.validation.validators.data_validator import DataValidator
 
 
-class TestDataValidator(unittest.TestCase):
-    """DataValidatorのテストクラス."""
-
-    def setUp(self):
-        """テストの前処理."""
-        self.validator = DataValidator()
-        self.mock_logger = Mock()
-
-        # 一時ディレクトリを作成
-        self.temp_dir = tempfile.mkdtemp()
-        self.temp_path = Path(self.temp_dir)
-
-        # 有効なデータパスを作成
-        self.valid_train_path = self.temp_path / "train"
-        self.valid_val_path = self.temp_path / "val"
-        self.valid_train_path.mkdir()
-        self.valid_val_path.mkdir()
-
-    def test_train_data_root_none_validation_fails(self):
-        """train_data_root設定がNoneの場合はバリデーションが失敗することをテスト."""
-        config = {"train_data_root": None, "val_data_root": str(self.valid_val_path)}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            "train_data_root が必須です。configs/pochi_config.py で "
-            "有効な訓練データパスを設定してください。"
-        )
-
-    def test_train_data_root_missing_validation_fails(self):
-        """train_data_root設定が設定辞書にない場合はバリデーションが失敗することをテスト."""
-        config = {"val_data_root": str(self.valid_val_path)}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            "train_data_root が必須です。configs/pochi_config.py で "
-            "有効な訓練データパスを設定してください。"
-        )
-
-    def test_train_data_root_not_exists_validation_fails(self):
-        """train_data_rootが存在しない場合はバリデーションが失敗することをテスト."""
-        nonexistent_path = str(self.temp_path / "nonexistent_train")
-        config = {
-            "train_data_root": nonexistent_path,
-            "val_data_root": str(self.valid_val_path),
-        }
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            f"訓練データパスが存在しません: {nonexistent_path}"
-        )
-
-    def test_val_data_root_none_validation_fails(self):
-        """val_data_root設定がNoneの場合はバリデーションが失敗することをテスト."""
-        config = {"train_data_root": str(self.valid_train_path), "val_data_root": None}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            "val_data_root が必須です。configs/pochi_config.py で "
-            "有効な検証データパスを設定してください。"
-        )
-
-    def test_val_data_root_not_exists_validation_fails(self):
-        """val_data_rootが存在しない場合はバリデーションが失敗することをテスト."""
-        nonexistent_path = str(self.temp_path / "nonexistent_val")
-        config = {
-            "train_data_root": str(self.valid_train_path),
-            "val_data_root": nonexistent_path,
-        }
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            f"検証データパスが存在しません: {nonexistent_path}"
-        )
-
-    def test_both_data_paths_valid(self):
-        """両方のデータパス設定が有効な場合はバリデーションが成功することをテスト."""
-        config = {
-            "train_data_root": str(self.valid_train_path),
-            "val_data_root": str(self.valid_val_path),
-        }
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is True
-        self.mock_logger.error.assert_not_called()
-
-    def test_empty_string_paths_validation_fails(self):
-        """空文字列のパス設定でバリデーションが失敗することをテスト."""
-        config = {"train_data_root": "", "val_data_root": ""}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション（train_data_rootで先に失敗）
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            "train_data_root が必須です。configs/pochi_config.py で "
-            "有効な訓練データパスを設定してください。"
-        )
+@pytest.fixture
+def validator():
+    """DataValidatorのfixture."""
+    return DataValidator()
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture
+def temp_paths():
+    """一時ディレクトリのfixture."""
+    temp_dir = tempfile.mkdtemp()
+    temp_path = Path(temp_dir)
+
+    # 有効なデータパスを作成
+    valid_train_path = temp_path / "train"
+    valid_val_path = temp_path / "val"
+    valid_train_path.mkdir()
+    valid_val_path.mkdir()
+
+    return {
+        "temp_path": temp_path,
+        "valid_train_path": valid_train_path,
+        "valid_val_path": valid_val_path,
+    }
+
+
+def test_train_data_root_none_validation_fails(validator, temp_paths, mocker):
+    """train_data_root設定がNoneの場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {
+        "train_data_root": None,
+        "val_data_root": str(temp_paths["valid_val_path"]),
+    }
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        "train_data_root が必須です。configs/pochi_config.py で "
+        "有効な訓練データパスを設定してください。"
+    )
+
+
+def test_train_data_root_missing_validation_fails(validator, temp_paths, mocker):
+    """train_data_root設定が設定辞書にない場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {"val_data_root": str(temp_paths["valid_val_path"])}
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        "train_data_root が必須です。configs/pochi_config.py で "
+        "有効な訓練データパスを設定してください。"
+    )
+
+
+def test_train_data_root_not_exists_validation_fails(validator, temp_paths, mocker):
+    """train_data_rootが存在しない場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    nonexistent_path = str(temp_paths["temp_path"] / "nonexistent_train")
+    config = {
+        "train_data_root": nonexistent_path,
+        "val_data_root": str(temp_paths["valid_val_path"]),
+    }
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        f"訓練データパスが存在しません: {nonexistent_path}"
+    )
+
+
+def test_val_data_root_none_validation_fails(validator, temp_paths, mocker):
+    """val_data_root設定がNoneの場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {
+        "train_data_root": str(temp_paths["valid_train_path"]),
+        "val_data_root": None,
+    }
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        "val_data_root が必須です。configs/pochi_config.py で "
+        "有効な検証データパスを設定してください。"
+    )
+
+
+def test_val_data_root_not_exists_validation_fails(validator, temp_paths, mocker):
+    """val_data_rootが存在しない場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    nonexistent_path = str(temp_paths["temp_path"] / "nonexistent_val")
+    config = {
+        "train_data_root": str(temp_paths["valid_train_path"]),
+        "val_data_root": nonexistent_path,
+    }
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        f"検証データパスが存在しません: {nonexistent_path}"
+    )
+
+
+def test_both_data_paths_valid(validator, temp_paths, mocker):
+    """両方のデータパス設定が有効な場合はバリデーションが成功することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {
+        "train_data_root": str(temp_paths["valid_train_path"]),
+        "val_data_root": str(temp_paths["valid_val_path"]),
+    }
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is True
+    mock_logger.error.assert_not_called()
+
+
+def test_empty_string_paths_validation_fails(validator, mocker):
+    """空文字列のパス設定でバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {"train_data_root": "", "val_data_root": ""}
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション（train_data_rootで先に失敗）
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        "train_data_root が必須です。configs/pochi_config.py で "
+        "有効な訓練データパスを設定してください。"
+    )

--- a/tests/unit/test_validation/test_validators/test_device_validator.py
+++ b/tests/unit/test_validation/test_validators/test_device_validator.py
@@ -2,76 +2,74 @@
 DeviceValidatorのテスト.
 """
 
-import unittest
-from unittest.mock import Mock
+import pytest
 
 from pochitrain.validation.validators.device_validator import DeviceValidator
 
 
-class TestDeviceValidator(unittest.TestCase):
-    """DeviceValidatorのテストクラス."""
-
-    def setUp(self):
-        """テストの前処理."""
-        self.validator = DeviceValidator()
-        self.mock_logger = Mock()
-
-    def test_device_none_validation_fails(self):
-        """device設定がNoneの場合はバリデーションが失敗することをテスト."""
-        config = {"device": None}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is False
-        # エラーメッセージが出力されることを確認
-        assert self.mock_logger.error.call_count == 2
-        self.mock_logger.error.assert_any_call(
-            "device設定が必須です。configs/pochi_config.pyでdeviceを'cuda'または'cpu'に設定してください。"
-        )
-        self.mock_logger.error.assert_any_call(
-            "例: device = 'cuda' または device = 'cpu'"
-        )
-
-    def test_device_cpu_shows_warning(self):
-        """device設定が'cpu'の場合は警告メッセージを表示することをテスト."""
-        config = {"device": "cpu"}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is True
-        # 警告メッセージが出力されることを確認
-        assert self.mock_logger.warning.call_count == 3
-        self.mock_logger.warning.assert_any_call("⚠️  CPU使用モードで実行中です")
-        self.mock_logger.warning.assert_any_call(
-            "⚠️  GPU使用を推奨します（大幅な性能向上が期待できます）"
-        )
-        self.mock_logger.warning.assert_any_call(
-            "⚠️  GPU使用時: device = 'cuda' に設定してください"
-        )
-
-    def test_device_cuda_no_warning(self):
-        """device設定が'cuda'の場合は警告メッセージを表示しないことをテスト."""
-        config = {"device": "cuda"}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is True
-        # 警告メッセージが出力されないことを確認
-        self.mock_logger.warning.assert_not_called()
-
-    def test_device_missing_from_config(self):
-        """設定辞書にdeviceキーがない場合のテスト."""
-        config = {}  # deviceキーなし
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション（device=Noneと同じ扱い）
-        assert result is False
-        assert self.mock_logger.error.call_count == 2
+@pytest.fixture
+def validator():
+    """DeviceValidatorのfixture."""
+    return DeviceValidator()
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_device_none_validation_fails(validator, mocker):
+    """device設定がNoneの場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {"device": None}
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is False
+    # エラーメッセージが出力されることを確認
+    assert mock_logger.error.call_count == 2
+    mock_logger.error.assert_any_call(
+        "device設定が必須です。configs/pochi_config.pyでdeviceを'cuda'または'cpu'に設定してください。"
+    )
+    mock_logger.error.assert_any_call("例: device = 'cuda' または device = 'cpu'")
+
+
+def test_device_cpu_shows_warning(validator, mocker):
+    """device設定が'cpu'の場合は警告メッセージを表示することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {"device": "cpu"}
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is True
+    # 警告メッセージが出力されることを確認
+    assert mock_logger.warning.call_count == 3
+    mock_logger.warning.assert_any_call("⚠️  CPU使用モードで実行中です")
+    mock_logger.warning.assert_any_call(
+        "⚠️  GPU使用を推奨します（大幅な性能向上が期待できます）"
+    )
+    mock_logger.warning.assert_any_call(
+        "⚠️  GPU使用時: device = 'cuda' に設定してください"
+    )
+
+
+def test_device_cuda_no_warning(validator, mocker):
+    """device設定が'cuda'の場合は警告メッセージを表示しないことをテスト."""
+    mock_logger = mocker.Mock()
+    config = {"device": "cuda"}
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is True
+    # 警告メッセージが出力されないことを確認
+    mock_logger.warning.assert_not_called()
+
+
+def test_device_missing_from_config(validator, mocker):
+    """設定辞書にdeviceキーがない場合のテスト."""
+    mock_logger = mocker.Mock()
+    config = {}  # deviceキーなし
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション（device=Noneと同じ扱い）
+    assert result is False
+    assert mock_logger.error.call_count == 2

--- a/tests/unit/test_validation/test_validators/test_optimizer_validator.py
+++ b/tests/unit/test_validation/test_validators/test_optimizer_validator.py
@@ -1,121 +1,132 @@
 """OptimizerValidatorのテスト."""
 
-import unittest
-from unittest.mock import MagicMock
+import pytest
 
 from pochitrain.validation.validators.optimizer_validator import OptimizerValidator
 
 
-class TestOptimizerValidator(unittest.TestCase):
-    """OptimizerValidatorのテストクラス."""
-
-    def setUp(self):
-        """テストの初期化."""
-        self.validator = OptimizerValidator()
-        self.mock_logger = MagicMock()
-
-    def test_learning_rate_missing_failure(self):
-        """learning_rate未設定でバリデーション失敗."""
-        config = {"optimizer": "Adam"}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        assert result is False
-        self.mock_logger.error.assert_called_with(
-            "learning_rate が設定されていません。configs/pochi_config.py で "
-            "学習率を設定してください。"
-        )
-
-    def test_learning_rate_invalid_type_failure(self):
-        """learning_rateが数値でない場合バリデーション失敗."""
-        config = {"learning_rate": "0.001", "optimizer": "Adam"}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        assert result is False
-        self.mock_logger.error.assert_called_with(
-            "learning_rate は数値である必要があります。現在の型: <class 'str'>"
-        )
-
-    def test_learning_rate_out_of_range_failure(self):
-        """learning_rateが範囲外の場合バリデーション失敗."""
-        # 0以下のケース
-        config = {"learning_rate": 0, "optimizer": "Adam"}
-        result = self.validator.validate(config, self.mock_logger)
-        assert result is False
-
-        # 1.0超過のケース
-        config = {"learning_rate": 1.5, "optimizer": "Adam"}
-        result = self.validator.validate(config, self.mock_logger)
-        assert result is False
-
-    def test_optimizer_missing_failure(self):
-        """optimizer未設定でバリデーション失敗."""
-        config = {"learning_rate": 0.001}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        assert result is False
-        self.mock_logger.error.assert_called_with(
-            "optimizer が設定されていません。configs/pochi_config.py で "
-            "最適化器を設定してください。"
-        )
-
-    def test_optimizer_invalid_type_failure(self):
-        """optimizerが文字列でない場合バリデーション失敗."""
-        config = {"learning_rate": 0.001, "optimizer": 123}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        assert result is False
-        self.mock_logger.error.assert_called_with(
-            "optimizer は文字列である必要があります。現在の型: <class 'int'>"
-        )
-
-    def test_optimizer_unsupported_failure(self):
-        """サポートされていないoptimizer名でバリデーション失敗."""
-        config = {"learning_rate": 0.001, "optimizer": "RMSprop"}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        assert result is False
-        self.mock_logger.error.assert_called_with(
-            "サポートされていない最適化器です: RMSprop. "
-            "サポート対象: ['Adam', 'SGD']"
-        )
-
-    def test_valid_adam_success(self):
-        """有効なAdam設定でバリデーション成功."""
-        config = {"learning_rate": 0.001, "optimizer": "Adam"}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        assert result is True
-        self.mock_logger.info.assert_any_call("学習率: 0.001")
-        self.mock_logger.info.assert_any_call("最適化器: Adam")
-
-    def test_valid_sgd_success(self):
-        """有効なSGD設定でバリデーション成功."""
-        config = {"learning_rate": 0.1, "optimizer": "SGD"}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        assert result is True
-        self.mock_logger.info.assert_any_call("学習率: 0.1")
-        self.mock_logger.info.assert_any_call("最適化器: SGD")
-
-    def test_learning_rate_boundary_values(self):
-        """learning_rateの境界値テスト."""
-        # 最小値（0に近い値）
-        config = {"learning_rate": 0.0001, "optimizer": "Adam"}
-        result = self.validator.validate(config, self.mock_logger)
-        assert result is True
-
-        # 最大値（1.0）
-        config = {"learning_rate": 1.0, "optimizer": "Adam"}
-        result = self.validator.validate(config, self.mock_logger)
-        assert result is True
+@pytest.fixture
+def validator():
+    """OptimizerValidatorのfixture."""
+    return OptimizerValidator()
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_learning_rate_missing_failure(validator, mocker):
+    """learning_rate未設定でバリデーション失敗."""
+    mock_logger = mocker.Mock()
+    config = {"optimizer": "Adam"}
+
+    result = validator.validate(config, mock_logger)
+
+    assert result is False
+    mock_logger.error.assert_called_with(
+        "learning_rate が設定されていません。configs/pochi_config.py で "
+        "学習率を設定してください。"
+    )
+
+
+def test_learning_rate_invalid_type_failure(validator, mocker):
+    """learning_rateが数値でない場合バリデーション失敗."""
+    mock_logger = mocker.Mock()
+    config = {"learning_rate": "0.001", "optimizer": "Adam"}
+
+    result = validator.validate(config, mock_logger)
+
+    assert result is False
+    mock_logger.error.assert_called_with(
+        "learning_rate は数値である必要があります。現在の型: <class 'str'>"
+    )
+
+
+def test_learning_rate_out_of_range_failure(validator, mocker):
+    """learning_rateが範囲外の場合バリデーション失敗."""
+    mock_logger = mocker.Mock()
+
+    # 0以下のケース
+    config = {"learning_rate": 0, "optimizer": "Adam"}
+    result = validator.validate(config, mock_logger)
+    assert result is False
+
+    # 1.0超過のケース
+    config = {"learning_rate": 1.5, "optimizer": "Adam"}
+    result = validator.validate(config, mock_logger)
+    assert result is False
+
+
+def test_optimizer_missing_failure(validator, mocker):
+    """optimizer未設定でバリデーション失敗."""
+    mock_logger = mocker.Mock()
+    config = {"learning_rate": 0.001}
+
+    result = validator.validate(config, mock_logger)
+
+    assert result is False
+    mock_logger.error.assert_called_with(
+        "optimizer が設定されていません。configs/pochi_config.py で "
+        "最適化器を設定してください。"
+    )
+
+
+def test_optimizer_invalid_type_failure(validator, mocker):
+    """optimizerが文字列でない場合バリデーション失敗."""
+    mock_logger = mocker.Mock()
+    config = {"learning_rate": 0.001, "optimizer": 123}
+
+    result = validator.validate(config, mock_logger)
+
+    assert result is False
+    mock_logger.error.assert_called_with(
+        "optimizer は文字列である必要があります。現在の型: <class 'int'>"
+    )
+
+
+def test_optimizer_unsupported_failure(validator, mocker):
+    """サポートされていないoptimizer名でバリデーション失敗."""
+    mock_logger = mocker.Mock()
+    config = {"learning_rate": 0.001, "optimizer": "RMSprop"}
+
+    result = validator.validate(config, mock_logger)
+
+    assert result is False
+    mock_logger.error.assert_called_with(
+        "サポートされていない最適化器です: RMSprop. " "サポート対象: ['Adam', 'SGD']"
+    )
+
+
+def test_valid_adam_success(validator, mocker):
+    """有効なAdam設定でバリデーション成功."""
+    mock_logger = mocker.Mock()
+    config = {"learning_rate": 0.001, "optimizer": "Adam"}
+
+    result = validator.validate(config, mock_logger)
+
+    assert result is True
+    mock_logger.info.assert_any_call("学習率: 0.001")
+    mock_logger.info.assert_any_call("最適化器: Adam")
+
+
+def test_valid_sgd_success(validator, mocker):
+    """有効なSGD設定でバリデーション成功."""
+    mock_logger = mocker.Mock()
+    config = {"learning_rate": 0.1, "optimizer": "SGD"}
+
+    result = validator.validate(config, mock_logger)
+
+    assert result is True
+    mock_logger.info.assert_any_call("学習率: 0.1")
+    mock_logger.info.assert_any_call("最適化器: SGD")
+
+
+def test_learning_rate_boundary_values(validator, mocker):
+    """learning_rateの境界値テスト."""
+    mock_logger = mocker.Mock()
+
+    # 最小値（0に近い値）
+    config = {"learning_rate": 0.0001, "optimizer": "Adam"}
+    result = validator.validate(config, mock_logger)
+    assert result is True
+
+    # 最大値（1.0）
+    config = {"learning_rate": 1.0, "optimizer": "Adam"}
+    result = validator.validate(config, mock_logger)
+    assert result is True

--- a/tests/unit/test_validation/test_validators/test_transform_validator.py
+++ b/tests/unit/test_validation/test_validators/test_transform_validator.py
@@ -2,85 +2,87 @@
 TransformValidatorのテスト.
 """
 
-import unittest
-from unittest.mock import Mock
+import pytest
 
 from pochitrain.validation.validators.transform_validator import TransformValidator
 
 
-class TestTransformValidator(unittest.TestCase):
-    """TransformValidatorのテストクラス."""
-
-    def setUp(self):
-        """テストの前処理."""
-        self.validator = TransformValidator()
-        self.mock_logger = Mock()
-
-    def test_train_transform_none_validation_fails(self):
-        """train_transform設定がNoneの場合はバリデーションが失敗することをテスト."""
-        config = {"train_transform": None, "val_transform": "dummy_transform"}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            "train_transform が必須です。configs/pochi_config.py で "
-            "transforms.Compose([...]) を train_transform として定義してください。"
-        )
-
-    def test_val_transform_none_validation_fails(self):
-        """val_transform設定がNoneの場合はバリデーションが失敗することをテスト."""
-        config = {"train_transform": "dummy_transform", "val_transform": None}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            "val_transform が必須です。configs/pochi_config.py で "
-            "transforms.Compose([...]) を val_transform として定義してください。"
-        )
-
-    def test_both_transforms_none_validation_fails(self):
-        """両方のtransform設定がNoneの場合はバリデーションが失敗することをテスト."""
-        config = {"train_transform": None, "val_transform": None}
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション（train_transformで先に失敗）
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            "train_transform が必須です。configs/pochi_config.py で "
-            "transforms.Compose([...]) を train_transform として定義してください。"
-        )
-
-    def test_transforms_missing_from_config(self):
-        """設定辞書にtransformキーがない場合のテスト."""
-        config = {}  # transformキーなし
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション（train_transform=Noneと同じ扱い）
-        assert result is False
-        self.mock_logger.error.assert_called_once_with(
-            "train_transform が必須です。configs/pochi_config.py で "
-            "transforms.Compose([...]) を train_transform として定義してください。"
-        )
-
-    def test_both_transforms_valid(self):
-        """両方のtransform設定が有効な場合はバリデーションが成功することをテスト."""
-        config = {
-            "train_transform": "valid_train_transform",
-            "val_transform": "valid_val_transform",
-        }
-
-        result = self.validator.validate(config, self.mock_logger)
-
-        # アサーション
-        assert result is True
-        self.mock_logger.error.assert_not_called()
+@pytest.fixture
+def validator():
+    """TransformValidatorのfixture."""
+    return TransformValidator()
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_train_transform_none_validation_fails(validator, mocker):
+    """train_transform設定がNoneの場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {"train_transform": None, "val_transform": "dummy_transform"}
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        "train_transform が必須です。configs/pochi_config.py で "
+        "transforms.Compose([...]) を train_transform として定義してください。"
+    )
+
+
+def test_val_transform_none_validation_fails(validator, mocker):
+    """val_transform設定がNoneの場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {"train_transform": "dummy_transform", "val_transform": None}
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        "val_transform が必須です。configs/pochi_config.py で "
+        "transforms.Compose([...]) を val_transform として定義してください。"
+    )
+
+
+def test_both_transforms_none_validation_fails(validator, mocker):
+    """両方のtransform設定がNoneの場合はバリデーションが失敗することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {"train_transform": None, "val_transform": None}
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション（train_transformで先に失敗）
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        "train_transform が必須です。configs/pochi_config.py で "
+        "transforms.Compose([...]) を train_transform として定義してください。"
+    )
+
+
+def test_transforms_missing_from_config(validator, mocker):
+    """設定辞書にtransformキーがない場合のテスト."""
+    mock_logger = mocker.Mock()
+    config = {}  # transformキーなし
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション（train_transform=Noneと同じ扱い）
+    assert result is False
+    mock_logger.error.assert_called_once_with(
+        "train_transform が必須です。configs/pochi_config.py で "
+        "transforms.Compose([...]) を train_transform として定義してください。"
+    )
+
+
+def test_both_transforms_valid(validator, mocker):
+    """両方のtransform設定が有効な場合はバリデーションが成功することをテスト."""
+    mock_logger = mocker.Mock()
+    config = {
+        "train_transform": "valid_train_transform",
+        "val_transform": "valid_val_transform",
+    }
+
+    result = validator.validate(config, mock_logger)
+
+    # アサーション
+    assert result is True
+    mock_logger.error.assert_not_called()


### PR DESCRIPTION
- unittest.TestCaseベースのテストをpytest形式に変更
- unittest.mock.patchをpytest-mockのmockerフィクスチャに統一
- test_config_validator.pyを完全にpytest形式に移行
  - unittest.TestCase → 通常のクラス
  - setUp → setup_method
  - @patch デコレータ → mocker.patch
- test_logger_manager.pyとtest_integration.pyのmock使用箇所を修正
- 未使用のimportを削除してlintエラーを解消
- 全119テストがpytestで正常動作することを確認