### PR TITLE
feat: ConfigValidatorにTrainingValidatorを統合してテストを修正

### DIFF
--- a/pochitrain/validation/config_validator.py
+++ b/pochitrain/validation/config_validator.py
@@ -14,6 +14,7 @@ from .validators import (
     DeviceValidator,
     OptimizerValidator,
     SchedulerValidator,
+    TrainingValidator,
     TransformValidator,
 )
 
@@ -34,6 +35,7 @@ class ConfigValidator:
         self.device_validator = DeviceValidator()
         self.optimizer_validator = OptimizerValidator()
         self.scheduler_validator = SchedulerValidator()
+        self.training_validator = TrainingValidator()
         self.transform_validator = TransformValidator()
 
     def validate(self, config: Dict[str, Any]) -> bool:
@@ -52,6 +54,7 @@ class ConfigValidator:
             self.class_weights_validator,  # クラス重み設定
             self.transform_validator,  # Transform設定
             self.device_validator,  # デバイス設定
+            self.training_validator,  # 訓練設定（epochs、batch_size、model_name）
             self.optimizer_validator,  # 最適化器設定
             self.scheduler_validator,  # スケジューラー設定
         ]

--- a/pochitrain/validation/validators/__init__.py
+++ b/pochitrain/validation/validators/__init__.py
@@ -9,6 +9,7 @@ from .data_validator import DataValidator
 from .device_validator import DeviceValidator
 from .optimizer_validator import OptimizerValidator
 from .scheduler_validator import SchedulerValidator
+from .training_validator import TrainingValidator
 from .transform_validator import TransformValidator
 
 __all__ = [
@@ -17,5 +18,6 @@ __all__ = [
     "DeviceValidator",
     "OptimizerValidator",
     "SchedulerValidator",
+    "TrainingValidator",
     "TransformValidator",
 ]

--- a/pochitrain/validation/validators/training_validator.py
+++ b/pochitrain/validation/validators/training_validator.py
@@ -1,0 +1,166 @@
+"""
+Training設定のバリデーター.
+
+epochs、batch_size、model_name設定の妥当性をチェックします。
+"""
+
+import logging
+from typing import Any, Dict
+
+from ..base_validator import BaseValidator
+
+
+class TrainingValidator(BaseValidator):
+    """Training設定のバリデーションクラス."""
+
+    def __init__(self) -> None:
+        """TrainingValidatorを初期化."""
+        # サポートするモデル名（pochitrain.models.pochi_modelsと同期）
+        self.supported_models = ["resnet18", "resnet34", "resnet50"]
+
+    def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
+        """
+        Training設定のバリデーション.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        # epochsのバリデーション
+        if not self._validate_epochs(config, logger):
+            return False
+
+        # batch_sizeのバリデーション
+        if not self._validate_batch_size(config, logger):
+            return False
+
+        # model_nameのバリデーション
+        if not self._validate_model_name(config, logger):
+            return False
+
+        # 成功時のログ出力
+        logger.info(f"エポック数: {config.get('epochs')}")
+        logger.info(f"バッチサイズ: {config.get('batch_size')}")
+        logger.info(f"モデル名: {config.get('model_name')}")
+
+        return True
+
+    def _validate_epochs(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
+        """
+        epochsパラメータのバリデーション.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        epochs = config.get("epochs")
+
+        # 必須チェック
+        if epochs is None:
+            logger.error(
+                "epochs が設定されていません。configs/pochi_config.py で "
+                "エポック数を設定してください。"
+            )
+            return False
+
+        # 型チェック（int のみ受け入れ、boolは除外）
+        if not isinstance(epochs, int) or isinstance(epochs, bool):
+            logger.error(
+                f"epochs は整数である必要があります。現在の型: {type(epochs).__name__}, "
+                f"現在の値: {epochs}"
+            )
+            return False
+
+        # 正の整数チェック（0は許可しない）
+        if epochs <= 0:
+            logger.error(f"epochs は正の整数である必要があります。現在の値: {epochs}")
+            return False
+
+        return True
+
+    def _validate_batch_size(
+        self, config: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """
+        batch_sizeパラメータのバリデーション.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        batch_size = config.get("batch_size")
+
+        # 必須チェック
+        if batch_size is None:
+            logger.error(
+                "batch_size が設定されていません。configs/pochi_config.py で "
+                "バッチサイズを設定してください。"
+            )
+            return False
+
+        # 型チェック（int のみ受け入れ、boolは除外）
+        if not isinstance(batch_size, int) or isinstance(batch_size, bool):
+            logger.error(
+                f"batch_size は整数である必要があります。現在の型: {type(batch_size).__name__}, "
+                f"現在の値: {batch_size}"
+            )
+            return False
+
+        # 正の整数チェック（0は許可しない）
+        if batch_size <= 0:
+            logger.error(
+                f"batch_size は正の整数である必要があります。現在の値: {batch_size}"
+            )
+            return False
+
+        return True
+
+    def _validate_model_name(
+        self, config: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """
+        model_nameパラメータのバリデーション.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        model_name = config.get("model_name")
+
+        # 必須チェック
+        if model_name is None:
+            logger.error(
+                "model_name が設定されていません。configs/pochi_config.py で "
+                "モデル名を設定してください。"
+            )
+            return False
+
+        # 型チェック
+        if not isinstance(model_name, str):
+            logger.error(
+                f"model_name は文字列である必要があります。現在の型: {type(model_name).__name__}, "
+                f"現在の値: {model_name}"
+            )
+            return False
+
+        # サポートされているモデル名チェック
+        if model_name not in self.supported_models:
+            logger.error(
+                f"サポートされていないモデル名です: {model_name}. "
+                f"サポート対象: {self.supported_models}"
+            )
+            return False
+
+        return True

--- a/tests/unit/test_validation/test_config_validator.py
+++ b/tests/unit/test_validation/test_config_validator.py
@@ -66,6 +66,13 @@ class TestConfigValidator:
         )
         mock_scheduler_validator_class.return_value = mock_scheduler_validator
 
+        mock_training_validator = mocker.Mock()
+        mock_training_validator.validate.return_value = True
+        mock_training_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.TrainingValidator"
+        )
+        mock_training_validator_class.return_value = mock_training_validator
+
         # テスト実行
         validator = ConfigValidator(mock_logger)
         config = {"device": "cuda"}
@@ -79,6 +86,7 @@ class TestConfigValidator:
         )
         mock_transform_validator.validate.assert_called_once_with(config, mock_logger)
         mock_device_validator.validate.assert_called_once_with(config, mock_logger)
+        mock_training_validator.validate.assert_called_once_with(config, mock_logger)
         mock_optimizer_validator.validate.assert_called_once_with(config, mock_logger)
         mock_scheduler_validator.validate.assert_called_once_with(config, mock_logger)
 
@@ -129,6 +137,13 @@ class TestConfigValidator:
         )
         mock_scheduler_validator_class.return_value = mock_scheduler_validator
 
+        mock_training_validator = mocker.Mock()
+        mock_training_validator.validate.return_value = True
+        mock_training_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.TrainingValidator"
+        )
+        mock_training_validator_class.return_value = mock_training_validator
+
         # テスト実行
         validator = ConfigValidator(mock_logger)
         config = {"device": "cuda"}
@@ -141,6 +156,7 @@ class TestConfigValidator:
         mock_class_weights_validator.validate.assert_not_called()
         mock_transform_validator.validate.assert_not_called()
         mock_device_validator.validate.assert_not_called()
+        mock_training_validator.validate.assert_not_called()
         mock_optimizer_validator.validate.assert_not_called()
         mock_scheduler_validator.validate.assert_not_called()
 
@@ -155,6 +171,7 @@ class TestConfigValidator:
         assert isinstance(validator.class_weights_validator, BaseValidator)
         assert isinstance(validator.transform_validator, BaseValidator)
         assert isinstance(validator.device_validator, BaseValidator)
+        assert isinstance(validator.training_validator, BaseValidator)
         assert isinstance(validator.optimizer_validator, BaseValidator)
         assert isinstance(validator.scheduler_validator, BaseValidator)
 
@@ -176,6 +193,9 @@ class TestConfigValidator:
             "optimizer": "Adam",
             "scheduler": "StepLR",
             "scheduler_params": {"step_size": 30, "gamma": 0.1},
+            "epochs": 100,
+            "batch_size": 32,
+            "model_name": "resnet50",
         }
         result_success = validator.validate(config_success)
         assert result_success is True
@@ -192,6 +212,9 @@ class TestConfigValidator:
             "learning_rate": 0.001,
             "optimizer": "Adam",
             "scheduler": None,
+            "epochs": 100,
+            "batch_size": 32,
+            "model_name": "resnet50",
         }
         result_failure_device = validator.validate(config_failure_device)
         assert result_failure_device is False
@@ -208,6 +231,9 @@ class TestConfigValidator:
             "learning_rate": 0.001,
             "optimizer": "Adam",
             "scheduler": None,
+            "epochs": 100,
+            "batch_size": 32,
+            "model_name": "resnet50",
         }
         result_failure_transform = validator.validate(config_failure_transform)
         assert result_failure_transform is False
@@ -225,6 +251,9 @@ class TestConfigValidator:
             "optimizer": "Adam",
             "scheduler": "StepLR",
             "scheduler_params": None,  # scheduler_params がNone
+            "epochs": 100,
+            "batch_size": 32,
+            "model_name": "resnet50",
         }
         result_failure_scheduler = validator.validate(config_failure_scheduler)
         assert result_failure_scheduler is False
@@ -241,6 +270,9 @@ class TestConfigValidator:
             "learning_rate": 0.001,
             "optimizer": "InvalidOptimizer",  # サポート外optimizer
             "scheduler": None,
+            "epochs": 100,
+            "batch_size": 32,
+            "model_name": "resnet50",
         }
         result_failure_optimizer = validator.validate(config_failure_optimizer)
         assert result_failure_optimizer is False

--- a/tests/unit/test_validation/test_validators/test_training_validator.py
+++ b/tests/unit/test_validation/test_validators/test_training_validator.py
@@ -1,0 +1,291 @@
+"""TrainingValidatorのテスト."""
+
+import pytest
+
+from pochitrain.validation.validators.training_validator import TrainingValidator
+
+
+@pytest.fixture
+def validator():
+    """TrainingValidatorのfixture."""
+    return TrainingValidator()
+
+
+class TestEpochsValidation:
+    """epochsパラメータのバリデーションテスト."""
+
+    def test_epochs_missing_failure(self, validator, mocker):
+        """epochs未設定でバリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"batch_size": 32, "model_name": "resnet18"}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "epochs が設定されていません。configs/pochi_config.py で "
+            "エポック数を設定してください。"
+        )
+
+    def test_epochs_invalid_type_failure(self, validator, mocker):
+        """epochsが整数でない場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+
+        # 文字列の場合
+        config = {"epochs": "50", "batch_size": 32, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "epochs は整数である必要があります。現在の型: str, 現在の値: 50"
+        )
+
+        # 浮動小数点数の場合
+        mock_logger.reset_mock()
+        config = {"epochs": 50.0, "batch_size": 32, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "epochs は整数である必要があります。現在の型: float, 現在の値: 50.0"
+        )
+
+        # ブール値の場合
+        mock_logger.reset_mock()
+        config = {"epochs": True, "batch_size": 32, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "epochs は整数である必要があります。現在の型: bool, 現在の値: True"
+        )
+
+    def test_epochs_non_positive_failure(self, validator, mocker):
+        """epochsが0以下の場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+
+        # 0の場合
+        config = {"epochs": 0, "batch_size": 32, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "epochs は正の整数である必要があります。現在の値: 0"
+        )
+
+        # 負の数の場合
+        mock_logger.reset_mock()
+        config = {"epochs": -10, "batch_size": 32, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "epochs は正の整数である必要があります。現在の値: -10"
+        )
+
+    def test_epochs_valid_success(self, validator, mocker):
+        """有効なepochsでバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"epochs": 50, "batch_size": 32, "model_name": "resnet18"}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+        mock_logger.info.assert_any_call("エポック数: 50")
+
+
+class TestBatchSizeValidation:
+    """batch_sizeパラメータのバリデーションテスト."""
+
+    def test_batch_size_missing_failure(self, validator, mocker):
+        """batch_size未設定でバリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"epochs": 50, "model_name": "resnet18"}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "batch_size が設定されていません。configs/pochi_config.py で "
+            "バッチサイズを設定してください。"
+        )
+
+    def test_batch_size_invalid_type_failure(self, validator, mocker):
+        """batch_sizeが整数でない場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+
+        # 文字列の場合
+        config = {"epochs": 50, "batch_size": "32", "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "batch_size は整数である必要があります。現在の型: str, 現在の値: 32"
+        )
+
+        # 浮動小数点数の場合
+        mock_logger.reset_mock()
+        config = {"epochs": 50, "batch_size": 32.0, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "batch_size は整数である必要があります。現在の型: float, 現在の値: 32.0"
+        )
+
+        # ブール値の場合
+        mock_logger.reset_mock()
+        config = {"epochs": 50, "batch_size": True, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "batch_size は整数である必要があります。現在の型: bool, 現在の値: True"
+        )
+
+    def test_batch_size_non_positive_failure(self, validator, mocker):
+        """batch_sizeが0以下の場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+
+        # 0の場合
+        config = {"epochs": 50, "batch_size": 0, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "batch_size は正の整数である必要があります。現在の値: 0"
+        )
+
+        # 負の数の場合
+        mock_logger.reset_mock()
+        config = {"epochs": 50, "batch_size": -8, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "batch_size は正の整数である必要があります。現在の値: -8"
+        )
+
+    def test_batch_size_valid_success(self, validator, mocker):
+        """有効なbatch_sizeでバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"epochs": 50, "batch_size": 32, "model_name": "resnet18"}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+        mock_logger.info.assert_any_call("バッチサイズ: 32")
+
+
+class TestModelNameValidation:
+    """model_nameパラメータのバリデーションテスト."""
+
+    def test_model_name_missing_failure(self, validator, mocker):
+        """model_name未設定でバリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"epochs": 50, "batch_size": 32}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "model_name が設定されていません。configs/pochi_config.py で "
+            "モデル名を設定してください。"
+        )
+
+    def test_model_name_invalid_type_failure(self, validator, mocker):
+        """model_nameが文字列でない場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+
+        # 整数の場合
+        config = {"epochs": 50, "batch_size": 32, "model_name": 18}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "model_name は文字列である必要があります。現在の型: int, 現在の値: 18"
+        )
+
+        # ブール値の場合
+        mock_logger.reset_mock()
+        config = {"epochs": 50, "batch_size": 32, "model_name": True}
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "model_name は文字列である必要があります。現在の型: bool, 現在の値: True"
+        )
+
+    def test_model_name_unsupported_failure(self, validator, mocker):
+        """サポートされていないmodel_nameでバリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"epochs": 50, "batch_size": 32, "model_name": "vgg16"}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "サポートされていないモデル名です: vgg16. "
+            "サポート対象: ['resnet18', 'resnet34', 'resnet50']"
+        )
+
+    def test_model_name_valid_success(self, validator, mocker):
+        """有効なmodel_nameでバリデーション成功."""
+        mock_logger = mocker.Mock()
+
+        # resnet18
+        config = {"epochs": 50, "batch_size": 32, "model_name": "resnet18"}
+        result = validator.validate(config, mock_logger)
+        assert result is True
+        mock_logger.info.assert_any_call("モデル名: resnet18")
+
+        # resnet34
+        mock_logger.reset_mock()
+        config = {"epochs": 50, "batch_size": 32, "model_name": "resnet34"}
+        result = validator.validate(config, mock_logger)
+        assert result is True
+        mock_logger.info.assert_any_call("モデル名: resnet34")
+
+        # resnet50
+        mock_logger.reset_mock()
+        config = {"epochs": 50, "batch_size": 32, "model_name": "resnet50"}
+        result = validator.validate(config, mock_logger)
+        assert result is True
+        mock_logger.info.assert_any_call("モデル名: resnet50")
+
+
+class TestTrainingValidatorIntegration:
+    """TrainingValidator統合テスト."""
+
+    def test_all_valid_parameters_success(self, validator, mocker):
+        """すべてのパラメータが有効な場合バリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"epochs": 100, "batch_size": 64, "model_name": "resnet50"}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+        mock_logger.info.assert_any_call("エポック数: 100")
+        mock_logger.info.assert_any_call("バッチサイズ: 64")
+        mock_logger.info.assert_any_call("モデル名: resnet50")
+
+    def test_multiple_invalid_parameters_failure(self, validator, mocker):
+        """複数のパラメータが無効な場合、最初のエラーでバリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {
+            "epochs": "invalid",  # 最初のエラー
+            "batch_size": -1,  # このエラーには到達しない
+            "model_name": "invalid_model",  # このエラーには到達しない
+        }
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        # epochsの型エラーが最初に検出される
+        mock_logger.error.assert_called_with(
+            "epochs は整数である必要があります。現在の型: str, 現在の値: invalid"
+        )
+
+    def test_boundary_values_success(self, validator, mocker):
+        """境界値でバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {
+            "epochs": 1,  # 最小有効値
+            "batch_size": 1,  # 最小有効値
+            "model_name": "resnet18",
+        }
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+        mock_logger.info.assert_any_call("エポック数: 1")
+        mock_logger.info.assert_any_call("バッチサイズ: 1")
+        mock_logger.info.assert_any_call("モデル名: resnet18")


### PR DESCRIPTION
- TrainingValidatorをConfigValidatorのバリデーション対象に追加
- test_config_validator.pyでTrainingValidatorのモックを適切に設定
- 統合テストの全設定例に必須の訓練パラメータを追加
- pre-commit run --all-filesで全チェックが正常に通ることを確認