### PR TITLE
feat: 推論機能の中核モジュール実装とコード品質の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ outputs/
 PROGRESS.md
 data/*
 work_dirs/*
+test_inference_functionality.py

--- a/pochitrain/__init__.py
+++ b/pochitrain/__init__.py
@@ -20,12 +20,13 @@ from .pochi_dataset import (
     get_basic_transforms,
     print_dataset_info,
 )
+from .pochi_predictor import PochiPredictor
 
 # Pochiインターフェース
 from .pochi_trainer import PochiTrainer
 
 # ユーティリティ
-from .utils.directory_manager import PochiWorkspaceManager
+from .utils.directory_manager import InferenceWorkspaceManager, PochiWorkspaceManager
 
 __version__ = "0.1.0"
 __author__ = "Pochi Team"
@@ -36,6 +37,7 @@ __all__ = [
     "LoggerManager",
     # Pochiインターフェース
     "PochiTrainer",
+    "PochiPredictor",
     "PochiImageDataset",
     "PochiModel",
     "create_data_loaders",
@@ -44,4 +46,5 @@ __all__ = [
     "print_dataset_info",
     # ユーティリティ
     "PochiWorkspaceManager",
+    "InferenceWorkspaceManager",
 ]

--- a/pochitrain/inference/__init__.py
+++ b/pochitrain/inference/__init__.py
@@ -1,0 +1,10 @@
+"""
+Pochitrainの推論サポートモジュール.
+
+推論に関連するCSV出力機能を提供します。
+メインの推論機能は pochitrain.pochi_predictor を参照してください。
+"""
+
+from .csv_exporter import InferenceCSVExporter
+
+__all__ = ["InferenceCSVExporter"]

--- a/pochitrain/inference/csv_exporter.py
+++ b/pochitrain/inference/csv_exporter.py
@@ -1,0 +1,243 @@
+"""
+推論結果のCSV出力機能.
+
+推論結果を構造化されたCSVファイルとして出力します。
+"""
+
+import csv
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class InferenceCSVExporter:
+    """
+    推論結果をCSVファイルに出力するクラス.
+
+    Args:
+        output_dir (str): 出力ディレクトリ
+        logger (logging.Logger, optional): ロガーインスタンス
+    """
+
+    def __init__(
+        self,
+        output_dir: str = "inference_results",
+        logger: Optional[logging.Logger] = None,
+    ):
+        """InferenceCSVExporterを初期化."""
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # ロガーの設定
+        if logger is None:
+            self.logger = logging.getLogger(__name__)
+        else:
+            self.logger = logger
+
+    def export_results(
+        self,
+        image_paths: List[str],
+        predicted_labels: List[int],
+        true_labels: List[int],
+        confidence_scores: List[float],
+        class_names: List[str],
+        model_info: Optional[Dict[str, Any]] = None,
+        filename: Optional[str] = None,
+    ) -> Path:
+        """
+        推論結果をCSVファイルに出力.
+
+        Args:
+            image_paths (List[str]): 画像パスのリスト
+            predicted_labels (List[int]): 推論ラベルのリスト
+            true_labels (List[int]): 正解ラベルのリスト
+            confidence_scores (List[float]): 信頼度のリスト
+            class_names (List[str]): クラス名のリスト
+            model_info (Dict[str, any], optional): モデル情報
+            filename (str, optional): 出力ファイル名
+
+        Returns:
+            Path: 出力されたCSVファイルのパス
+        """
+        # ファイル名の生成
+        if filename is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"inference_results_{timestamp}.csv"
+
+        if not filename.endswith(".csv"):
+            filename += ".csv"
+
+        output_path = self.output_dir / filename
+
+        # データの検証
+        self._validate_data(
+            image_paths, predicted_labels, true_labels, confidence_scores
+        )
+
+        # CSVファイルの書き込み
+        with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+
+            # ヘッダーの書き込み
+            self._write_header(writer, model_info)
+
+            # データの書き込み
+            self._write_data(
+                writer,
+                image_paths,
+                predicted_labels,
+                true_labels,
+                confidence_scores,
+                class_names,
+            )
+
+        self.logger.info(f"推論結果をCSVに出力: {output_path}")
+        return output_path
+
+    def _validate_data(
+        self,
+        image_paths: List[str],
+        predicted_labels: List[int],
+        true_labels: List[int],
+        confidence_scores: List[float],
+    ) -> None:
+        """データの整合性をチェック."""
+        lengths = [
+            len(image_paths),
+            len(predicted_labels),
+            len(true_labels),
+            len(confidence_scores),
+        ]
+
+        if len(set(lengths)) != 1:
+            raise ValueError(
+                f"データの長さが一致しません: "
+                f"paths={lengths[0]}, predicted={lengths[1]}, "
+                f"true={lengths[2]}, confidence={lengths[3]}"
+            )
+
+    def _write_header(self, writer: Any, model_info: Optional[Dict[str, Any]]) -> None:
+        """CSVのヘッダー部分を書き込み."""
+        # モデル情報をコメントとして追加
+        if model_info:
+            writer.writerow([f"# Model: {model_info.get('model_name', 'unknown')}"])
+            writer.writerow([f"# Classes: {model_info.get('num_classes', 'unknown')}"])
+            writer.writerow([f"# Device: {model_info.get('device', 'unknown')}"])
+            writer.writerow(
+                [f"# Model Path: {model_info.get('model_path', 'unknown')}"]
+            )
+
+            if model_info.get("best_accuracy") is not None:
+                writer.writerow(
+                    [f"# Best Accuracy: {model_info['best_accuracy']:.2f}%"]
+                )
+
+            if model_info.get("epoch") is not None:
+                writer.writerow([f"# Epoch: {model_info['epoch']}"])
+
+            writer.writerow([])  # 空行
+
+        # カラムヘッダー
+        writer.writerow(
+            [
+                "image_path",
+                "predicted_class",
+                "true_class",
+                "predicted_label",
+                "true_label",
+                "is_correct",
+                "confidence",
+            ]
+        )
+
+    def _write_data(
+        self,
+        writer: Any,
+        image_paths: List[str],
+        predicted_labels: List[int],
+        true_labels: List[int],
+        confidence_scores: List[float],
+        class_names: List[str],
+    ) -> None:
+        """データ行を書き込み."""
+        for i, (path, pred_label, true_label, confidence) in enumerate(
+            zip(image_paths, predicted_labels, true_labels, confidence_scores)
+        ):
+            # クラス名の取得
+            pred_class = (
+                class_names[pred_label] if pred_label < len(class_names) else "unknown"
+            )
+            true_class = (
+                class_names[true_label] if true_label < len(class_names) else "unknown"
+            )
+
+            # 正解判定
+            is_correct = pred_label == true_label
+
+            # データ行の書き込み
+            writer.writerow(
+                [
+                    path,
+                    pred_class,
+                    true_class,
+                    pred_label,
+                    true_label,
+                    is_correct,
+                    f"{confidence:.4f}",
+                ]
+            )
+
+    def export_summary(
+        self,
+        accuracy_info: Dict[str, float],
+        model_info: Optional[Dict[str, Any]] = None,
+        filename: Optional[str] = None,
+    ) -> Path:
+        """
+        推論結果のサマリーをCSVファイルに出力.
+
+        Args:
+            accuracy_info (Dict[str, float]): 精度情報
+            model_info (Dict[str, any], optional): モデル情報
+            filename (str, optional): 出力ファイル名
+
+        Returns:
+            Path: 出力されたCSVファイルのパス
+        """
+        if filename is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"inference_summary_{timestamp}.csv"
+
+        if not filename.endswith(".csv"):
+            filename += ".csv"
+
+        output_path = self.output_dir / filename
+
+        with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+
+            # ヘッダー
+            writer.writerow(["metric", "value"])
+
+            # 精度情報
+            writer.writerow(["total_samples", accuracy_info.get("total_samples", 0)])
+            writer.writerow(
+                ["correct_predictions", accuracy_info.get("correct_predictions", 0)]
+            )
+            writer.writerow(
+                [
+                    "accuracy_percentage",
+                    f"{accuracy_info.get('accuracy_percentage', 0):.2f}%",
+                ]
+            )
+
+            # モデル情報
+            if model_info:
+                writer.writerow([])
+                writer.writerow(["model_info", ""])
+                for key, value in model_info.items():
+                    writer.writerow([key, str(value)])
+
+        self.logger.info(f"推論サマリーをCSVに出力: {output_path}")
+        return output_path

--- a/pochitrain/pochi_predictor.py
+++ b/pochitrain/pochi_predictor.py
@@ -1,0 +1,251 @@
+"""
+pochitrain.pochi_predictor: 推論機能のメインモジュール.
+
+学習済みモデルを読み込んで推論を実行する機能を提供します。
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import torch
+from torch.utils.data import DataLoader
+
+from .pochi_dataset import PochiImageDataset, get_basic_transforms
+from .pochi_trainer import PochiTrainer
+from .utils.directory_manager import InferenceWorkspaceManager
+
+
+class PochiPredictor(PochiTrainer):
+    """
+    推論専用のPochiトレーナー拡張クラス.
+
+    PochiTrainerを継承し、推論に特化した機能を追加します。
+
+    Args:
+        model_name (str): モデル名 ('resnet18', 'resnet34', 'resnet50')
+        num_classes (int): 分類クラス数
+        device (str): デバイス ('cuda' or 'cpu')
+        model_path (str): 学習済みモデルのパス
+        work_dir (str, optional): 作業ディレクトリ
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        num_classes: int,
+        device: str,
+        model_path: str,
+        work_dir: str = "inference_results",
+    ):
+        """PochiPredictorを初期化."""
+        # 親クラスを初期化（pretrainedはFalseにして後でロード）
+        super().__init__(
+            model_name=model_name,
+            num_classes=num_classes,
+            device=device,
+            pretrained=False,
+            work_dir="temp_workspace",  # 一時的なワークスペース
+        )
+
+        # 推論専用ワークスペースマネージャーで上書き
+        self.inference_workspace_manager = InferenceWorkspaceManager(work_dir)
+        self.inference_workspace = self.inference_workspace_manager.create_workspace()
+
+        self.model_path = Path(model_path)
+        self._load_trained_model()
+
+    def _load_trained_model(self) -> None:
+        """学習済みモデルを読み込み."""
+        if not self.model_path.exists():
+            raise FileNotFoundError(
+                f"モデルファイルが見つかりません: {self.model_path}"
+            )
+
+        try:
+            # チェックポイントの読み込み
+            checkpoint = torch.load(self.model_path, map_location=self.device)
+
+            # モデルの状態辞書を読み込み
+            self.model.load_state_dict(checkpoint["model_state_dict"])
+            self.model.eval()  # 推論モードに設定
+
+            # メタ情報の取得
+            if "best_accuracy" in checkpoint:
+                self.best_accuracy = checkpoint["best_accuracy"]
+                self.logger.info(f"モデルの最高精度: {self.best_accuracy:.2f}%")
+
+            if "epoch" in checkpoint:
+                self.epoch = checkpoint["epoch"]
+                self.logger.info(f"学習エポック数: {self.epoch}")
+
+            self.logger.info(f"学習済みモデルを読み込み: {self.model_path}")
+
+        except Exception as e:
+            raise RuntimeError(f"モデルの読み込みに失敗しました: {e}")
+
+    def predict_with_paths(
+        self,
+        val_data_root: str,
+        batch_size: int = 32,
+        num_workers: int = 4,
+        image_size: int = 224,
+    ) -> Tuple[List[str], List[int], List[int], List[float], List[str]]:
+        """
+        バリデーションデータに対して推論を実行し、詳細な結果を返す.
+
+        Args:
+            val_data_root (str): バリデーションデータのルートディレクトリ
+            batch_size (int): バッチサイズ
+            num_workers (int): ワーカー数
+            image_size (int): 画像サイズ
+
+        Returns:
+            Tuple[List[str], List[int], List[int], List[float], List[str]]:
+                (画像パス, 推論ラベル, 正解ラベル, 信頼度, クラス名リスト)
+        """
+        # バリデーション用のデータローダーを作成
+        val_transform = get_basic_transforms(image_size=image_size, is_training=False)
+        val_dataset = PochiImageDataset(val_data_root, transform=val_transform)
+
+        val_loader = DataLoader(
+            val_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+            pin_memory=True,
+        )
+
+        self.logger.info(f"推論開始: {len(val_dataset)}枚の画像")
+
+        # 推論実行
+        predictions, confidences = self.predict(val_loader)
+
+        # 結果の整理
+        image_paths = val_dataset.get_file_paths()
+        predicted_labels = predictions.tolist()
+        confidence_scores = confidences.tolist()
+        true_labels = val_dataset.labels
+        class_names = val_dataset.get_classes()
+
+        self.logger.info("推論完了")
+
+        return (
+            image_paths,
+            predicted_labels,
+            true_labels,
+            confidence_scores,
+            class_names,
+        )
+
+    def calculate_accuracy(
+        self, predicted_labels: List[int], true_labels: List[int]
+    ) -> Dict[str, float]:
+        """
+        推論結果の精度を計算.
+
+        Args:
+            predicted_labels (List[int]): 推論ラベル
+            true_labels (List[int]): 正解ラベル
+
+        Returns:
+            Dict[str, float]: 精度情報
+        """
+        total = len(predicted_labels)
+        correct = sum(p == t for p, t in zip(predicted_labels, true_labels))
+        accuracy = (correct / total) * 100 if total > 0 else 0.0
+
+        accuracy_info = {
+            "total_samples": total,
+            "correct_predictions": correct,
+            "accuracy_percentage": accuracy,
+        }
+
+        self.logger.info(f"推論精度: {correct}/{total} ({accuracy:.2f}%)")
+
+        return accuracy_info
+
+    def get_model_info(self) -> Dict[str, Any]:
+        """
+        モデル情報を取得.
+
+        Returns:
+            Dict[str, any]: モデル情報
+        """
+        return {
+            "model_name": self.model_name,
+            "num_classes": self.num_classes,
+            "device": str(self.device),
+            "model_path": str(self.model_path),
+            "best_accuracy": getattr(self, "best_accuracy", None),
+            "epoch": getattr(self, "epoch", None),
+        }
+
+    def export_results_to_workspace(
+        self,
+        image_paths: List[str],
+        predicted_labels: List[int],
+        true_labels: List[int],
+        confidence_scores: List[float],
+        class_names: List[str],
+        results_filename: str = "inference_results.csv",
+        summary_filename: str = "inference_summary.csv",
+    ) -> Tuple[Path, Path]:
+        """
+        推論結果をワークスペース内にCSV出力.
+
+        Args:
+            image_paths (List[str]): 画像パスのリスト
+            predicted_labels (List[int]): 推論ラベルのリスト
+            true_labels (List[int]): 正解ラベルのリスト
+            confidence_scores (List[float]): 信頼度のリスト
+            class_names (List[str]): クラス名のリスト
+            results_filename (str): 詳細結果CSVファイル名
+            summary_filename (str): サマリーCSVファイル名
+
+        Returns:
+            Tuple[Path, Path]: (詳細結果CSVパス, サマリーCSVパス)
+        """
+        from .inference.csv_exporter import InferenceCSVExporter
+
+        # CSV出力器を作成（推論ワークスペースを指定）
+        csv_exporter = InferenceCSVExporter(
+            output_dir=str(self.inference_workspace), logger=self.logger
+        )
+
+        # モデル情報の取得
+        model_info = self.get_model_info()
+
+        # 精度計算
+        accuracy_info = self.calculate_accuracy(predicted_labels, true_labels)
+
+        # 詳細結果のCSV出力
+        results_csv = csv_exporter.export_results(
+            image_paths=image_paths,
+            predicted_labels=predicted_labels,
+            true_labels=true_labels,
+            confidence_scores=confidence_scores,
+            class_names=class_names,
+            model_info=model_info,
+            filename=results_filename,
+        )
+
+        # サマリーのCSV出力
+        summary_csv = csv_exporter.export_summary(
+            accuracy_info=accuracy_info,
+            model_info=model_info,
+            filename=summary_filename,
+        )
+
+        # モデル情報もJSONで保存
+        self.inference_workspace_manager.save_model_info(model_info)
+
+        return results_csv, summary_csv
+
+    def get_inference_workspace_info(self) -> Dict[str, Any]:
+        """
+        推論ワークスペース情報を取得.
+
+        Returns:
+            Dict[str, any]: ワークスペース情報
+        """
+        return self.inference_workspace_manager.get_workspace_info()

--- a/pochitrain/pochi_trainer.py
+++ b/pochitrain/pochi_trainer.py
@@ -38,6 +38,10 @@ class PochiTrainer:
         work_dir: str = "work_dirs",
     ):
         """PochiTrainerを初期化."""
+        # モデル設定の保存
+        self.model_name = model_name
+        self.num_classes = num_classes
+
         # デバイスの設定（バリデーション済みの設定を使用）
         self.device = torch.device(device)
 


### PR DESCRIPTION
- 推論専用クラス PochiPredictor を実装
- CSV出力機能 InferenceCSVExporter を追加
- 推論用ワークスペース管理機能を追加
- 学習済みモデルの読み込み・推論・結果出力の完全なフローを実装
- pre-commit フックのエラーを修正（未使用import削除、型注釈修正）

新機能:
- pochitrain/pochi_predictor.py: PochiTrainerを継承した推論専用クラス
- pochitrain/inference/: 推論機能パッケージ
- pochitrain/inference/csv_exporter.py: 推論結果のCSV出力機能
- 推論ワークスペース管理とタイムスタンプ付きディレクトリ作成

修正:
- 未使用のimport削除 (logging, Optional)
- 型注釈の修正 (any → Any, csv.writer → Any)
- blackによるコードフォーマット適用