### PR TITLE
feat: 推論時の混同行列可視化機能を実装

### DIFF
--- a/configs/pochi_train_config.py
+++ b/configs/pochi_train_config.py
@@ -51,3 +51,27 @@ val_transform = transforms.Compose(
         transforms.Normalize(mean=mean, std=std),
     ]
 )
+
+# 混同行列可視化設定
+confusion_matrix_config = {
+    "title": "Confusion Matrix",  # タイトル
+    "xlabel": "Predicted Label",  # x軸ラベル
+    "ylabel": "True Label",  # y軸ラベル
+    "fontsize": 14,  # セル内数値のフォントサイズ
+    "title_fontsize": 16,  # タイトルのフォントサイズ
+    "label_fontsize": 12,  # 軸ラベルのフォントサイズ
+    "figsize": (8, 6),  # 図のサイズ (幅, 高さ)
+    "cmap": "Blues",  # カラーマップ
+}
+
+# 日本語表示の例:
+# confusion_matrix_config = {
+#     "title": "混同行列",
+#     "xlabel": "予測ラベル",
+#     "ylabel": "実際ラベル",
+#     "fontsize": 14,
+#     "title_fontsize": 16,
+#     "label_fontsize": 12,
+#     "figsize": (8, 6),
+#     "cmap": "Blues",
+# }

--- a/pochi.py
+++ b/pochi.py
@@ -353,6 +353,9 @@ def infer_command(args):
     # CSV出力
     logger.info("結果をCSVに出力しています...")
     try:
+        # 混同行列設定を取得（設定ファイルにあれば使用）
+        cm_config = config.get("confusion_matrix_config", None)
+
         results_csv, summary_csv = predictor.export_results_to_workspace(
             image_paths=image_paths,
             predicted_labels=predicted_labels,
@@ -361,6 +364,7 @@ def infer_command(args):
             class_names=class_names,
             results_filename="inference_results.csv",
             summary_filename="inference_summary.csv",
+            cm_config=cm_config,
         )
 
         # 精度計算・表示

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pillow>=8.0.0
 # Data processing
 scikit-learn>=0.24.0
 matplotlib>=3.3.0
+japanize-matplotlib>=1.1.0
 
 # Configuration and logging
 pyyaml>=5.4.0


### PR DESCRIPTION
- PochiPredictorにsave_confusion_matrix_imageメソッドを追加
- 継承したPochiTrainerの_compute_confusion_matrix_pytorchを活用
- export_results_to_workspaceで自動的に混同行列画像を生成
- 設定ファイル(confusion_matrix_config)によるカスタマイズ対応
- japanize-matplotlibで日本語フォント対応
- エラーハンドリング実装（画像生成失敗でもCSV出力継続）
