### PR TITLE
feat: 層別学習率設定機能を実装

### DIFF
--- a/configs/pochi_train_config.py
+++ b/configs/pochi_train_config.py
@@ -44,6 +44,20 @@ gradient_tracking_config = {
     "aggregation_method": "median",  # 集約方法: "median", "mean", "max", "rms"
 }
 
+# 層別学習率設定
+enable_layer_wise_lr = False
+layer_wise_lr_config = {
+    "layer_rates": {
+        "conv1": 0.0001,
+        "bn1": 0.0001,
+        "layer1": 0.0002,
+        "layer2": 0.0005,
+        "layer3": 0.001,
+        "layer4": 0.002,
+        "fc": 0.01,
+    }
+}
+
 # データ変換設定
 mean = [0.485, 0.456, 0.406]  # 正規化平均値
 std = [0.229, 0.224, 0.225]  # 正規化標準偏差

--- a/pochi.py
+++ b/pochi.py
@@ -184,6 +184,16 @@ def train_command(args):
     else:
         logger.info(f"クラス重み: {class_weights}")
 
+    # 層別学習率設定の明示的ログ出力
+    enable_layer_wise_lr = config.get("enable_layer_wise_lr", False)
+    if enable_layer_wise_lr:
+        logger.info("層別学習率: 有効")
+        layer_wise_lr_config = config.get("layer_wise_lr_config", {})
+        layer_rates = layer_wise_lr_config.get("layer_rates", {})
+        logger.info(f"層別学習率設定: {layer_rates}")
+    else:
+        logger.info("層別学習率: 無効")
+
     logger.info("==================")
 
     # データローダーの作成
@@ -229,6 +239,8 @@ def train_command(args):
         scheduler_params=config.get("scheduler_params"),
         class_weights=config.get("class_weights"),
         num_classes=len(classes),
+        enable_layer_wise_lr=config.get("enable_layer_wise_lr", False),
+        layer_wise_lr_config=config.get("layer_wise_lr_config"),
     )
 
     # データセットパスの保存

--- a/pochitrain/validation/config_validator.py
+++ b/pochitrain/validation/config_validator.py
@@ -12,6 +12,7 @@ from .validators import (
     ClassWeightsValidator,
     DataValidator,
     DeviceValidator,
+    LayerWiseLRValidator,
     OptimizerValidator,
     SchedulerValidator,
     TrainingValidator,
@@ -33,6 +34,7 @@ class ConfigValidator:
         self.class_weights_validator = ClassWeightsValidator()
         self.data_validator = DataValidator()
         self.device_validator = DeviceValidator()
+        self.layer_wise_lr_validator = LayerWiseLRValidator()
         self.optimizer_validator = OptimizerValidator()
         self.scheduler_validator = SchedulerValidator()
         self.training_validator = TrainingValidator()
@@ -57,6 +59,7 @@ class ConfigValidator:
             self.training_validator,  # 訓練設定（epochs、batch_size、model_name）
             self.optimizer_validator,  # 最適化器設定
             self.scheduler_validator,  # スケジューラー設定
+            self.layer_wise_lr_validator,  # 層別学習率設定
         ]
 
         for validator in validators:

--- a/pochitrain/validation/validators/__init__.py
+++ b/pochitrain/validation/validators/__init__.py
@@ -7,6 +7,7 @@ pochitrain.validation.validators: 個別バリデーターモジュール.
 from .class_weights_validator import ClassWeightsValidator
 from .data_validator import DataValidator
 from .device_validator import DeviceValidator
+from .layer_wise_lr_validator import LayerWiseLRValidator
 from .optimizer_validator import OptimizerValidator
 from .scheduler_validator import SchedulerValidator
 from .training_validator import TrainingValidator
@@ -16,6 +17,7 @@ __all__ = [
     "ClassWeightsValidator",
     "DataValidator",
     "DeviceValidator",
+    "LayerWiseLRValidator",
     "OptimizerValidator",
     "SchedulerValidator",
     "TrainingValidator",

--- a/pochitrain/validation/validators/layer_wise_lr_validator.py
+++ b/pochitrain/validation/validators/layer_wise_lr_validator.py
@@ -1,0 +1,126 @@
+"""
+層別学習率設定のバリデーター.
+
+層別学習率の設定が正しいかチェックします。
+"""
+
+import logging
+from typing import Any, Dict
+
+from ..base_validator import BaseValidator
+
+
+class LayerWiseLRValidator(BaseValidator):
+    """層別学習率設定のバリデーションクラス."""
+
+    def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
+        """
+        層別学習率設定のバリデーション.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーションが成功した場合True、失敗した場合False
+        """
+        # enable_layer_wise_lr の存在と型チェック
+        if "enable_layer_wise_lr" not in config:
+            logger.error("設定に 'enable_layer_wise_lr' が見つかりません")
+            return False
+
+        enable_layer_wise_lr = config["enable_layer_wise_lr"]
+        if not isinstance(enable_layer_wise_lr, bool):
+            logger.error(
+                f"'enable_layer_wise_lr' はbool型である必要があります。"
+                f"現在の型: {type(enable_layer_wise_lr)}"
+            )
+            return False
+
+        # 層別学習率が無効の場合は、これ以上のチェックは不要
+        if not enable_layer_wise_lr:
+            logger.debug("層別学習率は無効です。バリデーションをスキップします。")
+            return True
+
+        # layer_wise_lr_config の存在チェック
+        if "layer_wise_lr_config" not in config:
+            logger.error(
+                "enable_layer_wise_lr=True の場合、'layer_wise_lr_config' が必要です"
+            )
+            return False
+
+        layer_wise_lr_config = config["layer_wise_lr_config"]
+        if not isinstance(layer_wise_lr_config, dict):
+            logger.error(
+                f"'layer_wise_lr_config' は辞書型である必要があります。"
+                f"現在の型: {type(layer_wise_lr_config)}"
+            )
+            return False
+
+        # layer_rates の存在と型チェック
+        if "layer_rates" not in layer_wise_lr_config:
+            logger.error("'layer_wise_lr_config' に 'layer_rates' が見つかりません")
+            return False
+
+        layer_rates = layer_wise_lr_config["layer_rates"]
+        if not isinstance(layer_rates, dict):
+            logger.error(
+                f"'layer_rates' は辞書型である必要があります。現在の型: {type(layer_rates)}"
+            )
+            return False
+
+        # layer_rates の各エントリをチェック
+        if not layer_rates:
+            logger.error(
+                "'layer_rates' が空です。少なくとも1つの層の学習率を指定してください"
+            )
+            return False
+
+        for layer_name, learning_rate in layer_rates.items():
+            if not isinstance(layer_name, str):
+                logger.error(
+                    f"層名は文字列である必要があります。層名: {layer_name}, 型: {type(layer_name)}"
+                )
+                return False
+
+            if not isinstance(learning_rate, (int, float)):
+                logger.error(
+                    f"学習率は数値である必要があります。層: {layer_name}, "
+                    f"学習率: {learning_rate}, 型: {type(learning_rate)}"
+                )
+                return False
+
+            if learning_rate <= 0:
+                logger.error(
+                    f"学習率は正の値である必要があります。層: {layer_name}, 学習率: {learning_rate}"
+                )
+                return False
+
+        # 推奨される層名のチェック（警告レベル）
+        recommended_layers = {
+            "conv1",
+            "bn1",
+            "layer1",
+            "layer2",
+            "layer3",
+            "layer4",
+            "fc",
+        }
+        configured_layers = set(layer_rates.keys())
+
+        missing_layers = recommended_layers - configured_layers
+        if missing_layers:
+            logger.warning(
+                f"推奨される層が設定されていません: {sorted(missing_layers)}. "
+                "これらの層は基本学習率が適用されます。"
+            )
+
+        unknown_layers = configured_layers - recommended_layers
+        if unknown_layers:
+            logger.warning(
+                f"未知の層名が設定されています: {sorted(unknown_layers)}. "
+                "これらの設定は無視される可能性があります。"
+            )
+
+        logger.info(f"層別学習率設定が有効です。設定された層数: {len(layer_rates)}")
+        return True

--- a/tests/unit/test_core/test_layer_wise_lr.py
+++ b/tests/unit/test_core/test_layer_wise_lr.py
@@ -1,0 +1,186 @@
+"""
+層別学習率機能のテスト.
+
+層別学習率の設定、パラメータグループ作成、メトリクス記録の動作をテストします。
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from pochitrain import PochiTrainer
+
+
+class TestLayerWiseLR:
+    """層別学習率機能のテストクラス."""
+
+    @pytest.fixture
+    def trainer(self):
+        """テスト用のPochiTrainerインスタンスを作成."""
+        return PochiTrainer(
+            model_name="resnet18",
+            num_classes=4,
+            device="cpu",
+            pretrained=False,
+            create_workspace=False,
+        )
+
+    def test_layer_wise_lr_disabled(self, trainer):
+        """層別学習率が無効の場合のテスト."""
+        trainer.setup_training(
+            learning_rate=0.001,
+            optimizer_name="SGD",
+            enable_layer_wise_lr=False,
+        )
+
+        # 通常のパラメータグループが作成されることを確認
+        assert len(trainer.optimizer.param_groups) == 1
+        assert trainer.optimizer.param_groups[0]["lr"] == 0.001
+        assert not trainer.enable_layer_wise_lr
+
+    def test_layer_wise_lr_enabled(self, trainer):
+        """層別学習率が有効の場合のテスト."""
+        layer_wise_lr_config = {
+            "layer_rates": {
+                "conv1": 0.0001,
+                "bn1": 0.0001,
+                "layer1": 0.0002,
+                "layer2": 0.0005,
+                "layer3": 0.001,
+                "layer4": 0.002,
+                "fc": 0.01,
+            }
+        }
+
+        trainer.setup_training(
+            learning_rate=0.001,
+            optimizer_name="SGD",
+            enable_layer_wise_lr=True,
+            layer_wise_lr_config=layer_wise_lr_config,
+        )
+
+        # 複数のパラメータグループが作成されることを確認
+        assert len(trainer.optimizer.param_groups) > 1
+        assert trainer.enable_layer_wise_lr
+        assert trainer.base_learning_rate == 0.001
+
+    def test_get_layer_group(self, trainer):
+        """層グループ名の取得テスト."""
+        # ResNetの各層名をテスト
+        assert trainer._get_layer_group("conv1.weight") == "conv1"
+        assert trainer._get_layer_group("bn1.weight") == "bn1"
+        assert trainer._get_layer_group("layer1.0.conv1.weight") == "layer1"
+        assert trainer._get_layer_group("layer2.1.bn2.bias") == "layer2"
+        assert trainer._get_layer_group("layer3.0.downsample.0.weight") == "layer3"
+        assert trainer._get_layer_group("layer4.1.conv2.weight") == "layer4"
+        assert trainer._get_layer_group("fc.weight") == "fc"
+        assert trainer._get_layer_group("unknown.weight") == "other"
+
+    def test_build_layer_wise_param_groups(self, trainer):
+        """パラメータグループ構築のテスト."""
+        layer_wise_lr_config = {
+            "layer_rates": {
+                "conv1": 0.0001,
+                "layer1": 0.0002,
+                "fc": 0.01,
+            }
+        }
+        trainer.layer_wise_lr_config = layer_wise_lr_config
+
+        param_groups = trainer._build_layer_wise_param_groups(0.001)
+
+        # パラメータグループが作成されることを確認
+        assert len(param_groups) > 0
+
+        # 各グループに必要な情報が含まれることを確認
+        for group in param_groups:
+            assert "params" in group
+            assert "lr" in group
+            assert "layer_name" in group
+            assert isinstance(group["params"], list)
+            assert isinstance(group["lr"], float)
+            assert group["lr"] > 0
+
+    def test_get_base_learning_rate(self, trainer):
+        """基本学習率取得のテスト."""
+        # 層別学習率無効時
+        trainer.setup_training(
+            learning_rate=0.001,
+            optimizer_name="SGD",
+            enable_layer_wise_lr=False,
+        )
+        lr = trainer._get_base_learning_rate()
+        assert lr == 0.001
+        assert not trainer.is_layer_wise_lr_enabled()
+
+        # 層別学習率有効時
+        layer_wise_lr_config = {
+            "layer_rates": {
+                "fc": 0.01,
+            }
+        }
+        trainer.setup_training(
+            learning_rate=0.002,
+            optimizer_name="SGD",
+            enable_layer_wise_lr=True,
+            layer_wise_lr_config=layer_wise_lr_config,
+        )
+        lr = trainer._get_base_learning_rate()
+        assert lr == 0.002  # 設定ファイルの固定値
+        assert trainer.is_layer_wise_lr_enabled()
+
+    def test_layer_wise_lr_with_scheduler(self, trainer):
+        """層別学習率とスケジューラーの組み合わせテスト."""
+        layer_wise_lr_config = {
+            "layer_rates": {
+                "conv1": 0.0001,
+                "fc": 0.01,
+            }
+        }
+
+        trainer.setup_training(
+            learning_rate=0.001,
+            optimizer_name="SGD",
+            scheduler_name="StepLR",
+            scheduler_params={"step_size": 10, "gamma": 0.1},
+            enable_layer_wise_lr=True,
+            layer_wise_lr_config=layer_wise_lr_config,
+        )
+
+        # スケジューラーが設定されることを確認
+        assert trainer.scheduler is not None
+        assert trainer.enable_layer_wise_lr
+
+    @patch("pochitrain.pochi_trainer.PochiTrainer._log_layer_wise_lr")
+    def test_log_layer_wise_lr_called(self, mock_log, trainer):
+        """層別学習率ログ出力が呼ばれることのテスト."""
+        layer_wise_lr_config = {
+            "layer_rates": {
+                "fc": 0.01,
+            }
+        }
+
+        trainer.setup_training(
+            learning_rate=0.001,
+            optimizer_name="SGD",
+            enable_layer_wise_lr=True,
+            layer_wise_lr_config=layer_wise_lr_config,
+        )
+
+        # ログ出力メソッドが呼ばれることを確認
+        mock_log.assert_called_once()
+
+    def test_layer_wise_lr_validation_error(self, trainer):
+        """不正な層別学習率設定でのエラーテスト."""
+        # layer_ratesが空の場合
+        layer_wise_lr_config = {"layer_rates": {}}
+
+        # エラーが発生しないことを確認（バリデーションは別途テスト）
+        trainer.setup_training(
+            learning_rate=0.001,
+            optimizer_name="SGD",
+            enable_layer_wise_lr=True,
+            layer_wise_lr_config=layer_wise_lr_config,
+        )
+
+        assert trainer.enable_layer_wise_lr

--- a/tests/unit/test_validation/test_config_validator.py
+++ b/tests/unit/test_validation/test_config_validator.py
@@ -73,6 +73,13 @@ class TestConfigValidator:
         )
         mock_training_validator_class.return_value = mock_training_validator
 
+        mock_layer_wise_lr_validator = mocker.Mock()
+        mock_layer_wise_lr_validator.validate.return_value = True
+        mock_layer_wise_lr_validator_class = mocker.patch(
+            "pochitrain.validation.config_validator.LayerWiseLRValidator"
+        )
+        mock_layer_wise_lr_validator_class.return_value = mock_layer_wise_lr_validator
+
         # テスト実行
         validator = ConfigValidator(mock_logger)
         config = {"device": "cuda"}
@@ -89,6 +96,9 @@ class TestConfigValidator:
         mock_training_validator.validate.assert_called_once_with(config, mock_logger)
         mock_optimizer_validator.validate.assert_called_once_with(config, mock_logger)
         mock_scheduler_validator.validate.assert_called_once_with(config, mock_logger)
+        mock_layer_wise_lr_validator.validate.assert_called_once_with(
+            config, mock_logger
+        )
 
     def test_validation_failure(self, mocker):
         """いずれかのバリデーションが失敗する場合のテスト."""
@@ -174,6 +184,7 @@ class TestConfigValidator:
         assert isinstance(validator.training_validator, BaseValidator)
         assert isinstance(validator.optimizer_validator, BaseValidator)
         assert isinstance(validator.scheduler_validator, BaseValidator)
+        assert isinstance(validator.layer_wise_lr_validator, BaseValidator)
 
     def test_validation_with_real_validators(self, mocker):
         """実際のバリデーターを使った統合テスト."""
@@ -196,6 +207,7 @@ class TestConfigValidator:
             "epochs": 100,
             "batch_size": 32,
             "model_name": "resnet50",
+            "enable_layer_wise_lr": False,
         }
         result_success = validator.validate(config_success)
         assert result_success is True

--- a/tests/unit/test_validation/test_layer_wise_lr_validator.py
+++ b/tests/unit/test_validation/test_layer_wise_lr_validator.py
@@ -1,0 +1,212 @@
+"""
+層別学習率バリデーターのテスト.
+
+LayerWiseLRValidatorの動作をテストします。
+"""
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from pochitrain.validation.validators.layer_wise_lr_validator import (
+    LayerWiseLRValidator,
+)
+
+
+class TestLayerWiseLRValidator:
+    """LayerWiseLRValidatorのテストクラス."""
+
+    @pytest.fixture
+    def validator(self):
+        """テスト用のバリデーターインスタンス."""
+        return LayerWiseLRValidator()
+
+    @pytest.fixture
+    def mock_logger(self):
+        """テスト用のモックロガー."""
+        return Mock(spec=logging.Logger)
+
+    def test_layer_wise_lr_disabled(self, validator, mock_logger):
+        """層別学習率が無効の場合のテスト."""
+        config = {"enable_layer_wise_lr": False}
+
+        result = validator.validate(config, mock_logger)
+        assert result is True
+        mock_logger.debug.assert_called_once()
+
+    def test_layer_wise_lr_enabled_valid_config(self, validator, mock_logger):
+        """層別学習率が有効で正しい設定の場合のテスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {
+                "layer_rates": {
+                    "conv1": 0.0001,
+                    "bn1": 0.0001,
+                    "layer1": 0.0002,
+                    "layer2": 0.0005,
+                    "layer3": 0.001,
+                    "layer4": 0.002,
+                    "fc": 0.01,
+                }
+            },
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is True
+        mock_logger.info.assert_called()
+
+    def test_missing_enable_layer_wise_lr(self, validator, mock_logger):
+        """enable_layer_wise_lrが存在しない場合のテスト."""
+        config = {}
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "設定に 'enable_layer_wise_lr' が見つかりません"
+        )
+
+    def test_invalid_enable_layer_wise_lr_type(self, validator, mock_logger):
+        """enable_layer_wise_lrの型が不正な場合のテスト."""
+        config = {"enable_layer_wise_lr": "true"}  # 文字列（不正）
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called()
+
+    def test_missing_layer_wise_lr_config(self, validator, mock_logger):
+        """layer_wise_lr_configが存在しない場合のテスト."""
+        config = {"enable_layer_wise_lr": True}
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "enable_layer_wise_lr=True の場合、'layer_wise_lr_config' が必要です"
+        )
+
+    def test_invalid_layer_wise_lr_config_type(self, validator, mock_logger):
+        """layer_wise_lr_configの型が不正な場合のテスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": "invalid",  # 文字列（不正）
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called()
+
+    def test_missing_layer_rates(self, validator, mock_logger):
+        """layer_ratesが存在しない場合のテスト."""
+        config = {"enable_layer_wise_lr": True, "layer_wise_lr_config": {}}
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "'layer_wise_lr_config' に 'layer_rates' が見つかりません"
+        )
+
+    def test_invalid_layer_rates_type(self, validator, mock_logger):
+        """layer_ratesの型が不正な場合のテスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {"layer_rates": []},  # リスト（不正）
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called()
+
+    def test_empty_layer_rates(self, validator, mock_logger):
+        """layer_ratesが空の場合のテスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {"layer_rates": {}},
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "'layer_rates' が空です。少なくとも1つの層の学習率を指定してください"
+        )
+
+    def test_invalid_layer_name_type(self, validator, mock_logger):
+        """層名の型が不正な場合のテスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {"layer_rates": {123: 0.001}},  # 数値（不正）
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called()
+
+    def test_invalid_learning_rate_type(self, validator, mock_logger):
+        """学習率の型が不正な場合のテスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {
+                "layer_rates": {"conv1": "0.001"}  # 文字列（不正）
+            },
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called()
+
+    def test_negative_learning_rate(self, validator, mock_logger):
+        """学習率が負の値の場合のテスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {
+                "layer_rates": {"conv1": -0.001}  # 負の値（不正）
+            },
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called()
+
+    def test_zero_learning_rate(self, validator, mock_logger):
+        """学習率が0の場合のテスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {"layer_rates": {"conv1": 0.0}},  # 0（不正）
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is False
+        mock_logger.error.assert_called()
+
+    def test_missing_recommended_layers_warning(self, validator, mock_logger):
+        """推奨される層が不足している場合の警告テスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {"layer_rates": {"fc": 0.01}},  # 一部の層のみ
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is True  # 警告だが成功
+        mock_logger.warning.assert_called()
+
+    def test_unknown_layers_warning(self, validator, mock_logger):
+        """未知の層名がある場合の警告テスト."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {
+                "layer_rates": {"conv1": 0.0001, "unknown_layer": 0.001}  # 未知の層
+            },
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is True  # 警告だが成功
+        mock_logger.warning.assert_called()
+
+    def test_integer_learning_rate(self, validator, mock_logger):
+        """学習率が整数の場合のテスト（有効）."""
+        config = {
+            "enable_layer_wise_lr": True,
+            "layer_wise_lr_config": {"layer_rates": {"conv1": 1}},  # 整数（有効）
+        }
+
+        result = validator.validate(config, mock_logger)
+        assert result is True


### PR DESCRIPTION
feat: 層別学習率設定機能を実装
- 各層（conv1, bn1, layer1-4, fc）に個別の学習率を設定可能
- enable_layer_wise_lr フラグで機能の有効/無効を制御
- PyTorchのパラメータグループ機能を使用して実装
- 層別学習率有効時はCSVに各層の学習率を個別記録
- 層別学習率専用グラフ（対数スケール）を自動生成
- 正答率グラフから学習率表示を除外（混乱防止）
- 設定値の妥当性チェック（LayerWiseLRValidator）を追加
- 既存のスケジューラー機能との併用をサポート
- 包括的な単体テストを追加

変更ファイル:
- configs/pochi_train_config.py: 層別学習率設定を追加
- pochitrain/pochi_trainer.py: パラメータグループ作成・管理機能
- pochitrain/visualization/metrics_exporter.py: CSV出力・グラフ生成対応
- pochitrain/validation/validators/layer_wise_lr_validator.py: 新規バリデーター
- pochi.py: エントリーポイントでの設定読み込み
- tests/: 層別学習率機能の単体テスト追加