### PR TITLE
fix: transform設定ドキュメントの誤記を修正

### DIFF
--- a/configs/docs/configuration.md
+++ b/configs/docs/configuration.md
@@ -227,7 +227,9 @@ class_weights = [0.5, 1.0, 1.0, 1.0]
 
 ### 重要な注意点
 
-⚠️ **transformが未設定（None）の場合、デフォルトで224x224にリサイズされます**
+⚠️ **transformは必須です。未設定（None）の場合はエラーになります**
+
+transformを設定しない場合、PIL Imageがそのままの状態で返されるため、PyTorchのテンソルに変換されずに訓練時にエラーが発生します。最低限でも `transforms.ToTensor()` を含む変換を設定してください。
 
 ### 基本パラメータ
 
@@ -238,13 +240,15 @@ std = [0.229, 0.224, 0.225]   # ImageNet標準値
 
 ### 訓練用変換の例
 
-#### 最小限構成（リサイズなし）
+#### 最小限構成（必須設定）
 ```python
 train_transform = transforms.Compose([
-    transforms.ToTensor(),
-    transforms.Normalize(mean=mean, std=std),
+    transforms.ToTensor(),  # 必須：PIL Image → PyTorchテンソルに変換
+    transforms.Normalize(mean=mean, std=std),  # 推奨：正規化
 ])
 ```
+
+**重要**: `transforms.ToTensor()` は必須です。これがないとPIL ImageがPyTorchテンソルに変換されず、訓練時にエラーが発生します。
 
 #### データ拡張あり
 ```python
@@ -269,13 +273,15 @@ val_transform = transforms.Compose([
 ])
 ```
 
-#### リサイズなし
+#### リサイズなし（最小限構成）
 ```python
 val_transform = transforms.Compose([
-    transforms.ToTensor(),
-    transforms.Normalize(mean=mean, std=std),
+    transforms.ToTensor(),  # 必須：PIL Image → PyTorchテンソルに変換
+    transforms.Normalize(mean=mean, std=std),  # 推奨：正規化
 ])
 ```
+
+**注意**: 検証用変換でも `transforms.ToTensor()` は必須です。
 
 ## カスタム正規化
 
@@ -417,4 +423,4 @@ scheduler_params = {
 
 - **num_workers**: CPUコア数の1/2〜1倍に設定
 - **batch_size**: GPUメモリに応じて調整
-- **pin_memory**: GPU使用時は`True`に設定（現在は自動） 
+- **pin_memory**: GPU使用時は`True`に設定（現在は自動）


### PR DESCRIPTION
## 概要
`configs/docs/configuration.md` のtransform設定に関する誤った記述を修正

## 問題
- ドキュメントに「transformが未設定（None）の場合、デフォルトで224x224にリサイズされます」という誤った記述があった
- 実際のコードでは、transformがNoneの場合は何も変換されず、PIL Imageがそのまま返される
- この状態ではPyTorchテンソルに変換されないため、訓練時にエラーが発生する

## 修正内容
### 1. 誤った記述の削除・修正
- ❌ 「transformが未設定（None）の場合、デフォルトで224x224にリサイズされます」
- ✅ 「transformは必須です。未設定（None）の場合はエラーになります」

### 2. 詳細な説明を追加
- transformを設定しない場合の実際の動作を説明
- PyTorchテンソル変換の重要性を明記
- 最低限 `transforms.ToTensor()` が必要であることを説明

### 3. 設定例の強化
- 最小限構成の例にコメントを追加（「必須」「推奨」の明記）
- 訓練用・検証用両方の例で `ToTensor()` の重要性を強調
- 具体的な注意事項を各セクションに追加

## 変更ファイル
- `configs/docs/configuration.md`: transform設定セクションの誤記修正と説明強化

## テスト結果
- ✅ lintエラーなし
- ✅ pre-commit全チェック通過（black, flake8, isort, mypy, pydocstyle, pytest）

## 影響範囲
- ドキュメントのみの修正
- 既存のコード動作に変更なし
- ユーザーの設定ミスを防ぐ効果