### PR TITLE
feat: optimized_config.pyの辞書型設定を整形して出力

### DIFF
--- a/pochitrain/optimization/result_exporter.py
+++ b/pochitrain/optimization/result_exporter.py
@@ -1,6 +1,7 @@
 """最適化結果エクスポーター実装（SRP: 単一責任原則）."""
 
 import json
+import pprint
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -86,6 +87,20 @@ class ConfigExporter(IResultExporter):
         """
         self._base_config = base_config
 
+    def _format_dict(self, d: dict[str, Any]) -> str:
+        """辞書を整形された文字列に変換.
+
+        pprint.pformat()を使用してPython形式で整形.
+        開き括弧後の空白は独特だが, Python構文として正しく動作する.
+
+        Args:
+            d: フォーマットする辞書
+
+        Returns:
+            整形されたPythonコード文字列
+        """
+        return pprint.pformat(d, width=80)
+
     def _serialize_transform(self, transform: Any) -> str:
         """transformオブジェクトをPythonコード文字列に変換.
 
@@ -165,7 +180,11 @@ class ConfigExporter(IResultExporter):
                 # モジュールオブジェクトは出力しない
                 if isinstance(value, type(json)):
                     continue
-                lines.append(f"{key} = {repr(value)}")
+                # 辞書型は整形して出力
+                if isinstance(value, dict):
+                    lines.append(f"{key} = {self._format_dict(value)}")
+                else:
+                    lines.append(f"{key} = {repr(value)}")
 
         # transform設定を最後に追加
         if transform_lines:


### PR DESCRIPTION
## Summary
- `ConfigExporter._format_dict()`メソッドを追加し、`pprint.pformat()`で辞書を整形
- `export()`メソッドで辞書型の値を検出し、複数行で読みやすく出力
- `confusion_matrix_config`、`gradient_tracking_config`、`layer_wise_lr_config`等が整形される
- Python構文として正しく動作（タプル、bool等が正しく出力される）

Closes #69

## Code Changes
```python
# pochitrain/optimization/result_exporter.py
def _format_dict(self, d: dict[str, Any]) -> str:
    """辞書を整形された文字列に変換.

    pprint.pformat()を使用してPython形式で整形.
    開き括弧後の空白は独特だが, Python構文として正しく動作する.
    """
    return pprint.pformat(d, width=80)
```

## Test plan
- [x] `uv run pre-commit run --all-files` が全てPassedになること
- [x] `uv run pytest` が全テストパスすること
- [x] 最適化実行後、辞書型設定が複数行で整形されて出力されること