### PR TITLE
refactor: load_config()関数をConfigLoaderクラスに共通化

### DIFF
--- a/pochitrain/utils/__init__.py
+++ b/pochitrain/utils/__init__.py
@@ -4,6 +4,7 @@ pochitrain.utils: ユーティリティモジュール.
 ワークスペース管理やタイムスタンプ処理などの汎用機能を提供
 """
 
+from .config_loader import ConfigLoader
 from .directory_manager import PochiWorkspaceManager
 from .timestamp_utils import (
     find_next_index,
@@ -13,6 +14,7 @@ from .timestamp_utils import (
 )
 
 __all__ = [
+    "ConfigLoader",
     "PochiWorkspaceManager",
     "generate_timestamp_dir",
     "find_next_index",

--- a/pochitrain/utils/config_loader.py
+++ b/pochitrain/utils/config_loader.py
@@ -1,0 +1,48 @@
+"""設定ファイル読み込みユーティリティ."""
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict, Union
+
+
+class ConfigLoader:
+    """設定ファイルを読み込むクラス."""
+
+    @staticmethod
+    def load_config(config_path: Union[str, Path]) -> Dict[str, Any]:
+        """設定ファイル(Python形式)を読み込む.
+
+        Args:
+            config_path: 設定ファイルのパス
+
+        Returns:
+            設定辞書
+
+        Raises:
+            FileNotFoundError: 設定ファイルが存在しない場合
+            RuntimeError: 設定ファイルの読み込みに失敗した場合
+        """
+        config_path_obj = Path(config_path)
+
+        if not config_path_obj.exists():
+            raise FileNotFoundError(f"設定ファイルが見つかりません: {config_path}")
+
+        spec = importlib.util.spec_from_file_location("config", config_path_obj)
+        if spec is None:
+            raise RuntimeError(f"設定ファイルの読み込みに失敗しました: {config_path}")
+
+        config_module = importlib.util.module_from_spec(spec)
+        if spec.loader is None:
+            raise RuntimeError(f"設定ファイルのローダーが見つかりません: {config_path}")
+
+        spec.loader.exec_module(config_module)
+
+        config: Dict[str, Any] = {}
+        for key in dir(config_module):
+            if not key.startswith("_"):
+                value = getattr(config_module, key)
+                # 関数やメソッドは除外するが, transformsオブジェクトは含める
+                if not callable(value) or hasattr(value, "transforms"):
+                    config[key] = value
+
+        return config

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -23,7 +23,7 @@ class TestConfigLoading:
 
     def test_basic_config_loading(self):
         """基本的な設定ファイル読み込みテスト"""
-        from pochi import load_config
+        from pochitrain.utils import ConfigLoader
 
         with tempfile.TemporaryDirectory() as temp_dir:
             config_content = """
@@ -44,7 +44,7 @@ device = "cpu"
             config_path = self.create_test_config(temp_dir, config_content)
 
             # 設定ファイルの読み込み
-            config = load_config(str(config_path))
+            config = ConfigLoader.load_config(str(config_path))
 
             # 設定値の確認
             assert config["model_name"] == "resnet18"
@@ -55,7 +55,7 @@ device = "cpu"
 
     def test_config_loading_with_scheduler(self):
         """スケジューラー設定を含む設定ファイルテスト"""
-        from pochi import load_config
+        from pochitrain.utils import ConfigLoader
 
         with tempfile.TemporaryDirectory() as temp_dir:
             config_content = """
@@ -66,7 +66,7 @@ scheduler_params = {"step_size": 30, "gamma": 0.1}
 """
             config_path = self.create_test_config(temp_dir, config_content)
 
-            config = load_config(str(config_path))
+            config = ConfigLoader.load_config(str(config_path))
 
             assert config["scheduler"] == "StepLR"
             assert config["scheduler_params"]["step_size"] == 30
@@ -74,10 +74,10 @@ scheduler_params = {"step_size": 30, "gamma": 0.1}
 
     def test_config_loading_missing_file(self):
         """存在しない設定ファイルのエラーテスト"""
-        from pochi import load_config
+        from pochitrain.utils import ConfigLoader
 
         with pytest.raises(FileNotFoundError):
-            load_config("/nonexistent/config.py")
+            ConfigLoader.load_config("/nonexistent/config.py")
 
 
 class TestMainWorkflow:
@@ -166,9 +166,9 @@ device = "cpu"
             config_path = self.create_test_config_file(temp_dir, train_root, val_root)
 
             # 設定の読み込み
-            from pochi import load_config
+            from pochitrain.utils import ConfigLoader
 
-            config = load_config(str(config_path))
+            config = ConfigLoader.load_config(str(config_path))
 
             # 必要なtransformを定義
             train_transform = transforms.Compose([transforms.ToTensor()])

--- a/tools/export_onnx.py
+++ b/tools/export_onnx.py
@@ -10,39 +10,16 @@ PyTorchモデル(.pth)をONNX形式に変換するスクリプト.
 """
 
 import argparse
-import importlib.util
 import sys
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Tuple
 
 import numpy as np
 import onnx
 import onnxruntime as ort
 import torch
 
-
-def load_config(config_path: str) -> Dict[str, Any]:
-    """設定ファイルを読み込む."""
-    config_path_obj = Path(config_path)
-
-    if not config_path_obj.exists():
-        raise FileNotFoundError(f"設定ファイルが見つかりません: {config_path}")
-
-    spec = importlib.util.spec_from_file_location("config", config_path_obj)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"設定ファイルの読み込みに失敗しました: {config_path}")
-
-    config_module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(config_module)
-
-    config = {}
-    for key in dir(config_module):
-        if not key.startswith("_"):
-            value = getattr(config_module, key)
-            if not callable(value) or hasattr(value, "transforms"):
-                config[key] = value
-
-    return config
+from pochitrain.utils import ConfigLoader
 
 
 def export_to_onnx(
@@ -231,7 +208,7 @@ def main() -> None:
 
     if config_path and config_path.exists():
         try:
-            config = load_config(str(config_path))
+            config = ConfigLoader.load_config(str(config_path))
             print(f"設定ファイルを読み込み: {config_path}")
         except Exception as e:
             print(f"警告: 設定ファイルの読み込みに失敗: {e}")

--- a/tools/infer_onnx.py
+++ b/tools/infer_onnx.py
@@ -8,11 +8,10 @@ ONNXモデルを使用した推論スクリプト.
 """
 
 import argparse
-import importlib.util
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 
@@ -24,29 +23,7 @@ except ImportError:
     print("インストール: pip install onnxruntime または pip install onnxruntime-gpu")
     sys.exit(1)
 
-
-def load_config(config_path: str) -> Dict[str, Any]:
-    """設定ファイルを読み込む."""
-    config_path_obj = Path(config_path)
-
-    if not config_path_obj.exists():
-        raise FileNotFoundError(f"設定ファイルが見つかりません: {config_path}")
-
-    spec = importlib.util.spec_from_file_location("config", config_path_obj)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"設定ファイルの読み込みに失敗しました: {config_path}")
-
-    config_module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(config_module)
-
-    config = {}
-    for key in dir(config_module):
-        if not key.startswith("_"):
-            value = getattr(config_module, key)
-            if not callable(value) or hasattr(value, "transforms"):
-                config[key] = value
-
-    return config
+from pochitrain.utils import ConfigLoader
 
 
 def create_onnx_session(
@@ -159,7 +136,7 @@ def main() -> None:
         config_path = Path(args.config)
         if config_path.exists():
             try:
-                config = load_config(str(config_path))
+                config = ConfigLoader.load_config(str(config_path))
                 print(f"設定ファイルを読み込み: {config_path}")
             except Exception as e:
                 print(f"警告: 設定ファイルの読み込みに失敗: {e}")


### PR DESCRIPTION
## Summary
- `pochitrain/utils/config_loader.py`に`ConfigLoader`クラスを作成
- `tools/export_onnx.py`, `tools/infer_onnx.py`, `pochi.py`の重複した`load_config()`を削除
- 全箇所で`ConfigLoader.load_config()`を使用するように統一

## Code Changes

```python
# pochitrain/utils/config_loader.py
class ConfigLoader:
    """設定ファイルを読み込むクラス."""

    @staticmethod
    def load_config(config_path: Union[str, Path]) -> Dict[str, Any]:
        """設定ファイル(Python形式)を読み込む."""
        config_path_obj = Path(config_path)

        if not config_path_obj.exists():
            raise FileNotFoundError(f"設定ファイルが見つかりません: {config_path}")

        spec = importlib.util.spec_from_file_location("config", config_path_obj)
        if spec is None:
            raise RuntimeError(f"設定ファイルの読み込みに失敗しました: {config_path}")

        config_module = importlib.util.module_from_spec(spec)
        if spec.loader is None:
            raise RuntimeError(f"設定ファイルのローダーが見つかりません: {config_path}")

        spec.loader.exec_module(config_module)

        config: Dict[str, Any] = {}
        for key in dir(config_module):
            if not key.startswith("_"):
                value = getattr(config_module, key)
                if not callable(value) or hasattr(value, "transforms"):
                    config[key] = value

        return config
```

```python
# 使用例 (tools/export_onnx.py, tools/infer_onnx.py, pochi.py)
from pochitrain.utils import ConfigLoader

config = ConfigLoader.load_config(str(config_path))
```

## Test Plan
- [x] `python pochi.py train --config configs/pochi_train_config.py`が動作することを確認
- [x] `python tools/export_onnx.py model.pth --input-size 224 224`が動作することを確認
- [x] `python tools/infer_onnx.py model.onnx --data data/val --config config.py`が動作することを確認
- [x] `uv run pre-commit run --all-files`が通ることを確認