### PR TITLE
feat: cuDNN benchmarkオプションと推論ウォームアップ除外を追加

### DIFF
--- a/configs/pochi_train_config.py
+++ b/configs/pochi_train_config.py
@@ -48,6 +48,7 @@ class_weights = None  # クラス毎の損失重み
 # その他設定
 work_dir = "work_dirs"  # 作業ディレクトリ
 device = "cuda"  # デバイス
+cudnn_benchmark = True  # cuDNN自動チューニング（固定サイズ入力で高速化）
 
 # 訓練メトリクス可視化設定
 enable_metrics_export = True  # メトリクスのCSV出力とグラフ生成を有効化

--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -193,6 +193,7 @@ def train_command(args: argparse.Namespace) -> None:
         device=config["device"],
         pretrained=config["pretrained"],
         work_dir=config["work_dir"],
+        cudnn_benchmark=config.get("cudnn_benchmark", False),
     )
 
     # 訓練設定

--- a/pochitrain/validation/validators/device_validator.py
+++ b/pochitrain/validation/validators/device_validator.py
@@ -41,4 +41,46 @@ class DeviceValidator(BaseValidator):
             logger.warning("⚠️  GPU使用を推奨します（大幅な性能向上が期待できます）")
             logger.warning("⚠️  GPU使用時: device = 'cuda' に設定してください")
 
+        # cudnn_benchmarkのバリデーション
+        if not self._validate_cudnn_benchmark(config, logger, device_config):
+            return False
+
+        return True
+
+    def _validate_cudnn_benchmark(
+        self, config: Dict[str, Any], logger: logging.Logger, device_config: str
+    ) -> bool:
+        """
+        cudnn_benchmark設定のバリデーション.
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+            device_config (str): デバイス設定
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        cudnn_benchmark = config.get("cudnn_benchmark")
+
+        # 設定がない場合はスキップ（オプション設定）
+        if cudnn_benchmark is None:
+            return True
+
+        # 型チェック（boolのみ許可）
+        if not isinstance(cudnn_benchmark, bool):
+            logger.error(
+                f"cudnn_benchmark はbool型である必要があります。"
+                f"現在の型: {type(cudnn_benchmark).__name__}, "
+                f"現在の値: {cudnn_benchmark}"
+            )
+            return False
+
+        # CPU使用時にcudnn_benchmark=Trueの場合は警告
+        if device_config == "cpu" and cudnn_benchmark:
+            logger.warning(
+                "⚠️  cudnn_benchmark=Trueが設定されていますが、"
+                "CPU使用時は無効です（GPUでのみ有効）"
+            )
+
         return True

--- a/tests/unit/test_core/test_pochi_trainer.py
+++ b/tests/unit/test_core/test_pochi_trainer.py
@@ -27,6 +27,54 @@ def test_pochi_trainer_init():
         assert trainer.best_accuracy == 0.0
 
 
+def test_pochi_trainer_cudnn_benchmark_disabled_on_cpu():
+    """CPU環境ではcudnn_benchmarkが無効になることをテスト"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        trainer = PochiTrainer(
+            model_name="resnet18",
+            num_classes=10,
+            pretrained=False,
+            device="cpu",
+            work_dir=temp_dir,
+            cudnn_benchmark=True,  # TrueでもCPUでは無効
+        )
+
+        assert trainer.cudnn_benchmark is False
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_pochi_trainer_cudnn_benchmark_enabled_on_cuda():
+    """CUDA環境でcudnn_benchmark=Trueが有効になることをテスト"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        trainer = PochiTrainer(
+            model_name="resnet18",
+            num_classes=10,
+            pretrained=False,
+            device="cuda",
+            work_dir=temp_dir,
+            cudnn_benchmark=True,
+        )
+
+        assert trainer.cudnn_benchmark is True
+        assert torch.backends.cudnn.benchmark is True
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_pochi_trainer_cudnn_benchmark_disabled_on_cuda():
+    """CUDA環境でcudnn_benchmark=Falseが無効のままであることをテスト"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        trainer = PochiTrainer(
+            model_name="resnet18",
+            num_classes=10,
+            pretrained=False,
+            device="cuda",
+            work_dir=temp_dir,
+            cudnn_benchmark=False,
+        )
+
+        assert trainer.cudnn_benchmark is False
+
+
 def test_pochi_trainer_setup_training():
     """PochiTrainerの訓練設定テスト"""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- `cudnn_benchmark`設定オプションを追加（固定サイズ入力での推論高速化）
- 推論時間計測からコールドスタート（最初のバッチ）を除外
- ウォームアップ除外枚数をログに表示

## Code Changes

### 設定ファイル
```python
# configs/pochi_train_config.py
cudnn_benchmark = True  # cuDNN自動チューニング（固定サイズ入力で高速化）
```

### PochiTrainer初期化
```python
# pochitrain/pochi_trainer.py
def __init__(self, ..., cudnn_benchmark: bool = False):
    if self.device.type == "cuda" and cudnn_benchmark:
        torch.backends.cudnn.benchmark = True
```

### 推論時間計測（ウォームアップ除外）
```python
# pochitrain/pochi_trainer.py
if is_first_batch:
    # ウォームアップ: 最初のバッチは計測対象外
    output = self.model(data)
    warmup_samples = batch_size
    is_first_batch = False
else:
    # 推論時間計測
    ...
```

## Test Plan
- [x] `cudnn_benchmark=True`でCUDA環境で有効化されることを確認
- [x] `cudnn_benchmark=True`でCPU環境では無効になることを確認
- [x] バリデーションでbool型以外がエラーになることを確認
- [x] 推論時間計測からウォームアップが除外されることを確認
- [x] pre-commit全てパス