### PR TITLE
feat: Early Stopping機能を追加

### DIFF
--- a/configs/pochi_train_config.py
+++ b/configs/pochi_train_config.py
@@ -62,6 +62,14 @@ gradient_tracking_config = {
     "aggregation_method": "median",  # 集約方法: "median", "mean", "max", "rms"
 }
 
+# Early Stopping設定
+early_stopping = {
+    "enabled": False,  # Early Stoppingを有効化
+    "patience": 30,  # 改善なしの許容エポック数
+    "min_delta": 3.0,  # この値以上の変化がないと改善と見なさない(0.0なら少しでも良くなれば改善扱い)
+    "monitor": "val_accuracy",  # 監視メトリクス ("val_accuracy" or "val_loss")
+}
+
 # 層別学習率設定
 enable_layer_wise_lr = True
 layer_wise_lr_config = {

--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -229,6 +229,19 @@ def train_command(args: argparse.Namespace) -> None:
     if trainer.enable_metrics_export:
         logger.info("訓練メトリクスのCSV出力とグラフ生成が有効です")
 
+    # Early Stopping設定の適用
+    early_stopping_config = config.get("early_stopping")
+    if early_stopping_config and early_stopping_config.get("enabled", False):
+        trainer.early_stopping_config = early_stopping_config
+        logger.info(
+            f"Early Stopping: 有効 "
+            f"(patience={early_stopping_config.get('patience', 10)}, "
+            f"min_delta={early_stopping_config.get('min_delta', 0.0)}, "
+            f"monitor={early_stopping_config.get('monitor', 'val_accuracy')})"
+        )
+    else:
+        logger.info("Early Stopping: 無効")
+
     # 勾配トレース設定の適用
     trainer.enable_gradient_tracking = config.get("enable_gradient_tracking", False)
     if trainer.enable_gradient_tracking:

--- a/pochitrain/early_stopping.py
+++ b/pochitrain/early_stopping.py
@@ -1,0 +1,120 @@
+"""
+Early Stopping モジュール.
+
+検証メトリクスの改善が停止した場合に訓練を自動停止する機能を提供します。
+"""
+
+import logging
+from typing import Optional
+
+
+class EarlyStopping:
+    """
+    Early Stopping クラス.
+
+    検証メトリクスが一定エポック数改善しない場合に訓練停止を通知します。
+    PochiTrainerから各エポック後に呼び出され, 停止判定を委譲されます。
+
+    Args:
+        patience (int): 改善なしの許容エポック数
+        min_delta (float): 改善と見なす最小変化量
+        monitor (str): 監視するメトリクス名 ('val_accuracy' or 'val_loss')
+        logger (logging.Logger, optional): ロガーインスタンス
+    """
+
+    def __init__(
+        self,
+        patience: int = 10,
+        min_delta: float = 0.0,
+        monitor: str = "val_accuracy",
+        logger: Optional[logging.Logger] = None,
+    ):
+        """EarlyStoppingを初期化."""
+        self.patience = patience
+        self.min_delta = min_delta
+        self.monitor = monitor
+        self.logger = logger
+
+        # 内部状態
+        self.best_value: Optional[float] = None
+        self.counter = 0
+        self.should_stop = False
+        self.best_epoch = 0
+
+        # 監視メトリクスに応じて比較方向を決定
+        # val_accuracy: 大きいほど良い, val_loss: 小さいほど良い
+        self._is_improvement = (
+            self._higher_is_better
+            if monitor == "val_accuracy"
+            else self._lower_is_better
+        )
+
+    def _higher_is_better(self, current: float, best: float) -> bool:
+        """現在値がベスト値よりmin_delta以上大きいか判定."""
+        return current > best + self.min_delta
+
+    def _lower_is_better(self, current: float, best: float) -> bool:
+        """現在値がベスト値よりmin_delta以上小さいか判定."""
+        return current < best - self.min_delta
+
+    def step(self, value: float, epoch: int) -> bool:
+        """
+        エポック終了後にメトリクスを評価し, 停止判定を行う.
+
+        Args:
+            value (float): 現在のエポックのメトリクス値
+            epoch (int): 現在のエポック番号
+
+        Returns:
+            bool: 訓練を停止すべき場合True
+        """
+        if self.best_value is None:
+            # 初回: ベスト値を初期化
+            self.best_value = value
+            self.best_epoch = epoch
+            return False
+
+        if self._is_improvement(value, self.best_value):
+            # 改善があった場合: ベスト値を更新しカウンターをリセット
+            self.best_value = value
+            self.best_epoch = epoch
+            self.counter = 0
+        else:
+            # 改善がなかった場合: カウンターを増加
+            self.counter += 1
+            if self.logger:
+                self.logger.info(
+                    f"EarlyStopping: {self.counter}/{self.patience} "
+                    f"(ベスト{self.monitor}: {self.best_value:.4f}, "
+                    f"エポック {self.best_epoch})"
+                )
+
+            if self.counter >= self.patience:
+                self.should_stop = True
+                if self.logger:
+                    self.logger.warning(
+                        f"EarlyStopping: {self.patience}エポック間"
+                        f"{self.monitor}の改善がないため訓練を停止します. "
+                        f"ベスト{self.monitor}: {self.best_value:.4f} "
+                        f"(エポック {self.best_epoch})"
+                    )
+                return True
+
+        return False
+
+    def get_status(self) -> dict:
+        """
+        現在のEarlyStopping状態を取得.
+
+        Returns:
+            dict: 状態情報
+        """
+        return {
+            "patience": self.patience,
+            "min_delta": self.min_delta,
+            "monitor": self.monitor,
+            "counter": self.counter,
+            "best_value": self.best_value,
+            "best_epoch": self.best_epoch,
+            "should_stop": self.should_stop,
+        }

--- a/pochitrain/validation/config_validator.py
+++ b/pochitrain/validation/config_validator.py
@@ -12,6 +12,7 @@ from .validators import (
     ClassWeightsValidator,
     DataValidator,
     DeviceValidator,
+    EarlyStoppingValidator,
     LayerWiseLRValidator,
     OptimizerValidator,
     SchedulerValidator,
@@ -34,6 +35,7 @@ class ConfigValidator:
         self.class_weights_validator = ClassWeightsValidator()
         self.data_validator = DataValidator()
         self.device_validator = DeviceValidator()
+        self.early_stopping_validator = EarlyStoppingValidator()
         self.layer_wise_lr_validator = LayerWiseLRValidator()
         self.optimizer_validator = OptimizerValidator()
         self.scheduler_validator = SchedulerValidator()
@@ -60,6 +62,7 @@ class ConfigValidator:
             self.optimizer_validator,  # 最適化器設定
             self.scheduler_validator,  # スケジューラー設定
             self.layer_wise_lr_validator,  # 層別学習率設定
+            self.early_stopping_validator,  # Early Stopping設定
         ]
 
         for validator in validators:

--- a/pochitrain/validation/validators/__init__.py
+++ b/pochitrain/validation/validators/__init__.py
@@ -7,6 +7,7 @@ pochitrain.validation.validators: 個別バリデーターモジュール.
 from .class_weights_validator import ClassWeightsValidator
 from .data_validator import DataValidator
 from .device_validator import DeviceValidator
+from .early_stopping_validator import EarlyStoppingValidator
 from .layer_wise_lr_validator import LayerWiseLRValidator
 from .optimizer_validator import OptimizerValidator
 from .scheduler_validator import SchedulerValidator
@@ -17,6 +18,7 @@ __all__ = [
     "ClassWeightsValidator",
     "DataValidator",
     "DeviceValidator",
+    "EarlyStoppingValidator",
     "LayerWiseLRValidator",
     "OptimizerValidator",
     "SchedulerValidator",

--- a/pochitrain/validation/validators/early_stopping_validator.py
+++ b/pochitrain/validation/validators/early_stopping_validator.py
@@ -1,0 +1,170 @@
+"""
+Early Stopping設定のバリデーター.
+
+early_stopping設定の妥当性をチェックします。
+"""
+
+import logging
+from typing import Any, Dict
+
+from ..base_validator import BaseValidator
+
+
+class EarlyStoppingValidator(BaseValidator):
+    """Early Stopping設定のバリデーションクラス."""
+
+    SUPPORTED_MONITORS = ["val_accuracy", "val_loss"]
+
+    def validate(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
+        """
+        Early Stopping設定のバリデーション.
+
+        early_stopping設定が存在しない場合や無効の場合はスキップして成功を返します。
+
+        Args:
+            config (Dict[str, Any]): 設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        es_config = config.get("early_stopping")
+
+        # 設定がない場合はスキップ（後方互換性）
+        if es_config is None:
+            return True
+
+        # 辞書型チェック
+        if not isinstance(es_config, dict):
+            logger.error(
+                f"early_stopping は辞書である必要があります。"
+                f"現在の型: {type(es_config).__name__}"
+            )
+            return False
+
+        # enabled チェック
+        enabled = es_config.get("enabled", False)
+        if not isinstance(enabled, bool):
+            logger.error(
+                f"early_stopping.enabled はboolである必要があります。"
+                f"現在の型: {type(enabled).__name__}, 現在の値: {enabled}"
+            )
+            return False
+
+        # 無効の場合はこれ以上チェック不要
+        if not enabled:
+            return True
+
+        # patience チェック
+        if not self._validate_patience(es_config, logger):
+            return False
+
+        # min_delta チェック
+        if not self._validate_min_delta(es_config, logger):
+            return False
+
+        # monitor チェック
+        if not self._validate_monitor(es_config, logger):
+            return False
+
+        logger.info(
+            f"Early Stopping: 有効 "
+            f"(patience={es_config.get('patience', 10)}, "
+            f"min_delta={es_config.get('min_delta', 0.0)}, "
+            f"monitor={es_config.get('monitor', 'val_accuracy')})"
+        )
+
+        return True
+
+    def _validate_patience(
+        self, es_config: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """
+        patienceパラメータのバリデーション.
+
+        Args:
+            es_config (Dict[str, Any]): early_stopping設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        patience = es_config.get("patience", 10)
+
+        if not isinstance(patience, int) or isinstance(patience, bool):
+            logger.error(
+                f"early_stopping.patience は整数である必要があります。"
+                f"現在の型: {type(patience).__name__}, 現在の値: {patience}"
+            )
+            return False
+
+        if patience <= 0:
+            logger.error(
+                f"early_stopping.patience は正の整数である必要があります。"
+                f"現在の値: {patience}"
+            )
+            return False
+
+        return True
+
+    def _validate_min_delta(
+        self, es_config: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """
+        min_deltaパラメータのバリデーション.
+
+        Args:
+            es_config (Dict[str, Any]): early_stopping設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        min_delta = es_config.get("min_delta", 0.0)
+
+        if not isinstance(min_delta, (int, float)) or isinstance(min_delta, bool):
+            logger.error(
+                f"early_stopping.min_delta は数値である必要があります。"
+                f"現在の型: {type(min_delta).__name__}, 現在の値: {min_delta}"
+            )
+            return False
+
+        if min_delta < 0:
+            logger.error(
+                f"early_stopping.min_delta は0以上である必要があります。"
+                f"現在の値: {min_delta}"
+            )
+            return False
+
+        return True
+
+    def _validate_monitor(
+        self, es_config: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """
+        monitorパラメータのバリデーション.
+
+        Args:
+            es_config (Dict[str, Any]): early_stopping設定辞書
+            logger (logging.Logger): ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        monitor = es_config.get("monitor", "val_accuracy")
+
+        if not isinstance(monitor, str):
+            logger.error(
+                f"early_stopping.monitor は文字列である必要があります。"
+                f"現在の型: {type(monitor).__name__}, 現在の値: {monitor}"
+            )
+            return False
+
+        if monitor not in self.SUPPORTED_MONITORS:
+            logger.error(
+                f"サポートされていないmonitor値です: {monitor}. "
+                f"サポート対象: {self.SUPPORTED_MONITORS}"
+            )
+            return False
+
+        return True

--- a/tests/unit/test_core/test_early_stopping.py
+++ b/tests/unit/test_core/test_early_stopping.py
@@ -1,0 +1,171 @@
+"""
+EarlyStoppingクラスのユニットテスト.
+"""
+
+import logging
+
+import pytest
+
+from pochitrain.early_stopping import EarlyStopping
+
+
+class TestEarlyStoppingInit:
+    """EarlyStopping初期化のテスト."""
+
+    def test_default_parameters(self):
+        """デフォルトパラメータでの初期化テスト."""
+        es = EarlyStopping()
+        assert es.patience == 10
+        assert es.min_delta == 0.0
+        assert es.monitor == "val_accuracy"
+        assert es.best_value is None
+        assert es.counter == 0
+        assert es.should_stop is False
+        assert es.best_epoch == 0
+
+    def test_custom_parameters(self):
+        """カスタムパラメータでの初期化テスト."""
+        es = EarlyStopping(patience=5, min_delta=0.01, monitor="val_loss")
+        assert es.patience == 5
+        assert es.min_delta == 0.01
+        assert es.monitor == "val_loss"
+
+    def test_with_logger(self):
+        """ロガー付きでの初期化テスト."""
+        logger = logging.getLogger("test")
+        es = EarlyStopping(logger=logger)
+        assert es.logger is logger
+
+
+class TestEarlyStoppingValAccuracy:
+    """val_accuracy監視でのEarlyStoppingテスト."""
+
+    def test_no_stop_on_improvement(self):
+        """改善が続く場合は停止しないことを確認."""
+        es = EarlyStopping(patience=3, monitor="val_accuracy")
+        assert es.step(80.0, 1) is False
+        assert es.step(85.0, 2) is False
+        assert es.step(90.0, 3) is False
+        assert es.should_stop is False
+        assert es.counter == 0
+
+    def test_stop_after_patience_exceeded(self):
+        """patience回改善なしで停止することを確認."""
+        es = EarlyStopping(patience=3, monitor="val_accuracy")
+        assert es.step(90.0, 1) is False  # 初期値
+        assert es.step(89.0, 2) is False  # 改善なし (1/3)
+        assert es.step(88.0, 3) is False  # 改善なし (2/3)
+        assert es.step(87.0, 4) is True  # 改善なし (3/3) -> 停止
+        assert es.should_stop is True
+
+    def test_counter_resets_on_improvement(self):
+        """改善があった場合にカウンターがリセットされることを確認."""
+        es = EarlyStopping(patience=3, monitor="val_accuracy")
+        assert es.step(90.0, 1) is False
+        assert es.step(89.0, 2) is False  # 改善なし (1/3)
+        assert es.step(88.0, 3) is False  # 改善なし (2/3)
+        assert es.step(91.0, 4) is False  # 改善! -> カウンターリセット
+        assert es.counter == 0
+        assert es.best_value == 91.0
+        assert es.best_epoch == 4
+
+    def test_min_delta_threshold(self):
+        """min_deltaによる改善判定のテスト."""
+        es = EarlyStopping(patience=2, min_delta=1.0, monitor="val_accuracy")
+        assert es.step(90.0, 1) is False  # 初期値
+        assert es.step(90.5, 2) is False  # +0.5 < min_delta(1.0) -> 改善なし (1/2)
+        assert (
+            es.step(90.8, 3) is True
+        )  # +0.8 < min_delta(1.0) -> 改善なし (2/2) -> 停止
+        assert es.best_value == 90.0  # ベスト値は初期値のまま
+
+    def test_equal_value_counts_as_no_improvement(self):
+        """同じ値は改善なしとカウントされることを確認."""
+        es = EarlyStopping(patience=2, monitor="val_accuracy")
+        assert es.step(90.0, 1) is False
+        assert es.step(90.0, 2) is False  # 同値 -> 改善なし (1/2)
+        assert es.step(90.0, 3) is True  # 同値 -> 改善なし (2/2) -> 停止
+
+
+class TestEarlyStoppingValLoss:
+    """val_loss監視でのEarlyStoppingテスト."""
+
+    def test_no_stop_on_decreasing_loss(self):
+        """損失が減少し続ける場合は停止しないことを確認."""
+        es = EarlyStopping(patience=3, monitor="val_loss")
+        assert es.step(1.0, 1) is False
+        assert es.step(0.8, 2) is False
+        assert es.step(0.6, 3) is False
+        assert es.should_stop is False
+
+    def test_stop_on_increasing_loss(self):
+        """損失が増加し続ける場合に停止することを確認."""
+        es = EarlyStopping(patience=2, monitor="val_loss")
+        assert es.step(0.5, 1) is False  # 初期値
+        assert es.step(0.6, 2) is False  # 悪化 (1/2)
+        assert es.step(0.7, 3) is True  # 悪化 (2/2) -> 停止
+
+    def test_min_delta_with_loss(self):
+        """val_lossでのmin_delta判定テスト."""
+        es = EarlyStopping(patience=2, min_delta=0.1, monitor="val_loss")
+        assert es.step(1.0, 1) is False  # 初期値
+        assert es.step(0.95, 2) is False  # -0.05 < min_delta(0.1) -> 改善なし (1/2)
+        assert (
+            es.step(0.92, 3) is True
+        )  # -0.08 < min_delta(0.1) -> 改善なし (2/2) -> 停止
+
+
+class TestEarlyStoppingGetStatus:
+    """get_statusメソッドのテスト."""
+
+    def test_initial_status(self):
+        """初期状態のステータス確認."""
+        es = EarlyStopping(patience=5, min_delta=0.01, monitor="val_accuracy")
+        status = es.get_status()
+        assert status["patience"] == 5
+        assert status["min_delta"] == 0.01
+        assert status["monitor"] == "val_accuracy"
+        assert status["counter"] == 0
+        assert status["best_value"] is None
+        assert status["best_epoch"] == 0
+        assert status["should_stop"] is False
+
+    def test_status_after_steps(self):
+        """数ステップ後のステータス確認."""
+        es = EarlyStopping(patience=3, monitor="val_accuracy")
+        es.step(90.0, 1)
+        es.step(89.0, 2)  # 改善なし
+
+        status = es.get_status()
+        assert status["counter"] == 1
+        assert status["best_value"] == 90.0
+        assert status["best_epoch"] == 1
+        assert status["should_stop"] is False
+
+
+class TestEarlyStoppingWithLogger:
+    """ロガー付きEarlyStoppingのテスト."""
+
+    def test_logs_on_no_improvement(self, caplog):
+        """改善なし時にログが出力されることを確認."""
+        logger = logging.getLogger("test_es")
+        logger.setLevel(logging.DEBUG)
+        es = EarlyStopping(patience=3, monitor="val_accuracy", logger=logger)
+
+        with caplog.at_level(logging.INFO, logger="test_es"):
+            es.step(90.0, 1)
+            es.step(89.0, 2)  # 改善なし -> ログ出力
+
+        assert "EarlyStopping: 1/3" in caplog.text
+
+    def test_logs_warning_on_stop(self, caplog):
+        """停止時にwarningが出力されることを確認."""
+        logger = logging.getLogger("test_es_warn")
+        logger.setLevel(logging.DEBUG)
+        es = EarlyStopping(patience=1, monitor="val_accuracy", logger=logger)
+
+        with caplog.at_level(logging.WARNING, logger="test_es_warn"):
+            es.step(90.0, 1)
+            es.step(89.0, 2)  # 停止
+
+        assert "訓練を停止します" in caplog.text

--- a/tests/unit/test_validation/test_validators/test_early_stopping_validator.py
+++ b/tests/unit/test_validation/test_validators/test_early_stopping_validator.py
@@ -1,0 +1,271 @@
+"""EarlyStoppingValidatorのテスト."""
+
+import pytest
+
+from pochitrain.validation.validators.early_stopping_validator import (
+    EarlyStoppingValidator,
+)
+
+
+@pytest.fixture
+def validator():
+    """EarlyStoppingValidatorのfixture."""
+    return EarlyStoppingValidator()
+
+
+class TestEarlyStoppingNotConfigured:
+    """early_stopping設定が存在しない場合のテスト."""
+
+    def test_no_config_success(self, validator, mocker):
+        """early_stopping設定がない場合はバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"epochs": 50}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+
+    def test_disabled_config_success(self, validator, mocker):
+        """enabled=Falseの場合はバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": False}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+
+
+class TestEarlyStoppingTypeValidation:
+    """early_stopping設定の型バリデーションテスト."""
+
+    def test_non_dict_failure(self, validator, mocker):
+        """辞書でない場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": "invalid"}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping は辞書である必要があります。現在の型: str"
+        )
+
+    def test_enabled_non_bool_failure(self, validator, mocker):
+        """enabledがboolでない場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": "true"}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.enabled はboolである必要があります。"
+            "現在の型: str, 現在の値: true"
+        )
+
+
+class TestPatienceValidation:
+    """patienceパラメータのバリデーションテスト."""
+
+    def test_patience_non_int_failure(self, validator, mocker):
+        """patienceが整数でない場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "patience": 5.0}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.patience は整数である必要があります。"
+            "現在の型: float, 現在の値: 5.0"
+        )
+
+    def test_patience_bool_failure(self, validator, mocker):
+        """patienceがboolの場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "patience": True}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.patience は整数である必要があります。"
+            "現在の型: bool, 現在の値: True"
+        )
+
+    def test_patience_zero_failure(self, validator, mocker):
+        """patience=0の場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "patience": 0}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.patience は正の整数である必要があります。現在の値: 0"
+        )
+
+    def test_patience_negative_failure(self, validator, mocker):
+        """patienceが負の場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "patience": -5}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.patience は正の整数である必要があります。現在の値: -5"
+        )
+
+    def test_patience_valid_success(self, validator, mocker):
+        """有効なpatienceでバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "patience": 10}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+
+
+class TestMinDeltaValidation:
+    """min_deltaパラメータのバリデーションテスト."""
+
+    def test_min_delta_non_numeric_failure(self, validator, mocker):
+        """min_deltaが数値でない場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "min_delta": "0.01"}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.min_delta は数値である必要があります。"
+            "現在の型: str, 現在の値: 0.01"
+        )
+
+    def test_min_delta_bool_failure(self, validator, mocker):
+        """min_deltaがboolの場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "min_delta": True}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.min_delta は数値である必要があります。"
+            "現在の型: bool, 現在の値: True"
+        )
+
+    def test_min_delta_negative_failure(self, validator, mocker):
+        """min_deltaが負の場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "min_delta": -0.1}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.min_delta は0以上である必要があります。現在の値: -0.1"
+        )
+
+    def test_min_delta_zero_success(self, validator, mocker):
+        """min_delta=0でバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "min_delta": 0.0}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+
+    def test_min_delta_int_success(self, validator, mocker):
+        """min_deltaが整数でもバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "min_delta": 1}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+
+
+class TestMonitorValidation:
+    """monitorパラメータのバリデーションテスト."""
+
+    def test_monitor_non_string_failure(self, validator, mocker):
+        """monitorが文字列でない場合バリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "monitor": 123}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "early_stopping.monitor は文字列である必要があります。"
+            "現在の型: int, 現在の値: 123"
+        )
+
+    def test_monitor_unsupported_failure(self, validator, mocker):
+        """サポートされていないmonitorでバリデーション失敗."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "monitor": "train_loss"}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is False
+        mock_logger.error.assert_called_with(
+            "サポートされていないmonitor値です: train_loss. "
+            "サポート対象: ['val_accuracy', 'val_loss']"
+        )
+
+    def test_monitor_val_accuracy_success(self, validator, mocker):
+        """monitor='val_accuracy'でバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "monitor": "val_accuracy"}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+
+    def test_monitor_val_loss_success(self, validator, mocker):
+        """monitor='val_loss'でバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True, "monitor": "val_loss"}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+
+
+class TestEarlyStoppingValidatorIntegration:
+    """EarlyStoppingValidator統合テスト."""
+
+    def test_full_valid_config_success(self, validator, mocker):
+        """全パラメータが有効な場合バリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {
+            "early_stopping": {
+                "enabled": True,
+                "patience": 10,
+                "min_delta": 0.01,
+                "monitor": "val_accuracy",
+            }
+        }
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+        mock_logger.info.assert_called_with(
+            "Early Stopping: 有効 "
+            "(patience=10, min_delta=0.01, monitor=val_accuracy)"
+        )
+
+    def test_default_values_success(self, validator, mocker):
+        """デフォルト値でバリデーション成功."""
+        mock_logger = mocker.Mock()
+        config = {"early_stopping": {"enabled": True}}
+
+        result = validator.validate(config, mock_logger)
+
+        assert result is True
+        mock_logger.info.assert_called_with(
+            "Early Stopping: 有効 " "(patience=10, min_delta=0.0, monitor=val_accuracy)"
+        )


### PR DESCRIPTION
## Summary
- 検証メトリクスが一定エポック数改善しない場合に訓練を自動停止するEarly Stopping機能を追加
- SRPに従い`EarlyStopping`クラスを独立モジュールとして実装し, `PochiTrainer`から委譲
- `val_accuracy`(精度最大化)と`val_loss`(損失最小化)の両方の監視に対応
- 設定バリデーター(`EarlyStoppingValidator`)をChain of Responsibilityに追加
- `early_stopping`設定が未定義または`enabled: False`の場合は従来通り動作(後方互換性)

## Code Changes

### 新規ファイル

```python
# pochitrain/early_stopping.py
class EarlyStopping:
    def __init__(self, patience, min_delta, monitor, logger): ...
    def step(self, value, epoch) -> bool:  # True=停止
```

```python
# pochitrain/validation/validators/early_stopping_validator.py
class EarlyStoppingValidator(BaseValidator):
    def validate(self, config, logger) -> bool:  # patience, min_delta, monitor を検証
```

### 設定例 (configs/pochi_train_config.py)

```python
early_stopping = {
    "enabled": False,
    "patience": 10,
    "min_delta": 0.0,
    "monitor": "val_accuracy",
}
```

### 変更ファイル
- `pochitrain/pochi_trainer.py`: `train()`内でEarlyStopping初期化・判定・停止ログを追加
- `pochitrain/cli/pochi.py`: `train_command`でEarly Stopping設定をTrainerに渡す処理を追加
- `pochitrain/validation/config_validator.py`: バリデーションチェーンにEarlyStoppingValidatorを追加
- `pochitrain/validation/validators/__init__.py`: EarlyStoppingValidatorをexportに追加

## Test Plan
- [x] `EarlyStopping`クラスのテスト15件 (初期化, val_accuracy監視, val_loss監視, ステータス, ログ出力)
- [x] `EarlyStoppingValidator`のテスト20件 (型検証, 範囲検証, monitor検証, 統合テスト)
- [x] 既存テスト全442件合格, mypy型チェック通過
- [x] `uv run pre-commit run --all-files` 全チェック通過