### PR TITLE
refactor: PochiPredictor の継承を解消

### DIFF
--- a/pochitrain/inference/__init__.py
+++ b/pochitrain/inference/__init__.py
@@ -1,8 +1,8 @@
 """
 Pochitrainの推論サポートモジュール.
 
-推論に関連するCSV出力機能を提供します。
-メインの推論機能は pochitrain.pochi_predictor を参照してください。
+推論に関連するCSV出力機能を提供します.
+メインの推論機能は pochitrain.pochi_predictor を参照してください.
 """
 
 from .csv_exporter import InferenceCSVExporter

--- a/tests/unit/test_core/test_pochi_predictor.py
+++ b/tests/unit/test_core/test_pochi_predictor.py
@@ -12,6 +12,7 @@ import torchvision.transforms as transforms
 
 from pochitrain.models.pochi_models import PochiModel
 from pochitrain.pochi_predictor import PochiPredictor
+from pochitrain.pochi_trainer import PochiTrainer
 
 
 def _create_test_checkpoint(
@@ -129,6 +130,18 @@ class TestPochiPredictorInit:
                 model_path=str(tmp_path / "nonexistent.pth"),
                 work_dir=str(tmp_path / "inference_results"),
             )
+
+    def test_not_instance_of_trainer(self, tmp_path):
+        """PochiPredictorはPochiTrainerのインスタンスではない."""
+        checkpoint_path = _create_test_checkpoint(tmp_path)
+        predictor = PochiPredictor(
+            model_name="resnet18",
+            num_classes=3,
+            device="cpu",
+            model_path=str(checkpoint_path),
+            work_dir=str(tmp_path / "inference_results"),
+        )
+        assert not isinstance(predictor, PochiTrainer)
 
     def test_inference_workspace_not_created_on_init(self, tmp_path):
         """初期化時に推論ワークスペースが作成されない（遅延作成）."""


### PR DESCRIPTION
## Summary

- `PochiPredictor` を `PochiTrainer` の継承から独立クラスに変更し, 推論に必要な属性のみを直接初期化するように修正
- `PochiTrainer.predict()` を削除し, 推論ロジックを `PochiPredictor.predict()` に直接実装 (訓練フローで未使用のため)
- `test_not_instance_of_trainer` テストを追加し, 継承関係の解消を検証

## Code Changes

```python
# pochitrain/pochi_predictor.py
# Before: PochiTrainer を継承
class PochiPredictor(PochiTrainer):
    def __init__(self, ...):
        super().__init__(..., create_workspace=False)

# After: 独立クラス, 必要な属性を直接初期化
class PochiPredictor:
    def __init__(self, model_name, num_classes, device, model_path, work_dir="inference_results"):
        self.device = torch.device(device)
        self.logger = LoggerManager().get_logger("pochitrain")
        self.model = create_model(model_name, num_classes, pretrained=False)
        ...
```

```python
# pochitrain/pochi_trainer.py
# predict() メソッドを削除（訓練フローで未使用, 推論は PochiPredictor が担当）
```

```python
# tests/unit/test_core/test_pochi_predictor.py
def test_not_instance_of_trainer(self, tmp_path):
    """PochiPredictorはPochiTrainerのインスタンスではない."""
    ...
    assert not isinstance(predictor, PochiTrainer)
```

## Test Plan

- [x] `test_pochi_predictor.py` 17件全パス (新規1件含む)
- [x] 既存テスト全468件通過 (回帰なし)
- [x] `uv run pre-commit run --all-files` 全チェック通過