### PR TITLE
refactor: 推論後処理の共通化

### DIFF
--- a/pochitrain/onnx/inference.py
+++ b/pochitrain/onnx/inference.py
@@ -8,6 +8,7 @@ import numpy as np
 import onnxruntime as ort
 
 from pochitrain.logging import LoggerManager
+from pochitrain.utils.inference_utils import post_process_logits
 
 logger: logging.Logger = LoggerManager().get_logger(__name__)
 
@@ -81,14 +82,7 @@ class OnnxInference:
         outputs = self.session.run([output_name], {input_name: images})
         logits = outputs[0]
 
-        # softmaxで確率に変換
-        exp_logits = np.exp(logits - np.max(logits, axis=1, keepdims=True))
-        probabilities = exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
-
-        predicted = np.argmax(probabilities, axis=1)
-        confidence = np.max(probabilities, axis=1)
-
-        return predicted, confidence
+        return post_process_logits(logits)
 
     def get_providers(self) -> List[str]:
         """使用中のプロバイダーを取得.

--- a/pochitrain/pochi_predictor.py
+++ b/pochitrain/pochi_predictor.py
@@ -14,6 +14,7 @@ from torch.utils.data import DataLoader
 
 from .logging import LoggerManager
 from .models.pochi_models import create_model
+from .utils.inference_utils import post_process_logits
 
 
 class PochiPredictor:
@@ -144,11 +145,11 @@ class PochiPredictor:
                     total_samples += batch_size
 
                 # 後処理（計測対象外）
-                probabilities = torch.softmax(output, dim=1)
-                confidence, predicted = probabilities.max(1)
+                logits = output.cpu().numpy()
+                predicted, confidence = post_process_logits(logits)
 
-                predictions.extend(predicted.cpu().numpy())
-                confidences.extend(confidence.cpu().numpy())
+                predictions.extend(predicted)
+                confidences.extend(confidence)
 
         # 1枚あたりの平均推論時間を表示（ウォームアップ分を除く）
         if total_samples > 0:

--- a/pochitrain/tensorrt/inference.py
+++ b/pochitrain/tensorrt/inference.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 
 from pochitrain.logging import LoggerManager
+from pochitrain.utils.inference_utils import post_process_logits
 
 logger: logging.Logger = LoggerManager().get_logger(__name__)
 
@@ -138,14 +139,7 @@ class TensorRTInference:
 
         logits = np.concatenate(all_logits, axis=0)
 
-        # softmaxで確率に変換
-        exp_logits = np.exp(logits - np.max(logits, axis=1, keepdims=True))
-        probabilities = exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
-
-        predicted = np.argmax(probabilities, axis=1)
-        confidence = np.max(probabilities, axis=1)
-
-        return predicted, confidence
+        return post_process_logits(logits)
 
     def get_input_shape(self) -> Tuple[int, ...]:
         """入力shapeを取得.


### PR DESCRIPTION
## Summary

- `post_process_logits()` 関数を `utils/inference_utils.py` に追加し, softmax → argmax → confidence 抽出の後処理を一元化
- `PochiPredictor.predict()`, `OnnxInference.run()`, `TensorRTInference.run()` の3箇所の重複実装を共通関数の呼び出しに置換
- `post_process_logits()` のユニットテスト9件を追加 (基本動作, 数値安定性, バッチ処理, エッジケース)

## Code Changes

```python
# pochitrain/utils/inference_utils.py (新規関数)
def post_process_logits(
    logits: np.ndarray,
) -> Tuple[np.ndarray, np.ndarray]:
    """ロジットからsoftmax + argmax + confidence抽出を行う共通後処理."""
    exp_logits = np.exp(logits - np.max(logits, axis=1, keepdims=True))
    probabilities = exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
    predicted = np.argmax(probabilities, axis=1)
    confidence = np.max(probabilities, axis=1)
    return predicted, confidence
```

```python
# pochitrain/onnx/inference.py (変更)
# Before
exp_logits = np.exp(logits - np.max(logits, axis=1, keepdims=True))
probabilities = exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
predicted = np.argmax(probabilities, axis=1)
confidence = np.max(probabilities, axis=1)
return predicted, confidence

# After
return post_process_logits(logits)
```

```python
# pochitrain/pochi_predictor.py (変更)
# Before
probabilities = torch.softmax(output, dim=1)
confidence, predicted = probabilities.max(1)
predictions.extend(predicted.cpu().numpy())
confidences.extend(confidence.cpu().numpy())

# After
logits = output.cpu().numpy()
predicted, confidence = post_process_logits(logits)
predictions.extend(predicted)
confidences.extend(confidence)
```

## Test Plan

- [x] `test_inference_utils.py` 49件全パス (新規9件含む)
- [x] `test_onnx/test_inference.py` 9件全パス (回帰なし)
- [x] `test_tensorrt/test_inference.py` 3件パス, 1件スキップ (回帰なし)
- [x] mypy 型チェック通過 (対象4ファイル)