### PR TITLE
refactor: EarlyStopping の初期化を setup_training() に統一

### DIFF
--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -213,6 +213,7 @@ def train_command(args: argparse.Namespace) -> None:
         num_classes=len(classes),
         enable_layer_wise_lr=config.get("enable_layer_wise_lr", False),
         layer_wise_lr_config=config.get("layer_wise_lr_config"),
+        early_stopping_config=config.get("early_stopping"),
     )
 
     # データセットパスの保存
@@ -245,17 +246,9 @@ def train_command(args: argparse.Namespace) -> None:
     if trainer.enable_metrics_export:
         logger.info("訓練メトリクスのCSV出力とグラフ生成が有効です")
 
-    # Early Stopping設定の適用
+    # Early Stopping設定のログ出力（初期化はsetup_training()で完了済み）
     early_stopping_config = config.get("early_stopping")
-    if early_stopping_config and early_stopping_config.get("enabled", False):
-        trainer.early_stopping_config = early_stopping_config
-        logger.info(
-            f"Early Stopping: 有効 "
-            f"(patience={early_stopping_config.get('patience', 10)}, "
-            f"min_delta={early_stopping_config.get('min_delta', 0.0)}, "
-            f"monitor={early_stopping_config.get('monitor', 'val_accuracy')})"
-        )
-    else:
+    if not (early_stopping_config and early_stopping_config.get("enabled", False)):
         logger.info("Early Stopping: 無効")
 
     # 勾配トレース設定の適用

--- a/pochitrain/training/training_configurator.py
+++ b/pochitrain/training/training_configurator.py
@@ -172,7 +172,7 @@ class TrainingConfigurator:
                 f"scheduler_paramsが必須です。configs/pochi_config.pyで設定してください。"
             )
 
-        schedulers = {
+        schedulers: Dict[str, type] = {
             "StepLR": optim.lr_scheduler.StepLR,
             "MultiStepLR": optim.lr_scheduler.MultiStepLR,
             "CosineAnnealingLR": optim.lr_scheduler.CosineAnnealingLR,
@@ -183,7 +183,10 @@ class TrainingConfigurator:
         scheduler_cls = schedulers.get(scheduler_name)
         if scheduler_cls is None:
             raise ValueError(f"サポートされていないスケジューラー: {scheduler_name}")
-        return scheduler_cls(optimizer, **scheduler_params)
+        scheduler: optim.lr_scheduler.LRScheduler = scheduler_cls(
+            optimizer, **scheduler_params
+        )
+        return scheduler
 
     def _build_layer_wise_param_groups(
         self,


### PR DESCRIPTION
## Summary

- `EarlyStopping` の初期化を `train()` 内部から `setup_training()` に移動し, 他の訓練コンポーネント (`optimizer`, `scheduler`, `criterion`) と初期化場所を統一
- `PochiTrainer.__init__` から不要な `early_stopping_config` 属性を削除し, `early_stopping` の型を `Optional[Any]` から `Optional[EarlyStopping]` に明確化
- CLI (`pochi.py`) の dict 直接代入と重複ログ出力を削除し, `setup_training()` 経由で設定するように変更
- `training_configurator.py` の既存 mypy エラー (`no-any-return`) を修正

## Code Changes

```python
# pochitrain/pochi_trainer.py - setup_training() に early_stopping_config パラメータを追加
def setup_training(
    self,
    ...
    early_stopping_config: Optional[Dict[str, Any]] = None,
) -> None:
    ...
    # Early Stoppingの初期化
    if early_stopping_config is not None and early_stopping_config.get(
        "enabled", False
    ):
        self.early_stopping = EarlyStopping(
            patience=early_stopping_config.get("patience", 10),
            min_delta=early_stopping_config.get("min_delta", 0.0),
            monitor=early_stopping_config.get("monitor", "val_accuracy"),
            logger=self.logger,
        )
```

```python
# pochitrain/cli/pochi.py - setup_training() 経由で設定
trainer.setup_training(
    ...
    early_stopping_config=config.get("early_stopping"),
)
```

## Test Plan

- [x] 全 511 テストパス (1 skipped: TensorRT環境依存)
- [x] mypy 型チェック通過 (変更対象の全ファイル)
- [x] EarlyStopping テスト 15 件パス
- [x] EarlyStoppingValidator テスト 20 件パス