### PR TITLE
refactor: BaseValidator にヘルパーメソッドを追加し, バリデーターのボイラープレートを削減

### DIFF
--- a/pochitrain/validation/base_validator.py
+++ b/pochitrain/validation/base_validator.py
@@ -2,11 +2,12 @@
 バリデーターの抽象基底クラス.
 
 全てのバリデーターが実装すべきインターフェースを定義します。
+共通のバリデーションヘルパーメソッドを提供します。
 """
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Sequence, Tuple, Type, Union
 
 
 class BaseValidator(ABC):
@@ -25,3 +26,167 @@ class BaseValidator(ABC):
             bool: バリデーション成功時True、失敗時False
         """
         pass
+
+    def _validate_required_type(
+        self,
+        value: Any,
+        field_name: str,
+        expected_type: Union[Type[Any], Tuple[Type[Any], ...]],
+        logger: logging.Logger,
+        *,
+        exclude_bool: bool = False,
+    ) -> bool:
+        """
+        必須フィールドの存在チェックと型チェックを行う.
+
+        Args:
+            value: チェック対象の値
+            field_name: フィールド名(エラーメッセージ用)
+            expected_type: 期待する型(単一またはタプル)
+            logger: ロガーインスタンス
+            exclude_bool: Trueの場合、bool型を除外する
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        if value is None:
+            logger.error(
+                f"{field_name} が設定されていません。"
+                f"configs/pochi_train_config.py で設定してください。"
+            )
+            return False
+
+        if exclude_bool and isinstance(value, bool):
+            logger.error(
+                f"{field_name} は {self._type_name(expected_type)} である必要があります。"
+                f"現在の型: {type(value).__name__}, 現在の値: {value}"
+            )
+            return False
+
+        if not isinstance(value, expected_type):
+            logger.error(
+                f"{field_name} は {self._type_name(expected_type)} である必要があります。"
+                f"現在の型: {type(value).__name__}, 現在の値: {value}"
+            )
+            return False
+
+        return True
+
+    def _validate_positive(
+        self,
+        value: Any,
+        field_name: str,
+        logger: logging.Logger,
+    ) -> bool:
+        """
+        値が正の数であることをチェックする.
+
+        Args:
+            value: チェック対象の値
+            field_name: フィールド名(エラーメッセージ用)
+            logger: ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        if value <= 0:
+            logger.error(
+                f"{field_name} は正の値である必要があります。現在の値: {value}"
+            )
+            return False
+        return True
+
+    def _validate_range(
+        self,
+        value: Any,
+        field_name: str,
+        logger: logging.Logger,
+        *,
+        gt: Optional[Union[int, float]] = None,
+        ge: Optional[Union[int, float]] = None,
+        lt: Optional[Union[int, float]] = None,
+        le: Optional[Union[int, float]] = None,
+    ) -> bool:
+        """
+        値が指定範囲内であることをチェックする.
+
+        Args:
+            value: チェック対象の値
+            field_name: フィールド名(エラーメッセージ用)
+            logger: ロガーインスタンス
+            gt: より大きい(exclusive lower bound)
+            ge: 以上(inclusive lower bound)
+            lt: より小さい(exclusive upper bound)
+            le: 以下(inclusive upper bound)
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        bounds = []
+        if gt is not None:
+            if value <= gt:
+                bounds.append(f"{gt} < ")
+        if ge is not None:
+            if value < ge:
+                bounds.append(f"{ge} <= ")
+        if lt is not None:
+            if value >= lt:
+                bounds.append(f" < {lt}")
+        if le is not None:
+            if value > le:
+                bounds.append(f" <= {le}")
+
+        if bounds:
+            range_parts = []
+            if gt is not None:
+                range_parts.append(f"{gt} < ")
+            if ge is not None:
+                range_parts.append(f"{ge} <= ")
+            range_parts.append(field_name)
+            if lt is not None:
+                range_parts.append(f" < {lt}")
+            if le is not None:
+                range_parts.append(f" <= {le}")
+            range_str = "".join(range_parts)
+
+            logger.error(
+                f"{field_name} は {range_str} の範囲である必要があります。"
+                f"現在の値: {value}"
+            )
+            return False
+
+        return True
+
+    def _validate_choice(
+        self,
+        value: Any,
+        field_name: str,
+        choices: Sequence[Any],
+        logger: logging.Logger,
+    ) -> bool:
+        """
+        値が選択肢のいずれかであることをチェックする.
+
+        Args:
+            value: チェック対象の値
+            field_name: フィールド名(エラーメッセージ用)
+            choices: 有効な選択肢のシーケンス
+            logger: ロガーインスタンス
+
+        Returns:
+            bool: バリデーション成功時True、失敗時False
+        """
+        if value not in choices:
+            logger.error(
+                f"サポートされていない{field_name}です: {value}. "
+                f"サポート対象: {list(choices)}"
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _type_name(expected_type: Union[Type[Any], Tuple[Type[Any], ...]]) -> str:
+        """型名の表示用文字列を生成する."""
+        if isinstance(expected_type, tuple):
+            return " または ".join(t.__name__ for t in expected_type)
+        return expected_type.__name__

--- a/pochitrain/validation/validators/class_weights_validator.py
+++ b/pochitrain/validation/validators/class_weights_validator.py
@@ -28,18 +28,11 @@ class ClassWeightsValidator(BaseValidator):
         num_classes = config.get("num_classes")
 
         # num_classesの必須チェック
-        if num_classes is None:
-            logger.error(
-                "num_classes が設定されていません。configs/pochi_train_config.py で "
-                "クラス数を設定してください。"
-            )
+        if not self._validate_required_type(
+            num_classes, "num_classes", int, logger, exclude_bool=True
+        ):
             return False
-
-        # num_classesの型と値チェック
-        if not isinstance(num_classes, int) or num_classes <= 0:
-            logger.error(
-                f"num_classes は正の整数である必要があります。現在の値: {num_classes}"
-            )
+        if not self._validate_positive(num_classes, "num_classes", logger):
             return False
 
         # class_weightsがNoneの場合は正常（クラス重みなし）

--- a/pochitrain/validation/validators/optimizer_validator.py
+++ b/pochitrain/validation/validators/optimizer_validator.py
@@ -29,52 +29,24 @@ class OptimizerValidator(BaseValidator):
         Returns:
             bool: バリデーション成功時True、失敗時False
         """
-        # learning_rateの必須チェック
+        # learning_rateのバリデーション
         learning_rate = config.get("learning_rate")
-        if learning_rate is None:
-            logger.error(
-                "learning_rate が設定されていません。configs/pochi_train_config.py で "
-                "学習率を設定してください。"
-            )
+        if not self._validate_required_type(
+            learning_rate, "learning_rate", (int, float), logger
+        ):
+            return False
+        if not self._validate_range(
+            learning_rate, "learning_rate", logger, gt=0, le=1.0
+        ):
             return False
 
-        # learning_rateの型チェック
-        if not isinstance(learning_rate, (int, float)):
-            logger.error(
-                f"learning_rate は数値である必要があります。現在の型: {type(learning_rate)}"
-            )
-            return False
-
-        # learning_rateの範囲チェック（0 < lr ≤ 1.0）
-        if learning_rate <= 0 or learning_rate > 1.0:
-            logger.error(
-                f"learning_rate は 0 < lr ≤ 1.0 の範囲である必要があります。"
-                f"現在の値: {learning_rate}"
-            )
-            return False
-
-        # optimizerの必須チェック
+        # optimizerのバリデーション
         optimizer = config.get("optimizer")
-        if optimizer is None:
-            logger.error(
-                "optimizer が設定されていません。configs/pochi_train_config.py で "
-                "最適化器を設定してください。"
-            )
+        if not self._validate_required_type(optimizer, "optimizer", str, logger):
             return False
-
-        # optimizerの型チェック
-        if not isinstance(optimizer, str):
-            logger.error(
-                f"optimizer は文字列である必要があります。現在の型: {type(optimizer)}"
-            )
-            return False
-
-        # optimizerの妥当性チェック
-        if optimizer not in self.supported_optimizers:
-            logger.error(
-                f"サポートされていない最適化器です: {optimizer}. "
-                f"サポート対象: {self.supported_optimizers}"
-            )
+        if not self._validate_choice(
+            optimizer, "最適化器", self.supported_optimizers, logger
+        ):
             return False
 
         # 成功時のログ出力

--- a/pochitrain/validation/validators/scheduler_validator.py
+++ b/pochitrain/validation/validators/scheduler_validator.py
@@ -46,12 +46,12 @@ class SchedulerValidator(BaseValidator):
             return False
 
         # サポートされているスケジューラーかチェック
-        if scheduler_name not in self.SUPPORTED_SCHEDULERS:
-            logger.error(
-                f"サポートされていないスケジューラー: {scheduler_name}. "
-                f"サポートされているスケジューラー: "
-                f"{list(self.SUPPORTED_SCHEDULERS.keys())}"
-            )
+        if not self._validate_choice(
+            scheduler_name,
+            "スケジューラー",
+            list(self.SUPPORTED_SCHEDULERS.keys()),
+            logger,
+        ):
             return False
 
         # scheduler_params の存在確認
@@ -106,87 +106,118 @@ class SchedulerValidator(BaseValidator):
             bool: 検証成功時はTrue、失敗時はFalse
         """
         if scheduler_name == "StepLR":
-            step_size = scheduler_params.get("step_size")
-            if not isinstance(step_size, int):
-                logger.error("StepLR の step_size は整数型である必要があります。")
-                return False
-            if step_size is not None and step_size <= 0:
-                logger.error("StepLR の step_size は正数である必要があります。")
-                return False
-
-            gamma = scheduler_params.get("gamma")
-            if not isinstance(gamma, (int, float)):
-                logger.error("StepLR の gamma は数値型である必要があります。")
-                return False
-            if gamma is not None and gamma <= 0:
-                logger.error("StepLR の gamma は正数である必要があります。")
-                return False
-
+            return self._validate_step_lr(scheduler_params, logger)
         elif scheduler_name == "MultiStepLR":
-            milestones = scheduler_params.get("milestones")
-            if not isinstance(milestones, list) or not milestones:
-                logger.error(
-                    "MultiStepLR の milestones はリスト型である必要があります。"
-                )
-                return False
-            if not all(isinstance(m, int) and m > 0 for m in milestones):
-                logger.error(
-                    "MultiStepLR の milestones はすべて正の整数である必要があります。"
-                )
-                return False
-
-            gamma = scheduler_params.get("gamma")
-            if not isinstance(gamma, (int, float)):
-                logger.error("MultiStepLR の gamma は数値型である必要があります。")
-                return False
-            if gamma is not None and gamma <= 0:
-                logger.error("MultiStepLR の gamma は正数である必要があります。")
-                return False
-
+            return self._validate_multi_step_lr(scheduler_params, logger)
         elif scheduler_name == "CosineAnnealingLR":
-            t_max = scheduler_params.get("T_max")
-            if not isinstance(t_max, int):
-                logger.error(
-                    "CosineAnnealingLR の T_max は整数型である必要があります。"
-                )
-                return False
-            if t_max is not None and t_max <= 0:
-                logger.error("CosineAnnealingLR の T_max は正数である必要があります。")
-                return False
-
+            return self._validate_cosine_annealing_lr(scheduler_params, logger)
         elif scheduler_name == "ExponentialLR":
-            gamma = scheduler_params.get("gamma")
-            if not isinstance(gamma, (int, float)):
-                logger.error("ExponentialLR の gamma は数値型である必要があります。")
-                return False
-            if gamma is not None and gamma <= 0:
-                logger.error("ExponentialLR の gamma は正数である必要があります。")
-                return False
-
+            return self._validate_exponential_lr(scheduler_params, logger)
         elif scheduler_name == "LinearLR":
-            start_factor = scheduler_params.get("start_factor")
-            end_factor = scheduler_params.get("end_factor")
-            total_iters = scheduler_params.get("total_iters")
+            return self._validate_linear_lr(scheduler_params, logger)
 
-            if not isinstance(start_factor, (int, float)):
-                logger.error("LinearLR の start_factor は数値型である必要があります。")
-                return False
-            if start_factor is not None and start_factor < 0:
-                logger.error("LinearLR の start_factor は非負数である必要があります。")
-                return False
+        return True
 
-            if not isinstance(end_factor, (int, float)):
-                logger.error("LinearLR の end_factor は数値型である必要があります。")
-                return False
-            if end_factor is not None and end_factor < 0:
-                logger.error("LinearLR の end_factor は非負数である必要があります。")
-                return False
+    def _validate_step_lr(self, params: Dict[str, Any], logger: logging.Logger) -> bool:
+        """StepLRパラメータの検証."""
+        step_size = params.get("step_size")
+        if not self._validate_required_type(
+            step_size, "StepLR の step_size", int, logger
+        ):
+            return False
+        if not self._validate_positive(step_size, "StepLR の step_size", logger):
+            return False
 
-            if not isinstance(total_iters, int):
-                logger.error("LinearLR の total_iters は整数型である必要があります。")
-                return False
-            if total_iters is not None and total_iters <= 0:
-                logger.error("LinearLR の total_iters は正数である必要があります。")
-                return False
+        gamma = params.get("gamma")
+        if not self._validate_required_type(
+            gamma, "StepLR の gamma", (int, float), logger
+        ):
+            return False
+        if not self._validate_positive(gamma, "StepLR の gamma", logger):
+            return False
+
+        return True
+
+    def _validate_multi_step_lr(
+        self, params: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """MultiStepLRパラメータの検証."""
+        milestones = params.get("milestones")
+        if not isinstance(milestones, list) or not milestones:
+            logger.error("MultiStepLR の milestones はリスト型である必要があります。")
+            return False
+        if not all(isinstance(m, int) and m > 0 for m in milestones):
+            logger.error(
+                "MultiStepLR の milestones はすべて正の整数である必要があります。"
+            )
+            return False
+
+        gamma = params.get("gamma")
+        if not self._validate_required_type(
+            gamma, "MultiStepLR の gamma", (int, float), logger
+        ):
+            return False
+        if not self._validate_positive(gamma, "MultiStepLR の gamma", logger):
+            return False
+
+        return True
+
+    def _validate_cosine_annealing_lr(
+        self, params: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """CosineAnnealingLRパラメータの検証."""
+        t_max = params.get("T_max")
+        if not self._validate_required_type(
+            t_max, "CosineAnnealingLR の T_max", int, logger
+        ):
+            return False
+        if not self._validate_positive(t_max, "CosineAnnealingLR の T_max", logger):
+            return False
+
+        return True
+
+    def _validate_exponential_lr(
+        self, params: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """ExponentialLRパラメータの検証."""
+        gamma = params.get("gamma")
+        if not self._validate_required_type(
+            gamma, "ExponentialLR の gamma", (int, float), logger
+        ):
+            return False
+        if not self._validate_positive(gamma, "ExponentialLR の gamma", logger):
+            return False
+
+        return True
+
+    def _validate_linear_lr(
+        self, params: Dict[str, Any], logger: logging.Logger
+    ) -> bool:
+        """LinearLRパラメータの検証."""
+        start_factor = params.get("start_factor")
+        if not self._validate_required_type(
+            start_factor, "LinearLR の start_factor", (int, float), logger
+        ):
+            return False
+        if not self._validate_range(
+            start_factor, "LinearLR の start_factor", logger, ge=0
+        ):
+            return False
+
+        end_factor = params.get("end_factor")
+        if not self._validate_required_type(
+            end_factor, "LinearLR の end_factor", (int, float), logger
+        ):
+            return False
+        if not self._validate_range(end_factor, "LinearLR の end_factor", logger, ge=0):
+            return False
+
+        total_iters = params.get("total_iters")
+        if not self._validate_required_type(
+            total_iters, "LinearLR の total_iters", int, logger
+        ):
+            return False
+        if not self._validate_positive(total_iters, "LinearLR の total_iters", logger):
+            return False
 
         return True

--- a/pochitrain/validation/validators/training_validator.py
+++ b/pochitrain/validation/validators/training_validator.py
@@ -30,137 +30,35 @@ class TrainingValidator(BaseValidator):
             bool: バリデーション成功時True、失敗時False
         """
         # epochsのバリデーション
-        if not self._validate_epochs(config, logger):
+        epochs = config.get("epochs")
+        if not self._validate_required_type(
+            epochs, "epochs", int, logger, exclude_bool=True
+        ):
+            return False
+        if not self._validate_positive(epochs, "epochs", logger):
             return False
 
         # batch_sizeのバリデーション
-        if not self._validate_batch_size(config, logger):
+        batch_size = config.get("batch_size")
+        if not self._validate_required_type(
+            batch_size, "batch_size", int, logger, exclude_bool=True
+        ):
+            return False
+        if not self._validate_positive(batch_size, "batch_size", logger):
             return False
 
         # model_nameのバリデーション
-        if not self._validate_model_name(config, logger):
+        model_name = config.get("model_name")
+        if not self._validate_required_type(model_name, "model_name", str, logger):
+            return False
+        if not self._validate_choice(
+            model_name, "モデル名", self.supported_models, logger
+        ):
             return False
 
         # 成功時のログ出力
-        logger.info(f"エポック数: {config.get('epochs')}")
-        logger.info(f"バッチサイズ: {config.get('batch_size')}")
-        logger.info(f"モデル名: {config.get('model_name')}")
-
-        return True
-
-    def _validate_epochs(self, config: Dict[str, Any], logger: logging.Logger) -> bool:
-        """
-        epochsパラメータのバリデーション.
-
-        Args:
-            config (Dict[str, Any]): 設定辞書
-            logger (logging.Logger): ロガーインスタンス
-
-        Returns:
-            bool: バリデーション成功時True、失敗時False
-        """
-        epochs = config.get("epochs")
-
-        # 必須チェック
-        if epochs is None:
-            logger.error(
-                "epochs が設定されていません。configs/pochi_train_config.py で "
-                "エポック数を設定してください。"
-            )
-            return False
-
-        # 型チェック（int のみ受け入れ、boolは除外）
-        if not isinstance(epochs, int) or isinstance(epochs, bool):
-            logger.error(
-                f"epochs は整数である必要があります。現在の型: {type(epochs).__name__}, "
-                f"現在の値: {epochs}"
-            )
-            return False
-
-        # 正の整数チェック（0は許可しない）
-        if epochs <= 0:
-            logger.error(f"epochs は正の整数である必要があります。現在の値: {epochs}")
-            return False
-
-        return True
-
-    def _validate_batch_size(
-        self, config: Dict[str, Any], logger: logging.Logger
-    ) -> bool:
-        """
-        batch_sizeパラメータのバリデーション.
-
-        Args:
-            config (Dict[str, Any]): 設定辞書
-            logger (logging.Logger): ロガーインスタンス
-
-        Returns:
-            bool: バリデーション成功時True、失敗時False
-        """
-        batch_size = config.get("batch_size")
-
-        # 必須チェック
-        if batch_size is None:
-            logger.error(
-                "batch_size が設定されていません。configs/pochi_train_config.py で "
-                "バッチサイズを設定してください。"
-            )
-            return False
-
-        # 型チェック（int のみ受け入れ、boolは除外）
-        if not isinstance(batch_size, int) or isinstance(batch_size, bool):
-            logger.error(
-                f"batch_size は整数である必要があります。現在の型: {type(batch_size).__name__}, "
-                f"現在の値: {batch_size}"
-            )
-            return False
-
-        # 正の整数チェック（0は許可しない）
-        if batch_size <= 0:
-            logger.error(
-                f"batch_size は正の整数である必要があります。現在の値: {batch_size}"
-            )
-            return False
-
-        return True
-
-    def _validate_model_name(
-        self, config: Dict[str, Any], logger: logging.Logger
-    ) -> bool:
-        """
-        model_nameパラメータのバリデーション.
-
-        Args:
-            config (Dict[str, Any]): 設定辞書
-            logger (logging.Logger): ロガーインスタンス
-
-        Returns:
-            bool: バリデーション成功時True、失敗時False
-        """
-        model_name = config.get("model_name")
-
-        # 必須チェック
-        if model_name is None:
-            logger.error(
-                "model_name が設定されていません。configs/pochi_train_config.py で "
-                "モデル名を設定してください。"
-            )
-            return False
-
-        # 型チェック
-        if not isinstance(model_name, str):
-            logger.error(
-                f"model_name は文字列である必要があります。現在の型: {type(model_name).__name__}, "
-                f"現在の値: {model_name}"
-            )
-            return False
-
-        # サポートされているモデル名チェック
-        if model_name not in self.supported_models:
-            logger.error(
-                f"サポートされていないモデル名です: {model_name}. "
-                f"サポート対象: {self.supported_models}"
-            )
-            return False
+        logger.info(f"エポック数: {epochs}")
+        logger.info(f"バッチサイズ: {batch_size}")
+        logger.info(f"モデル名: {model_name}")
 
         return True

--- a/tests/unit/test_validation/test_validators/test_class_weights_validator.py
+++ b/tests/unit/test_validation/test_validators/test_class_weights_validator.py
@@ -27,8 +27,8 @@ class TestClassWeightsValidator(unittest.TestCase):
         # アサーション
         assert result is False
         self.mock_logger.error.assert_called_once_with(
-            "num_classes が設定されていません。configs/pochi_train_config.py で "
-            "クラス数を設定してください。"
+            "num_classes が設定されていません。"
+            "configs/pochi_train_config.py で設定してください。"
         )
 
     def test_num_classes_none_validation_fails(self):
@@ -40,8 +40,8 @@ class TestClassWeightsValidator(unittest.TestCase):
         # アサーション
         assert result is False
         self.mock_logger.error.assert_called_once_with(
-            "num_classes が設定されていません。configs/pochi_train_config.py で "
-            "クラス数を設定してください。"
+            "num_classes が設定されていません。"
+            "configs/pochi_train_config.py で設定してください。"
         )
 
     def test_num_classes_invalid_type_validation_fails(self):
@@ -53,7 +53,7 @@ class TestClassWeightsValidator(unittest.TestCase):
         # アサーション
         assert result is False
         self.mock_logger.error.assert_called_once_with(
-            "num_classes は正の整数である必要があります。現在の値: 4"
+            "num_classes は int である必要があります。" "現在の型: str, 現在の値: 4"
         )
 
     def test_num_classes_negative_validation_fails(self):
@@ -65,7 +65,7 @@ class TestClassWeightsValidator(unittest.TestCase):
         # アサーション
         assert result is False
         self.mock_logger.error.assert_called_once_with(
-            "num_classes は正の整数である必要があります。現在の値: -1"
+            "num_classes は正の値である必要があります。現在の値: -1"
         )
 
     def test_num_classes_zero_validation_fails(self):
@@ -77,7 +77,7 @@ class TestClassWeightsValidator(unittest.TestCase):
         # アサーション
         assert result is False
         self.mock_logger.error.assert_called_once_with(
-            "num_classes は正の整数である必要があります。現在の値: 0"
+            "num_classes は正の値である必要があります。現在の値: 0"
         )
 
     def test_class_weights_none_validation_succeeds(self):

--- a/tests/unit/test_validation/test_validators/test_early_stopping_validator.py
+++ b/tests/unit/test_validation/test_validators/test_early_stopping_validator.py
@@ -76,7 +76,7 @@ class TestPatienceValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "early_stopping.patience は整数である必要があります。"
+            "early_stopping.patience は int である必要があります。"
             "現在の型: float, 現在の値: 5.0"
         )
 
@@ -89,7 +89,7 @@ class TestPatienceValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "early_stopping.patience は整数である必要があります。"
+            "early_stopping.patience は int である必要があります。"
             "現在の型: bool, 現在の値: True"
         )
 
@@ -102,7 +102,7 @@ class TestPatienceValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "early_stopping.patience は正の整数である必要があります。現在の値: 0"
+            "early_stopping.patience は正の値である必要があります。現在の値: 0"
         )
 
     def test_patience_negative_failure(self, validator, mocker):
@@ -114,7 +114,7 @@ class TestPatienceValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "early_stopping.patience は正の整数である必要があります。現在の値: -5"
+            "early_stopping.patience は正の値である必要があります。現在の値: -5"
         )
 
     def test_patience_valid_success(self, validator, mocker):
@@ -165,7 +165,8 @@ class TestMinDeltaValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "early_stopping.min_delta は0以上である必要があります。現在の値: -0.1"
+            "early_stopping.min_delta は 0 <= early_stopping.min_delta の範囲である必要があります。"
+            "現在の値: -0.1"
         )
 
     def test_min_delta_zero_success(self, validator, mocker):
@@ -199,7 +200,7 @@ class TestMonitorValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "early_stopping.monitor は文字列である必要があります。"
+            "early_stopping.monitor は str である必要があります。"
             "現在の型: int, 現在の値: 123"
         )
 

--- a/tests/unit/test_validation/test_validators/test_optimizer_validator.py
+++ b/tests/unit/test_validation/test_validators/test_optimizer_validator.py
@@ -20,8 +20,8 @@ def test_learning_rate_missing_failure(validator, mocker):
 
     assert result is False
     mock_logger.error.assert_called_with(
-        "learning_rate が設定されていません。configs/pochi_train_config.py で "
-        "学習率を設定してください。"
+        "learning_rate が設定されていません。"
+        "configs/pochi_train_config.py で設定してください。"
     )
 
 
@@ -34,7 +34,8 @@ def test_learning_rate_invalid_type_failure(validator, mocker):
 
     assert result is False
     mock_logger.error.assert_called_with(
-        "learning_rate は数値である必要があります。現在の型: <class 'str'>"
+        "learning_rate は int または float である必要があります。"
+        "現在の型: str, 現在の値: 0.001"
     )
 
 
@@ -62,8 +63,8 @@ def test_optimizer_missing_failure(validator, mocker):
 
     assert result is False
     mock_logger.error.assert_called_with(
-        "optimizer が設定されていません。configs/pochi_train_config.py で "
-        "最適化器を設定してください。"
+        "optimizer が設定されていません。"
+        "configs/pochi_train_config.py で設定してください。"
     )
 
 
@@ -76,7 +77,7 @@ def test_optimizer_invalid_type_failure(validator, mocker):
 
     assert result is False
     mock_logger.error.assert_called_with(
-        "optimizer は文字列である必要があります。現在の型: <class 'int'>"
+        "optimizer は str である必要があります。" "現在の型: int, 現在の値: 123"
     )
 
 

--- a/tests/unit/test_validation/test_validators/test_training_validator.py
+++ b/tests/unit/test_validation/test_validators/test_training_validator.py
@@ -23,8 +23,8 @@ class TestEpochsValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "epochs が設定されていません。configs/pochi_train_config.py で "
-            "エポック数を設定してください。"
+            "epochs が設定されていません。"
+            "configs/pochi_train_config.py で設定してください。"
         )
 
     def test_epochs_invalid_type_failure(self, validator, mocker):
@@ -36,7 +36,7 @@ class TestEpochsValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "epochs は整数である必要があります。現在の型: str, 現在の値: 50"
+            "epochs は int である必要があります。現在の型: str, 現在の値: 50"
         )
 
         # 浮動小数点数の場合
@@ -45,7 +45,7 @@ class TestEpochsValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "epochs は整数である必要があります。現在の型: float, 現在の値: 50.0"
+            "epochs は int である必要があります。現在の型: float, 現在の値: 50.0"
         )
 
         # ブール値の場合
@@ -54,7 +54,7 @@ class TestEpochsValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "epochs は整数である必要があります。現在の型: bool, 現在の値: True"
+            "epochs は int である必要があります。現在の型: bool, 現在の値: True"
         )
 
     def test_epochs_non_positive_failure(self, validator, mocker):
@@ -66,7 +66,7 @@ class TestEpochsValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "epochs は正の整数である必要があります。現在の値: 0"
+            "epochs は正の値である必要があります。現在の値: 0"
         )
 
         # 負の数の場合
@@ -75,7 +75,7 @@ class TestEpochsValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "epochs は正の整数である必要があります。現在の値: -10"
+            "epochs は正の値である必要があります。現在の値: -10"
         )
 
     def test_epochs_valid_success(self, validator, mocker):
@@ -101,8 +101,8 @@ class TestBatchSizeValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "batch_size が設定されていません。configs/pochi_train_config.py で "
-            "バッチサイズを設定してください。"
+            "batch_size が設定されていません。"
+            "configs/pochi_train_config.py で設定してください。"
         )
 
     def test_batch_size_invalid_type_failure(self, validator, mocker):
@@ -114,7 +114,7 @@ class TestBatchSizeValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "batch_size は整数である必要があります。現在の型: str, 現在の値: 32"
+            "batch_size は int である必要があります。現在の型: str, 現在の値: 32"
         )
 
         # 浮動小数点数の場合
@@ -123,7 +123,7 @@ class TestBatchSizeValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "batch_size は整数である必要があります。現在の型: float, 現在の値: 32.0"
+            "batch_size は int である必要があります。現在の型: float, 現在の値: 32.0"
         )
 
         # ブール値の場合
@@ -132,7 +132,7 @@ class TestBatchSizeValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "batch_size は整数である必要があります。現在の型: bool, 現在の値: True"
+            "batch_size は int である必要があります。現在の型: bool, 現在の値: True"
         )
 
     def test_batch_size_non_positive_failure(self, validator, mocker):
@@ -144,7 +144,7 @@ class TestBatchSizeValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "batch_size は正の整数である必要があります。現在の値: 0"
+            "batch_size は正の値である必要があります。現在の値: 0"
         )
 
         # 負の数の場合
@@ -153,7 +153,7 @@ class TestBatchSizeValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "batch_size は正の整数である必要があります。現在の値: -8"
+            "batch_size は正の値である必要があります。現在の値: -8"
         )
 
     def test_batch_size_valid_success(self, validator, mocker):
@@ -179,8 +179,8 @@ class TestModelNameValidation:
 
         assert result is False
         mock_logger.error.assert_called_with(
-            "model_name が設定されていません。configs/pochi_train_config.py で "
-            "モデル名を設定してください。"
+            "model_name が設定されていません。"
+            "configs/pochi_train_config.py で設定してください。"
         )
 
     def test_model_name_invalid_type_failure(self, validator, mocker):
@@ -192,7 +192,7 @@ class TestModelNameValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "model_name は文字列である必要があります。現在の型: int, 現在の値: 18"
+            "model_name は str である必要があります。現在の型: int, 現在の値: 18"
         )
 
         # ブール値の場合
@@ -201,7 +201,7 @@ class TestModelNameValidation:
         result = validator.validate(config, mock_logger)
         assert result is False
         mock_logger.error.assert_called_with(
-            "model_name は文字列である必要があります。現在の型: bool, 現在の値: True"
+            "model_name は str である必要があります。現在の型: bool, 現在の値: True"
         )
 
     def test_model_name_unsupported_failure(self, validator, mocker):
@@ -271,7 +271,7 @@ class TestTrainingValidatorIntegration:
         assert result is False
         # epochsの型エラーが最初に検出される
         mock_logger.error.assert_called_with(
-            "epochs は整数である必要があります。現在の型: str, 現在の値: invalid"
+            "epochs は int である必要があります。現在の型: str, 現在の値: invalid"
         )
 
     def test_boundary_values_success(self, validator, mocker):


### PR DESCRIPTION
## Summary

- `BaseValidator` に共通ヘルパーメソッド (`_validate_required_type`, `_validate_positive`, `_validate_range`, `_validate_choice`) を追加し, 各バリデーターの重複コードを削減
- `TrainingValidator`, `OptimizerValidator`, `SchedulerValidator`, `EarlyStoppingValidator`, `ClassWeightsValidator` を共通ヘルパーを使用するようリファクタリング
- テストのエラーメッセージ期待値をヘルパーの統一フォーマットに合わせて更新

## Code Changes

```python
# pochitrain/validation/base_validator.py - 共通ヘルパーメソッドを追加
def _validate_required_type(
    self, value, field_name, expected_type, logger, *, exclude_bool=False
) -> bool:
    """必須フィールドの存在チェックと型チェック."""

def _validate_positive(self, value, field_name, logger) -> bool:
    """値が正の数であることをチェック."""

def _validate_range(
    self, value, field_name, logger, *, gt=None, ge=None, lt=None, le=None
) -> bool:
    """値が指定範囲内であることをチェック."""

def _validate_choice(self, value, field_name, choices, logger) -> bool:
    """値が選択肢のいずれかであることをチェック."""
```

```python
# pochitrain/validation/validators/training_validator.py - ヘルパー使用例
epochs = config.get("epochs")
if not self._validate_required_type(
    epochs, "epochs", int, logger, exclude_bool=True
):
    return False
if not self._validate_positive(epochs, "epochs", logger):
    return False
```

## Test Plan

- [x] validation テスト 134 件全パス
- [x] mypy 型チェック通過 (validation モジュール全 13 ファイル)
