### PR TITLE
refactor: ロガーのフォールバックを LoggerManager 経由に統一

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,7 @@ __marimo__/
 
 # dev-files
 CLAUDE.md
+AGENTS.md
 *repomix*.*
 Plan.md
 issue.*

--- a/pochitrain/exporters/base_csv_exporter.py
+++ b/pochitrain/exporters/base_csv_exporter.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, Union
 
+from pochitrain.logging import LoggerManager
+
 
 class BaseCSVExporter(ABC):
     """
@@ -33,7 +35,7 @@ class BaseCSVExporter(ABC):
         self.output_dir = Path(output_dir)
 
         if logger is None:
-            self.logger = logging.getLogger(type(self).__qualname__)
+            self.logger = LoggerManager().get_logger(type(self).__qualname__)
         else:
             self.logger = logger
 

--- a/pochitrain/visualization/gradient_tracer.py
+++ b/pochitrain/visualization/gradient_tracer.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import torch.nn as nn
 
+from pochitrain.logging import LoggerManager
+
 
 class GradientTracer:
     """
@@ -40,7 +42,7 @@ class GradientTracer:
 
         # ロガーの設定
         if logger is None:
-            self.logger = logging.getLogger(__name__)
+            self.logger = LoggerManager().get_logger(__name__)
         else:
             self.logger = logger
 


### PR DESCRIPTION
## Summary

- `GradientTracer` と `BaseCSVExporter` で `logger=None` 時のフォールバックを `logging.getLogger()` から `LoggerManager().get_logger()` に変更
- アプリケーション全体でロガー取得方法を `LoggerManager` シングルトン経由に統一

## Code Changes

```python
# pochitrain/visualization/gradient_tracer.py
from pochitrain.logging import LoggerManager

# Before
if logger is None:
    self.logger = logging.getLogger(__name__)

# After
if logger is None:
    self.logger = LoggerManager().get_logger(__name__)
```

```python
# pochitrain/exporters/base_csv_exporter.py
from pochitrain.logging import LoggerManager

# Before
if logger is None:
    self.logger = logging.getLogger(type(self).__qualname__)

# After
if logger is None:
    self.logger = LoggerManager().get_logger(type(self).__qualname__)
```

## Test Plan

- [x] 全テスト 511 件パス
- [x] mypy 型チェック通過
- [x] isort チェック通過