### PR TITLE
fix: 空 DataLoader の平均計算ガード追加

### DIFF
--- a/pochitrain/pochi_trainer.py
+++ b/pochitrain/pochi_trainer.py
@@ -278,8 +278,10 @@ class PochiTrainer:
                 )
 
         # エポックの統計情報
-        avg_loss = total_loss / len(train_loader)
-        accuracy = 100.0 * correct / total
+        # 例外回避のための防御的ガード. 本来はバリデーションで止めるのが望ましい
+        loader_len = len(train_loader)
+        avg_loss = total_loss / loader_len if loader_len > 0 else 0.0
+        accuracy = 100.0 * correct / total if total > 0 else 0.0
 
         return {"loss": avg_loss, "accuracy": accuracy}
 

--- a/pochitrain/training/evaluator.py
+++ b/pochitrain/training/evaluator.py
@@ -69,8 +69,10 @@ class Evaluator:
                 all_predicted.append(predicted)
                 all_targets.append(target)
 
-        avg_loss = total_loss / len(val_loader)
-        accuracy = 100.0 * correct / total
+        # 例外回避のための防御的ガード. 本来はバリデーションで止めるのが望ましい
+        loader_len = len(val_loader)
+        avg_loss = total_loss / loader_len if loader_len > 0 else 0.0
+        accuracy = 100.0 * correct / total if total > 0 else 0.0
 
         # 混同行列の計算と出力
         if num_classes_for_cm is not None and all_predicted and all_targets:

--- a/tests/unit/test_core/test_empty_dataloader.py
+++ b/tests/unit/test_core/test_empty_dataloader.py
@@ -1,0 +1,50 @@
+import logging
+import tempfile
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from pochitrain.pochi_trainer import PochiTrainer
+from pochitrain.training.evaluator import Evaluator
+
+
+def _empty_loader(batch_size: int = 4) -> DataLoader:
+    data = torch.empty((0, 3, 224, 224))
+    targets = torch.empty((0,), dtype=torch.long)
+    dataset = TensorDataset(data, targets)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=False)
+
+
+def test_train_epoch_with_empty_loader():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        trainer = PochiTrainer(
+            model_name="resnet18",
+            num_classes=2,
+            pretrained=False,
+            device="cpu",
+            work_dir=temp_dir,
+        )
+        trainer.setup_training(
+            learning_rate=0.001, optimizer_name="Adam", num_classes=2
+        )
+
+        metrics = trainer.train_epoch(_empty_loader())
+
+        assert metrics["loss"] == 0.0
+        assert metrics["accuracy"] == 0.0
+
+
+def test_evaluator_with_empty_loader():
+    logger = logging.getLogger("test_evaluator_empty_loader")
+    evaluator = Evaluator(device=torch.device("cpu"), logger=logger)
+    model = torch.nn.Linear(2, 2)
+    criterion = torch.nn.CrossEntropyLoss()
+
+    metrics = evaluator.validate(
+        model=model,
+        val_loader=_empty_loader(),
+        criterion=criterion,
+    )
+
+    assert metrics["val_loss"] == 0.0
+    assert metrics["val_accuracy"] == 0.0


### PR DESCRIPTION
## Summary

- `pochitrain/pochi_trainer.py` と `pochitrain/training/evaluator.py` の平均計算にガードを追加
- 空 DataLoader 到達時に 0 除算を避ける防御的コメントを追記
- 空 DataLoader のケースをテストで追加

## Code Changes

```python
# pochitrain/pochi_trainer.py
# 例外回避のための防御的ガード. 本来はバリデーションで止めるのが望ましい
loader_len = len(train_loader)
avg_loss = total_loss / loader_len if loader_len > 0 else 0.0
accuracy = 100.0 * correct / total if total > 0 else 0.0
```

```python
# pochitrain/training/evaluator.py
# 例外回避のための防御的ガード. 本来はバリデーションで止めるのが望ましい
loader_len = len(val_loader)
avg_loss = total_loss / loader_len if loader_len > 0 else 0.0
accuracy = 100.0 * correct / total if total > 0 else 0.0
```

## Test Plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest tests/unit/test_core/test_empty_dataloader.py`