### PR TITLE
feat: 損失平均をサンプル重み付けに変更

### DIFF
--- a/pochitrain/pochi_trainer.py
+++ b/pochitrain/pochi_trainer.py
@@ -265,9 +265,10 @@ class PochiTrainer:
                 self.optimizer.step()
 
             # 統計情報の更新
-            total_loss += loss.item()
+            batch_size = target.size(0)
+            total_loss += loss.item() * batch_size
             _, predicted = output.max(1)
-            total += target.size(0)
+            total += batch_size
             correct += predicted.eq(target).sum().item()
 
             # ログ出力
@@ -279,8 +280,7 @@ class PochiTrainer:
 
         # エポックの統計情報
         # 例外回避のための防御的ガード. 本来はバリデーションで止めるのが望ましい
-        loader_len = len(train_loader)
-        avg_loss = total_loss / loader_len if loader_len > 0 else 0.0
+        avg_loss = total_loss / total if total > 0 else 0.0
         accuracy = 100.0 * correct / total if total > 0 else 0.0
 
         return {"loss": avg_loss, "accuracy": accuracy}

--- a/pochitrain/training/evaluator.py
+++ b/pochitrain/training/evaluator.py
@@ -60,9 +60,10 @@ class Evaluator:
                 output = model(data)
                 loss = criterion(output, target)
 
-                total_loss += loss.item()
+                batch_size = target.size(0)
+                total_loss += loss.item() * batch_size
                 _, predicted = output.max(1)
-                total += target.size(0)
+                total += batch_size
                 correct += predicted.eq(target).sum().item()
 
                 # 混同行列用にデータを保存
@@ -70,8 +71,7 @@ class Evaluator:
                 all_targets.append(target)
 
         # 例外回避のための防御的ガード. 本来はバリデーションで止めるのが望ましい
-        loader_len = len(val_loader)
-        avg_loss = total_loss / loader_len if loader_len > 0 else 0.0
+        avg_loss = total_loss / total if total > 0 else 0.0
         accuracy = 100.0 * correct / total if total > 0 else 0.0
 
         # 混同行列の計算と出力


### PR DESCRIPTION
## Summary

- `train_epoch()` と `validate()` の損失平均をバッチ数割りからサンプル数割りに変更
- 不均一バッチサイズでの損失平均の偏りを解消
- サンプル重み付け平均のテストを追加

## Code Changes

```python
# pochitrain/pochi_trainer.py, pochitrain/training/evaluator.py
# Before
total_loss += loss.item()
avg_loss = total_loss / len(loader)

# After
batch_size = target.size(0)
total_loss += loss.item() * batch_size
avg_loss = total_loss / total
```

## Test Plan

- [x] `uv run pytest tests/unit/test_core/test_empty_dataloader.py`
- [x] `uv run pytest tests/unit/test_core/test_evaluator.py`
- [x] `uv run pytest` (全テスト通過)
- [x] `uv run pre-commit run --all-files`