### PR TITLE
feat: 推論ログの表記統一およびロガーの単純化

### DIFF
--- a/pochitrain/cli/infer_onnx.py
+++ b/pochitrain/cli/infer_onnx.py
@@ -134,7 +134,7 @@ def main() -> None:
         inference.run(warmup_np)
 
     # 推論実行
-    logger.info("推論を開始...")
+    logger.info("推論を開始します...")
     all_predictions: List[int] = []
     all_confidences: List[float] = []
     all_true_labels: List[int] = []
@@ -187,6 +187,8 @@ def main() -> None:
         all_confidences.extend(confidence.tolist())
         all_true_labels.extend(batch_labels)
 
+    logger.info("推論完了")
+
     # 精度計算
     correct = sum(p == t for p, t in zip(all_predictions, all_true_labels))
     num_samples = len(dataset)
@@ -202,7 +204,6 @@ def main() -> None:
         total_samples=total_samples,
         warmup_samples=warmup_samples,
     )
-    logger.info("推論完了")
 
     # 結果ファイル出力
     class_names = dataset.get_classes()

--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -155,7 +155,7 @@ def main() -> None:
         inference.run(image_np)
 
     # 推論実行（バッチサイズ1固定）
-    logger.info("推論を開始...")
+    logger.info("推論を開始します...")
     all_predictions: List[int] = []
     all_confidences: List[float] = []
     all_true_labels: List[int] = []
@@ -188,6 +188,8 @@ def main() -> None:
         all_confidences.append(float(confidence[0]))
         all_true_labels.append(label)
 
+    logger.info("推論完了")
+
     # 精度計算
     correct = sum(p == t for p, t in zip(all_predictions, all_true_labels))
     num_samples = len(dataset)
@@ -203,7 +205,6 @@ def main() -> None:
         total_samples=total_samples,
         warmup_samples=warmup_samples,
     )
-    logger.info("推論完了")
 
     # 結果ファイル出力
     class_names = dataset.get_classes()

--- a/pochitrain/logging/logger_manager.py
+++ b/pochitrain/logging/logger_manager.py
@@ -16,53 +16,6 @@ except ImportError:
     COLORLOG_AVAILABLE = False
 
 
-class LevelBasedFormatter(logging.Formatter):
-    """デバッグモードによって切り替わるログ形式."""
-
-    def __init__(
-        self,
-        info_format: str,
-        debug_format: str,
-        datefmt: str,
-        use_color: bool = False,
-        log_colors: dict | None = None,
-        force_debug_format: bool = False,
-    ) -> None:
-        """ログ整形の初期化."""
-        super().__init__(datefmt=datefmt)
-        self._info_format = info_format
-        self._debug_format = debug_format
-        self._use_color = use_color
-        self._log_colors = log_colors or {}
-        self._force_debug_format = force_debug_format
-        if use_color:
-            self._info_formatter = colorlog.ColoredFormatter(
-                info_format, datefmt=datefmt, log_colors=self._log_colors
-            )
-            self._debug_formatter = colorlog.ColoredFormatter(
-                debug_format, datefmt=datefmt, log_colors=self._log_colors
-            )
-        else:
-            self._info_formatter = logging.Formatter(info_format, datefmt=datefmt)
-            self._debug_formatter = logging.Formatter(debug_format, datefmt=datefmt)
-
-    @property
-    def force_debug_format(self) -> bool:
-        """デバッグフォーマットの強制使用フラグ."""
-        return self._force_debug_format
-
-    @force_debug_format.setter
-    def force_debug_format(self, value: bool) -> None:
-        self._force_debug_format = value
-
-    def format(self, record: logging.LogRecord) -> str:
-        """ログレコードを整形."""
-        record.levelname = {"WARNING": "WARN"}.get(record.levelname, record.levelname)
-        if self._force_debug_format:
-            return str(self._debug_formatter.format(record))
-        return str(self._info_formatter.format(record))
-
-
 class LogLevel(Enum):
     """ログレベル列挙型."""
 
@@ -83,7 +36,6 @@ class LoggerManager:
     Attributes:
         _loggers (Dict[str, logging.Logger]): 管理されているロガーの辞書
         _default_level (LogLevel): デフォルトのログレベル
-        _format_string (str): ログフォーマット文字列
     """
 
     _instance: Optional["LoggerManager"] = None
@@ -101,13 +53,10 @@ class LoggerManager:
             return
 
         self._default_level = LogLevel.INFO
-        self._use_debug_format = False
-        self._info_format = (
-            "%(asctime)s|%(log_color)s%(levelname)-5.5s%(reset)s| %(message)s"
-        )
-        self._debug_format = (
+        # 常にモジュール名・行数を表示するフォーマット
+        self._format = (
             "%(asctime)s|%(log_color)s%(levelname)-5.5s%(reset)s|"
-            "%(filename)-28s|%(lineno)03d| %(message)s"
+            "%(module)-18s|%(lineno)03d| %(message)s"
         )
         self._date_format = "%Y-%m-%d %H:%M:%S"
         self._log_colors = {
@@ -185,26 +134,19 @@ class LoggerManager:
         formatter: logging.Formatter
         if COLORLOG_AVAILABLE:
             handler = colorlog.StreamHandler()
-            formatter = LevelBasedFormatter(
-                self._info_format,
-                self._debug_format,
+            formatter = colorlog.ColoredFormatter(
+                self._format,
                 datefmt=self._date_format,
-                use_color=True,
                 log_colors=self._log_colors,
-                force_debug_format=self._use_debug_format,
             )
         else:
             handler = logging.StreamHandler()
             # colorlogが利用できない場合は色情報を除去したフォーマット
-            info_format = "%(asctime)s|%(levelname)-5.5s| %(message)s"
-            debug_format = "%(asctime)s|%(levelname)-5.5s|%(filename)-28s|%(lineno)03d| %(message)s"
-            formatter = LevelBasedFormatter(
-                info_format,
-                debug_format,
-                datefmt=self._date_format,
-                use_color=False,
-                force_debug_format=self._use_debug_format,
+            plain_format = (
+                "%(asctime)s|%(levelname)-5.5s|"
+                "%(module)-18s|%(lineno)03d| %(message)s"
             )
+            formatter = logging.Formatter(plain_format, datefmt=self._date_format)
 
         handler.setFormatter(formatter)
         return handler
@@ -217,17 +159,7 @@ class LoggerManager:
             level (LogLevel): 新しいデフォルトレベル
         """
         self._default_level = level
-        self._use_debug_format = level == LogLevel.DEBUG
-        self._update_existing_handlers_format()
         self._update_existing_loggers_level()
-
-    def _update_existing_handlers_format(self) -> None:
-        """既存ハンドラーのフォーマット設定を更新する."""
-        for logger in self._loggers.values():
-            for handler in logger.handlers:
-                formatter = handler.formatter
-                if isinstance(formatter, LevelBasedFormatter):
-                    formatter.force_debug_format = self._use_debug_format
 
     def _update_existing_loggers_level(self) -> None:
         """既存ロガーのレベル設定を更新する."""

--- a/pochitrain/onnx/inference.py
+++ b/pochitrain/onnx/inference.py
@@ -64,7 +64,7 @@ class OnnxInference:
         providers.append("CPUExecutionProvider")
 
         session = ort.InferenceSession(str(self.model_path), providers=providers)
-        logger.info(f"実行プロバイダー: {session.get_providers()}")
+        logger.debug(f"実行プロバイダー: {session.get_providers()}")
         return session
 
     def run(self, images: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:

--- a/pochitrain/training/evaluator.py
+++ b/pochitrain/training/evaluator.py
@@ -158,7 +158,7 @@ class Evaluator:
         correct = sum(p == t for p, t in zip(predicted_labels, true_labels))
         accuracy = (correct / total) * 100 if total > 0 else 0.0
 
-        accuracy_info: Dict[str, float] = {
+        accuracy_info: Dict[str, Any] = {
             "total_samples": total,
             "correct_predictions": correct,
             "accuracy_percentage": accuracy,

--- a/pochitrain/utils/inference_utils.py
+++ b/pochitrain/utils/inference_utils.py
@@ -465,9 +465,8 @@ def log_inference_result(
     accuracy = (correct / num_samples) * 100 if num_samples > 0 else 0.0
     throughput = 1000 / avg_time_per_image if avg_time_per_image > 0 else 0
 
-    logger.info(f"精度: {correct}/{num_samples} ({accuracy:.2f}%)")
-    logger.info(
-        f"平均推論時間: {avg_time_per_image:.2f} ms/image "
-        f"(計測: {total_samples}枚, ウォームアップ除外: {warmup_samples}枚)"
-    )
-    logger.info(f"スループット: {throughput:.1f} images/sec")
+    logger.info(f"推論画像枚数: {num_samples}枚")
+    logger.info(f"精度: {accuracy:.2f}%")
+    logger.info(f"平均推論時間: {avg_time_per_image:.2f} ms/image")
+    logger.info(f"スループット: {throughput:.1f} images/sec, 推論時間ベース")
+    logger.info(f"計測詳細: {total_samples}枚, ウォームアップ除外: {warmup_samples}枚")


### PR DESCRIPTION
## Summary
- 推論ログの表記揺れ修正, 計測範囲の明示, およびロガーのシンプル化.
- 手法間 (PyTorch/ONNX/TensorRT) でログ項目と順序を統一し, 視認性を向上.
- PyTorch推論の計測対象を純粋な推論時間のみに限定し, 他手法との比較を可能に調整.
- 1行が長くなりすぎないよう, 平均推論時間と計測詳細を別々の行に出力するように調整.
- `pochi.py` における `log_inference_result` 呼び出し時の型エラー (floatからintへの不整合) を修正.
- ロガーの動的フォーマット切替を廃止し, 常にモジュール名と行数を表示する単一構成へ移行.
- ログヘッダーのファイル名表示をモジュール名表示に変更し、固定長を28文字から18文字に短縮.

## Details
### 推論ログの表記統一
- 開始/終了メッセージを全手法で統一（「推論を開始します...」, 「推論完了」）.
- 推論時間とスループットの表示順序を見直し, メイン指標を優先して表示.
- 冗長なヘッダーやカッコ書きを排除し, シンプルなリスト形式へ整理.

### 計測範囲の適正化
- `PochiPredictor` 内部で推論実行部分のみをタイマーで囲み, データ読み込み等のI/O待ち時間を計測から除外.
- ログに「推論時間ベース」および「計測詳細」を明記し, 数値の定義を明確化.

### ロガーの最適化
- `LevelBasedFormatter` を廃止し, ログレベルに関わらず一貫したフォーマットを提供.
- ヘッダーのファイル名表示を `filename.py` (28文字) から `module_name` (18文字) に短縮し, メッセージ領域を拡大.

## Code Changes
```python
# pochitrain/logging/logger_manager.py
# 常にモジュール名・行数を表示するフォーマット
self._format = (
    "%(asctime)s|%(log_color)s%(levelname)-5.5s%(reset)s|"
    "%(module)-18s|%(lineno)03d| %(message)s"
)
```

```python
# pochitrain/utils/inference_utils.py
# 推論時間とスループットを優先し, 計測詳細は補足として分離
logger.info(f"平均推論時間: {avg_time_per_image:.2f} ms/image")
logger.info(f"スループット: {throughput:.1f} images/sec, 推論時間ベース")
logger.info(f"計測詳細: {total_samples}枚, ウォームアップ除外: {warmup_samples}枚")
```

## Test Plan
- [x] `uv run pochi infer` で PyTorch 推論ログの項目・順序・計測時間が正しいことを確認.
- [x] `uv run infer-onnx` で ONNX 推論ログの表記が統一されていることを確認.
- [x] `uv run infer-trt` で TensorRT 推論ログの表記が統一されていることを確認.
- [x] `--debug` フラグの有無に関わらず, 常にモジュール名と行数が表示されることを確認.
- [x] 長いログメッセージを表示した際, ヘッダー短縮により視認性が向上していることを確認.