### PR TITLE
feat: 推論レポート形式および言語の統一

### DIFF
--- a/pochitrain/inference/csv_exporter.py
+++ b/pochitrain/inference/csv_exporter.py
@@ -107,25 +107,6 @@ class InferenceCSVExporter(BaseCSVExporter):
 
     def _write_header(self, writer: Any, model_info: Optional[Dict[str, Any]]) -> None:
         """CSVのヘッダー部分を書き込み."""
-        # モデル情報をコメントとして追加
-        if model_info:
-            writer.writerow([f"# Model: {model_info.get('model_name', 'unknown')}"])
-            writer.writerow([f"# Classes: {model_info.get('num_classes', 'unknown')}"])
-            writer.writerow([f"# Device: {model_info.get('device', 'unknown')}"])
-            writer.writerow(
-                [f"# Model Path: {model_info.get('model_path', 'unknown')}"]
-            )
-
-            if model_info.get("best_accuracy") is not None:
-                writer.writerow(
-                    [f"# Best Accuracy: {model_info['best_accuracy']:.2f}%"]
-                )
-
-            if model_info.get("epoch") is not None:
-                writer.writerow([f"# Epoch: {model_info['epoch']}"])
-
-            writer.writerow([])  # 空行
-
         # カラムヘッダー
         writer.writerow(
             [

--- a/pochitrain/inference/result_exporter.py
+++ b/pochitrain/inference/result_exporter.py
@@ -52,16 +52,16 @@ class InferenceResultExporter:
         class_names: List[str],
         model_info: Dict[str, Any],
         results_filename: str = "inference_results.csv",
-        summary_filename: str = "inference_summary.csv",
+        summary_filename: Optional[str] = None,
         cm_config: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[Path, Path]:
+    ) -> Tuple[Path, Optional[Path]]:
         """推論結果を一括エクスポート.
 
         実行内容:
         1. ワークスペース確保 (遅延作成)
         2. 精度計算 (Evaluator 経由)
         3. 詳細結果CSV出力 (InferenceCSVExporter 経由)
-        4. サマリーCSV出力
+        4. サマリーCSV出力 (summary_filename が指定されている場合のみ)
         5. モデル情報JSON保存
         6. 混同行列画像生成
         7. クラス別精度レポート生成
@@ -74,11 +74,11 @@ class InferenceResultExporter:
             class_names: クラス名のリスト
             model_info: モデル情報の辞書
             results_filename: 詳細結果CSVファイル名
-            summary_filename: サマリーCSVファイル名
+            summary_filename: サマリーCSVファイル名 (None の場合は出力スキップ)
             cm_config: 混同行列可視化設定
 
         Returns:
-            Tuple[Path, Path]: (詳細結果CSVパス, サマリーCSVパス)
+            Tuple[Path, Optional[Path]]: (詳細結果CSVパス, サマリーCSVパス)
         """
         # 推論ワークスペースを確保(遅延作成)
         inference_workspace = self._ensure_workspace()
@@ -107,11 +107,13 @@ class InferenceResultExporter:
         )
 
         # サマリーのCSV出力
-        summary_csv = csv_exporter.export_summary(
-            accuracy_info=accuracy_info,
-            model_info=model_info,
-            filename=summary_filename,
-        )
+        summary_csv = None
+        if summary_filename:
+            summary_csv = csv_exporter.export_summary(
+                accuracy_info=accuracy_info,
+                model_info=model_info,
+                filename=summary_filename,
+            )
 
         # モデル情報もJSONで保存
         self.workspace_manager.save_model_info(model_info)

--- a/tests/unit/test_core/test_inference_result_exporter.py
+++ b/tests/unit/test_core/test_inference_result_exporter.py
@@ -116,9 +116,9 @@ class TestInferenceResultExporterExport:
             results_csv, summary_csv = exporter.export(**sample_data)
 
         assert results_csv.exists()
-        assert summary_csv.exists()
         assert results_csv.name == "inference_results.csv"
-        assert summary_csv.name == "inference_summary.csv"
+        # summary_filename=None (デフォルト) のため, サマリーCSVは出力されない
+        assert summary_csv is None
 
     def test_export_creates_workspace_lazily(self, tmp_path, sample_data):
         """export 時にワークスペースが遅延作成される."""
@@ -187,7 +187,7 @@ class TestInferenceResultExporterExport:
 
         # エラーがあってもCSV出力は成功
         assert results_csv.exists()
-        assert summary_csv.exists()
+        assert summary_csv is None
         # 警告ログが出力されている
         logger.warning.assert_any_call(
             "混同行列画像生成に失敗しました: matplotlib error"
@@ -213,7 +213,7 @@ class TestInferenceResultExporterExport:
             results_csv, summary_csv = exporter.export(**sample_data)
 
         assert results_csv.exists()
-        assert summary_csv.exists()
+        assert summary_csv is None
         logger.warning.assert_any_call(
             "クラス別精度レポート生成に失敗しました: sklearn error"
         )


### PR DESCRIPTION
## Summary

- PyTorch (`pochi.py`) の推論レポートを日本語化し、他バックエンド (ONNX/TensorRT) と出力形式を統一.
- プレフィックスなしの `inference_results.csv` や `inference_summary.csv` を廃止し、バックエンド名を冠した命名規則を採用.
- CSV出力から冗長なメタ情報コメントを削除し、データ処理の親和性を向上.

## Details

### 1. PyTorch推論レポートの刷新
- **サマリー形式の変更**: 従来の `inference_summary.csv` (英語) を廃止. 代わりに日本語のテキストサマリー `pytorch_inference_summary.txt` を出力するように変更.
- **命名規則の統一**: 出力ファイル名に `pytorch_` プレフィックスを付与 (`pytorch_inference_results.csv`). これにより ONNX/TensorRT の命名規則と完全に一致.

### 2. 出力内容の洗練
- **CSVヘッダーの整理**: `InferenceCSVExporter` において、CSV冒頭に出力されていたモデルのメタ情報コメント (`# モデル: ...` 等) を削除. 1行目からカラムヘッダーが始まる純粋なCSV形式に変更.
- **共通ユーティリティの活用**: `write_inference_summary` を PyTorch CLI でも使用するようにし、バックエンド間で同一内容のレポートが得られるように改善.

### 3. 基盤クラスの拡張
- **`InferenceResultExporter`**: サマリーCSVの出力をオプション化 (`summary_filename=None` でスキップ可能).

## Test Plan
- [x] `pochi infer`: `pytorch_inference_results.csv` および `pytorch_inference_summary.txt` (日本語) が生成されるか.
- [x] CSV形式: 1行目がヘッダー (`image_path, ...`) になっており、以前のコメント行が消えているか.
- [x] 一貫性: ONNX/TensorRT 環境でも同様の形式が維持されているか.
