### PR TITLE
refactor: optimizationモジュールのbase_configをPochiConfigに統一

### DIFF
--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -606,7 +606,7 @@ def optimize_command(args: argparse.Namespace) -> None:
 
     # 目的関数を作成
     objective = ClassificationObjective(
-        base_config=pochi_config.to_dict(),
+        base_config=pochi_config,
         param_suggestor=param_suggestor,
         train_loader=train_loader,
         val_loader=val_loader,
@@ -659,7 +659,7 @@ def optimize_command(args: argparse.Namespace) -> None:
     json_exporter.export(best_params, best_value, study, str(output_dir))
 
     # Python設定ファイル形式でエクスポート
-    config_exporter = ConfigExporter(pochi_config.to_dict())
+    config_exporter = ConfigExporter(pochi_config)
     config_exporter.export(best_params, best_value, study, str(output_dir))
 
     # 統計情報とパラメータ重要度をエクスポート

--- a/pochitrain/optimization/objective.py
+++ b/pochitrain/optimization/objective.py
@@ -5,6 +5,7 @@ from typing import Any
 import optuna
 from torch.utils.data import DataLoader
 
+from pochitrain.config.pochi_config import PochiConfig
 from pochitrain.optimization.interfaces import IObjectiveFunction, IParamSuggestor
 
 
@@ -16,7 +17,7 @@ class ClassificationObjective(IObjectiveFunction):
 
     def __init__(
         self,
-        base_config: dict[str, Any],
+        base_config: PochiConfig,
         param_suggestor: IParamSuggestor,
         train_loader: DataLoader,
         val_loader: DataLoader,
@@ -26,7 +27,7 @@ class ClassificationObjective(IObjectiveFunction):
         """初期化.
 
         Args:
-            base_config: ベース設定（model_name, num_classes等）
+            base_config: ベース設定（PochiConfig dataclass）
             param_suggestor: パラメータサジェスター
             train_loader: 訓練データローダー
             val_loader: 検証データローダー
@@ -57,10 +58,10 @@ class ClassificationObjective(IObjectiveFunction):
 
         # トレーナーを作成（ワークスペースは作成しない）
         trainer = PochiTrainer(
-            model_name=self._base_config.get("model_name", "resnet18"),
-            num_classes=self._base_config["num_classes"],
+            model_name=self._base_config.model_name,
+            num_classes=self._base_config.num_classes,
             device=self._device,
-            pretrained=self._base_config.get("pretrained", True),
+            pretrained=self._base_config.pretrained,
             create_workspace=False,  # Optuna最適化中はワークスペース不要
         )
 
@@ -68,19 +69,19 @@ class ClassificationObjective(IObjectiveFunction):
         trainer.setup_training(
             learning_rate=suggested_params.get(
                 "learning_rate",
-                self._base_config.get("learning_rate", 0.001),
+                self._base_config.learning_rate,
             ),
             optimizer_name=suggested_params.get(
                 "optimizer",
-                self._base_config.get("optimizer", "Adam"),
+                self._base_config.optimizer,
             ),
             scheduler_name=suggested_params.get(
                 "scheduler",
-                self._base_config.get("scheduler"),
+                self._base_config.scheduler,
             ),
             scheduler_params=suggested_params.get(
                 "scheduler_params",
-                self._base_config.get("scheduler_params"),
+                self._base_config.scheduler_params,
             ),
             enable_layer_wise_lr=suggested_params.get("enable_layer_wise_lr", False),
             layer_wise_lr_config=suggested_params.get("layer_wise_lr_config"),

--- a/tests/unit/optimization/test_objective.py
+++ b/tests/unit/optimization/test_objective.py
@@ -1,0 +1,167 @@
+"""ClassificationObjectiveのユニットテスト."""
+
+from unittest.mock import MagicMock, patch
+
+from pochitrain.config.pochi_config import PochiConfig
+from pochitrain.optimization.objective import ClassificationObjective
+
+
+def _create_base_config() -> PochiConfig:
+    """テスト用PochiConfigを作成."""
+    return PochiConfig(
+        model_name="resnet18",
+        num_classes=5,
+        device="cpu",
+        epochs=10,
+        batch_size=32,
+        learning_rate=0.001,
+        optimizer="Adam",
+        train_data_root="data/train",
+        train_transform=MagicMock(),
+        val_transform=MagicMock(),
+        enable_layer_wise_lr=False,
+    )
+
+
+class TestClassificationObjective:
+    """ClassificationObjectiveのテスト."""
+
+    @patch("pochitrain.PochiTrainer", autospec=True)
+    def test_call_creates_trainer_with_config_attributes(
+        self, mock_trainer_cls: MagicMock
+    ) -> None:
+        """PochiConfigの属性でTrainerが作成されることをテスト."""
+        config = _create_base_config()
+        mock_suggestor = MagicMock()
+        mock_suggestor.suggest.return_value = {"learning_rate": 0.01}
+
+        mock_trainer = MagicMock()
+        mock_trainer.validate.return_value = {"val_accuracy": 0.85}
+        mock_trainer_cls.return_value = mock_trainer
+
+        objective = ClassificationObjective(
+            base_config=config,
+            param_suggestor=mock_suggestor,
+            train_loader=MagicMock(),
+            val_loader=MagicMock(),
+            optuna_epochs=1,
+            device="cpu",
+        )
+
+        mock_trial = MagicMock()
+        mock_trial.should_prune.return_value = False
+        objective(mock_trial)
+
+        mock_trainer_cls.assert_called_once_with(
+            model_name="resnet18",
+            num_classes=5,
+            device="cpu",
+            pretrained=True,
+            create_workspace=False,
+        )
+
+    @patch("pochitrain.PochiTrainer", autospec=True)
+    def test_call_uses_suggested_params_over_config(
+        self, mock_trainer_cls: MagicMock
+    ) -> None:
+        """サジェストされたパラメータがベース設定より優先されることをテスト."""
+        config = _create_base_config()
+        mock_suggestor = MagicMock()
+        mock_suggestor.suggest.return_value = {
+            "learning_rate": 0.05,
+            "optimizer": "SGD",
+        }
+
+        mock_trainer = MagicMock()
+        mock_trainer.validate.return_value = {"val_accuracy": 0.90}
+        mock_trainer_cls.return_value = mock_trainer
+
+        objective = ClassificationObjective(
+            base_config=config,
+            param_suggestor=mock_suggestor,
+            train_loader=MagicMock(),
+            val_loader=MagicMock(),
+            optuna_epochs=1,
+            device="cpu",
+        )
+
+        mock_trial = MagicMock()
+        mock_trial.should_prune.return_value = False
+        objective(mock_trial)
+
+        mock_trainer.setup_training.assert_called_once_with(
+            learning_rate=0.05,
+            optimizer_name="SGD",
+            scheduler_name=None,
+            scheduler_params=None,
+            enable_layer_wise_lr=False,
+            layer_wise_lr_config=None,
+        )
+
+    @patch("pochitrain.PochiTrainer", autospec=True)
+    def test_call_falls_back_to_config_when_not_suggested(
+        self, mock_trainer_cls: MagicMock
+    ) -> None:
+        """サジェストされないパラメータはベース設定が使われることをテスト."""
+        config = _create_base_config()
+        config.scheduler = "StepLR"
+        config.scheduler_params = {"step_size": 10}
+
+        mock_suggestor = MagicMock()
+        mock_suggestor.suggest.return_value = {}
+
+        mock_trainer = MagicMock()
+        mock_trainer.validate.return_value = {"val_accuracy": 0.80}
+        mock_trainer_cls.return_value = mock_trainer
+
+        objective = ClassificationObjective(
+            base_config=config,
+            param_suggestor=mock_suggestor,
+            train_loader=MagicMock(),
+            val_loader=MagicMock(),
+            optuna_epochs=1,
+            device="cpu",
+        )
+
+        mock_trial = MagicMock()
+        mock_trial.should_prune.return_value = False
+        objective(mock_trial)
+
+        mock_trainer.setup_training.assert_called_once_with(
+            learning_rate=0.001,
+            optimizer_name="Adam",
+            scheduler_name="StepLR",
+            scheduler_params={"step_size": 10},
+            enable_layer_wise_lr=False,
+            layer_wise_lr_config=None,
+        )
+
+    @patch("pochitrain.PochiTrainer", autospec=True)
+    def test_call_returns_best_accuracy(self, mock_trainer_cls: MagicMock) -> None:
+        """最良の検証精度が返されることをテスト."""
+        config = _create_base_config()
+        mock_suggestor = MagicMock()
+        mock_suggestor.suggest.return_value = {}
+
+        mock_trainer = MagicMock()
+        mock_trainer.validate.side_effect = [
+            {"val_accuracy": 0.70},
+            {"val_accuracy": 0.85},
+            {"val_accuracy": 0.80},
+        ]
+        mock_trainer_cls.return_value = mock_trainer
+
+        objective = ClassificationObjective(
+            base_config=config,
+            param_suggestor=mock_suggestor,
+            train_loader=MagicMock(),
+            val_loader=MagicMock(),
+            optuna_epochs=3,
+            device="cpu",
+        )
+
+        mock_trial = MagicMock()
+        mock_trial.should_prune.return_value = False
+        result = objective(mock_trial)
+
+        assert result == 0.85

--- a/tests/unit/optimization/test_result_exporter.py
+++ b/tests/unit/optimization/test_result_exporter.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from pochitrain.config.pochi_config import PochiConfig
 from pochitrain.optimization.result_exporter import (
     ConfigExporter,
     JsonResultExporter,
@@ -99,11 +100,19 @@ class TestConfigExporter:
 
     def test_export_creates_optimized_config_py(self) -> None:
         """optimized_config.pyが作成されることをテスト."""
-        base_config = {
-            "model_name": "resnet18",
-            "num_classes": 10,
-            "epochs": 50,
-        }
+        base_config = PochiConfig(
+            model_name="resnet18",
+            num_classes=10,
+            device="cpu",
+            epochs=50,
+            batch_size=32,
+            learning_rate=0.001,
+            optimizer="Adam",
+            train_data_root="data/train",
+            train_transform=MagicMock(),
+            val_transform=MagicMock(),
+            enable_layer_wise_lr=False,
+        )
         exporter = ConfigExporter(base_config)
 
         mock_study = MagicMock()


### PR DESCRIPTION
## Summary
- `ClassificationObjective` と `ConfigExporter` の `base_config` 型を `dict[str, Any]` から `PochiConfig` に変更
- CLI (`pochi.py`) の `to_dict()` ブリッジ呼び出し2箇所を削除し, `PochiConfig` を直接渡すように変更
- `ConfigExporter` のイテレーションを `dict.items()` から `dataclasses.fields()` に置換し, sub-dataclass の自動変換に対応

## Code Changes

```python
# pochitrain/optimization/objective.py
# Before
base_config: dict[str, Any]
self._base_config.get("model_name", "resnet18")

# After
base_config: PochiConfig
self._base_config.model_name
```

```python
# pochitrain/optimization/result_exporter.py
# Before
for key, value in self._base_config.items():

# After
for field_info in dataclasses.fields(self._base_config):
    key = field_info.name
    value = getattr(self._base_config, key)
```

```python
# pochitrain/cli/pochi.py
# Before
objective = ClassificationObjective(base_config=pochi_config.to_dict(), ...)
config_exporter = ConfigExporter(pochi_config.to_dict())

# After
objective = ClassificationObjective(base_config=pochi_config, ...)
config_exporter = ConfigExporter(pochi_config)
```

## Test plan
- [x] `uv run pytest` 全テスト通過 (519 passed, 1 skipped)
- [x] `uv run pre-commit run --all-files` 全チェック通過
- [x] `ClassificationObjective` の新規テスト4件追加 (`test_objective.py`)