### PR TITLE
feat: TensorRT INT8量子化変換機能とpochi convertコマンドを追加

### DIFF
--- a/pochitrain/tensorrt/__init__.py
+++ b/pochitrain/tensorrt/__init__.py
@@ -1,4 +1,4 @@
-"""TensorRT推論機能を提供するモジュール."""
+"""TensorRT推論・変換機能を提供するモジュール."""
 
 from .inference import TensorRTInference
 

--- a/pochitrain/tensorrt/calibrator.py
+++ b/pochitrain/tensorrt/calibrator.py
@@ -1,0 +1,255 @@
+"""TensorRT INT8キャリブレーションモジュール.
+
+PochiImageDatasetからキャリブレーションデータを供給し,
+TensorRT INT8量子化に必要なスケールファクタを計算する.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Sized, cast
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset, Subset
+
+from pochitrain.logging import LoggerManager
+from pochitrain.pochi_dataset import PochiImageDataset
+
+logger: logging.Logger = LoggerManager().get_logger(__name__)
+
+
+def _check_tensorrt_for_calibrator() -> None:
+    """キャリブレータ使用時のTensorRT利用可否チェック.
+
+    Raises:
+        ImportError: TensorRTがインストールされていない場合
+    """
+    try:
+        import tensorrt as trt  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "TensorRTがインストールされていません. "
+            "TensorRT SDKをインストールしてください."
+        )
+
+
+def create_calibration_dataset(
+    data_root: str,
+    transform: Callable[..., Any],
+    max_samples: int = 500,
+    seed: int = 42,
+) -> Dataset[Any]:
+    """キャリブレーション用のサブセットデータセットを作成する.
+
+    検証データセットからランダムにサンプリングして,
+    キャリブレーション用の小さなデータセットを作成する.
+
+    Args:
+        data_root: データルートディレクトリ
+        transform: 前処理Transform (訓練時と同一のval_transformを推奨)
+        max_samples: 最大サンプル数 (デフォルト: 500)
+        seed: 乱数シード (再現性のため)
+
+    Returns:
+        キャリブレーション用サブセットデータセット
+    """
+    dataset = PochiImageDataset(data_root, transform=transform)
+    total = len(dataset)
+
+    if total <= max_samples:
+        logger.debug(f"データセット全体をキャリブレーションに使用: {total}枚")
+        return dataset
+
+    generator = torch.Generator().manual_seed(seed)
+    indices = torch.randperm(total, generator=generator)[:max_samples].tolist()
+    subset = Subset(dataset, indices)
+    logger.debug(
+        f"キャリブレーション用サブセットを作成: "
+        f"{len(indices)}枚 / {total}枚 (seed={seed})"
+    )
+    return subset
+
+
+def _create_calibrator_class() -> type:
+    """IInt8EntropyCalibrator2を継承したキャリブレータクラスを動的に生成する.
+
+    TensorRTはオプション依存のため, トップレベルでの継承ができない.
+    この関数はTensorRTがインストールされている環境でのみ呼び出される.
+
+    Returns:
+        PochiInt8Calibrator クラス (trt.IInt8EntropyCalibrator2 の派生型)
+
+    Raises:
+        ImportError: TensorRTがインストールされていない場合
+    """
+    import tensorrt as trt
+
+    class _PochiInt8Calibrator(trt.IInt8EntropyCalibrator2):  # type: ignore[misc]
+        """TensorRT INT8キャリブレータ.
+
+        IInt8EntropyCalibrator2を継承し, PochiImageDatasetから
+        キャリブレーションデータを供給する.
+
+        PyTorch CUDAテンソルをGPUバッファとして使用するため, pycudaは不要.
+
+        Attributes:
+            batch_size: キャリブレーションバッチサイズ
+            cache_file: キャリブレーションキャッシュファイルパス
+        """
+
+        def __init__(
+            self,
+            dataset: Dataset[Any],
+            input_shape: tuple[int, ...],
+            batch_size: int = 1,
+            cache_file: str = "calibration.cache",
+        ) -> None:
+            """PochiInt8Calibratorを初期化.
+
+            Args:
+                dataset: キャリブレーション用データセット
+                input_shape: モデル入力形状 (channels, height, width)
+                batch_size: バッチサイズ
+                cache_file: キャリブレーションキャッシュのファイルパス
+            """
+            super().__init__()
+
+            self.dataset = dataset
+            self.batch_size = batch_size
+            self.cache_file = cache_file
+            self.current_index = 0
+            self.input_shape = input_shape
+
+            # DataLoaderで効率的にデータを供給
+            self._data_loader = DataLoader(
+                dataset,
+                batch_size=batch_size,
+                shuffle=False,
+                num_workers=0,
+                drop_last=False,
+            )
+            self._data_iter = iter(self._data_loader)
+
+            # GPUバッファ確保 (PyTorch CUDAテンソル)
+            self._d_input = torch.empty(
+                (batch_size, *input_shape), dtype=torch.float32, device="cuda"
+            )
+
+            logger.debug(
+                f"INT8キャリブレータ初期化: "
+                f"データ数={len(cast(Sized, dataset))}, "
+                f"バッチサイズ={batch_size}, "
+                f"入力形状={input_shape}"
+            )
+
+        def get_batch_size(self) -> int:
+            """キャリブレーションバッチサイズを返す.
+
+            Returns:
+                バッチサイズ
+            """
+            return self.batch_size
+
+        def get_batch(self, names: List[str]) -> Optional[List[int]]:
+            """次のキャリブレーションバッチを供給する.
+
+            Args:
+                names: テンソル名のリスト (TensorRT APIから渡される)
+
+            Returns:
+                GPUバッファポインタのリスト, またはデータ終了時にNone
+            """
+            try:
+                batch_images, _ = next(self._data_iter)
+            except StopIteration:
+                return None
+
+            actual_batch_size = batch_images.shape[0]
+
+            if actual_batch_size < self.batch_size:
+                # バッチサイズに満たない場合はゼロパディング
+                self._d_input.zero_()
+
+            self._d_input[:actual_batch_size].copy_(batch_images[:actual_batch_size])
+            self.current_index += actual_batch_size
+
+            return [int(self._d_input.data_ptr())]
+
+        def read_calibration_cache(self) -> Optional[bytes]:
+            """キャリブレーションキャッシュを読み込む.
+
+            キャッシュが存在する場合は再キャリブレーション不要.
+
+            Returns:
+                キャッシュデータ, またはキャッシュが存在しない場合None
+            """
+            if os.path.exists(self.cache_file):
+                logger.debug(
+                    f"キャリブレーションキャッシュを読み込み: {self.cache_file}"
+                )
+                with open(self.cache_file, "rb") as f:
+                    return f.read()
+            return None
+
+        def write_calibration_cache(self, cache: bytes) -> None:
+            """キャリブレーション結果をキャッシュファイルに保存する.
+
+            Args:
+                cache: キャリブレーションキャッシュデータ
+            """
+            cache_path = Path(self.cache_file)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with open(self.cache_file, "wb") as f:
+                f.write(cache)
+            logger.debug(f"キャリブレーションキャッシュを保存: {self.cache_file}")
+
+    return _PochiInt8Calibrator
+
+
+def create_int8_calibrator(
+    data_root: str,
+    transform: Callable[..., Any],
+    input_shape: tuple[int, ...],
+    batch_size: int = 1,
+    max_samples: int = 500,
+    cache_file: str = "calibration.cache",
+    seed: int = 42,
+) -> Any:
+    """INT8キャリブレータを作成するファクトリ関数.
+
+    データセットの作成からキャリブレータの初期化までを一括で行う.
+    TensorRT IInt8EntropyCalibrator2 を継承したインスタンスを返す.
+
+    Args:
+        data_root: データルートディレクトリ
+        transform: 前処理Transform (val_transform)
+        input_shape: モデル入力形状 (channels, height, width)
+        batch_size: キャリブレーションバッチサイズ
+        max_samples: 最大サンプル数
+        cache_file: キャリブレーションキャッシュのファイルパス
+        seed: 乱数シード
+
+    Returns:
+        初期化済みのINT8キャリブレータ (trt.IInt8EntropyCalibrator2 派生)
+
+    Raises:
+        ImportError: TensorRTがインストールされていない場合
+    """
+    _check_tensorrt_for_calibrator()
+
+    dataset = create_calibration_dataset(
+        data_root=data_root,
+        transform=transform,
+        max_samples=max_samples,
+        seed=seed,
+    )
+
+    calibrator_cls = _create_calibrator_class()
+    return calibrator_cls(
+        dataset=dataset,
+        input_shape=input_shape,
+        batch_size=batch_size,
+        cache_file=cache_file,
+    )

--- a/pochitrain/tensorrt/converter.py
+++ b/pochitrain/tensorrt/converter.py
@@ -1,0 +1,165 @@
+"""TensorRTエンジンコンバーターモジュール.
+
+ONNXモデルからTensorRTエンジンを生成する.
+FP32, FP16, INT8の各精度モードに対応.
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from pochitrain.logging import LoggerManager
+from pochitrain.tensorrt.inference import check_tensorrt_availability
+
+logger: logging.Logger = LoggerManager().get_logger(__name__)
+
+
+class TensorRTConverter:
+    """ONNXモデルをTensorRTエンジンに変換するクラス.
+
+    TensorRT Builder APIを使用して, ONNXモデルからFP32/FP16/INT8の
+    TensorRTエンジンファイルを生成する.
+
+    Attributes:
+        onnx_path: ONNXモデルファイルパス
+        workspace_size: TensorRTビルダーの最大ワークスペースサイズ (bytes)
+    """
+
+    def __init__(
+        self,
+        onnx_path: Path,
+        workspace_size: int = 1 << 30,
+    ) -> None:
+        """TensorRTConverterを初期化.
+
+        Args:
+            onnx_path: ONNXモデルファイルパス
+            workspace_size: 最大ワークスペースサイズ (デフォルト: 1GB)
+
+        Raises:
+            ImportError: TensorRTがインストールされていない場合
+            FileNotFoundError: ONNXファイルが見つからない場合
+        """
+        if not check_tensorrt_availability():
+            raise ImportError(
+                "TensorRTがインストールされていません. "
+                "TensorRT SDKをインストールしてください."
+            )
+
+        self.onnx_path = Path(onnx_path)
+        if not self.onnx_path.exists():
+            raise FileNotFoundError(f"ONNXモデルが見つかりません: {self.onnx_path}")
+
+        self.workspace_size = workspace_size
+
+    def convert(
+        self,
+        output_path: Path,
+        precision: str = "fp32",
+        calibrator: Optional[object] = None,
+    ) -> Path:
+        """ONNXモデルをTensorRTエンジンに変換する.
+
+        Args:
+            output_path: 出力エンジンファイルパス (.engine)
+            precision: 精度モード ("fp32", "fp16", "int8")
+            calibrator: INT8キャリブレータ (precision="int8"の場合に必須)
+
+        Returns:
+            生成されたエンジンファイルパス
+
+        Raises:
+            ValueError: 無効なprecision指定, またはINT8でcalibratorが未指定の場合
+            RuntimeError: エンジンのビルドに失敗した場合
+        """
+        import tensorrt as trt
+
+        valid_precisions = ("fp32", "fp16", "int8")
+        if precision not in valid_precisions:
+            raise ValueError(
+                f"無効なprecision: {precision}. " f"有効な値: {valid_precisions}"
+            )
+
+        if precision == "int8" and calibrator is None:
+            raise ValueError(
+                "INT8精度にはcalibratorが必須です. "
+                "create_int8_calibrator()でキャリブレータを作成してください."
+            )
+
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        logger.info(f"TensorRTエンジンを生成中... (精度: {precision.upper()})")
+        logger.debug(f"ONNX: {self.onnx_path}")
+        logger.debug(f"出力: {output_path}")
+
+        # TensorRTロガー・ビルダー・ネットワーク作成
+        trt_logger = trt.Logger(trt.Logger.WARNING)
+        builder = trt.Builder(trt_logger)
+        network = builder.create_network(
+            1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+        )
+
+        # ONNXパーサーでモデルを読み込み
+        parser = trt.OnnxParser(network, trt_logger)
+        if not parser.parse_from_file(str(self.onnx_path)):
+            errors = []
+            for i in range(parser.num_errors):
+                errors.append(str(parser.get_error(i)))
+            raise RuntimeError(f"ONNXパースエラー: {'; '.join(errors)}")
+
+        logger.debug(
+            f"ONNXパース完了: 入力数={network.num_inputs}, "
+            f"出力数={network.num_outputs}"
+        )
+
+        # ビルド設定
+        config = builder.create_builder_config()
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, self.workspace_size)
+
+        # 動的入力に対するOptimization Profileの設定
+        # ONNXエクスポート時にdynamic_axesが設定されている場合に必要
+        profile = builder.create_optimization_profile()
+        has_dynamic = False
+        for i in range(network.num_inputs):
+            inp = network.get_input(i)
+            shape = inp.shape
+            # 動的次元 (-1) があるかチェック
+            if any(d == -1 for d in shape):
+                has_dynamic = True
+                # 動的次元をバッチサイズ1に固定
+                static_shape = tuple(1 if d == -1 else d for d in shape)
+                profile.set_shape(inp.name, static_shape, static_shape, static_shape)
+                logger.debug(
+                    f"動的入力を検出: {inp.name}, "
+                    f"shape={tuple(shape)} -> {static_shape}"
+                )
+        if has_dynamic:
+            config.add_optimization_profile(profile)
+
+        # 精度フラグの設定
+        if precision == "fp16":
+            config.set_flag(trt.BuilderFlag.FP16)
+            logger.debug("FP16モードを有効化")
+        elif precision == "int8":
+            config.set_flag(trt.BuilderFlag.INT8)
+            config.set_flag(trt.BuilderFlag.FP16)  # INT8非対応層のフォールバック
+            config.int8_calibrator = calibrator
+            logger.debug("INT8モードを有効化 (FP16フォールバック付き)")
+
+        # エンジンビルド
+        logger.info("エンジンをビルド中 (数分かかる場合があります)...")
+        serialized_engine = builder.build_serialized_network(network, config)
+
+        if serialized_engine is None:
+            raise RuntimeError("TensorRTエンジンのビルドに失敗しました")
+
+        # エンジンファイルを保存
+        with open(output_path, "wb") as f:
+            f.write(serialized_engine)
+
+        file_size_mb = output_path.stat().st_size / (1024 * 1024)
+        logger.info(f"TensorRTエンジン生成完了: {output_path}")
+        logger.info(f"ファイルサイズ: {file_size_mb:.2f} MB")
+
+        return output_path

--- a/tests/unit/test_cli/test_convert_cli.py
+++ b/tests/unit/test_cli/test_convert_cli.py
@@ -1,0 +1,175 @@
+"""pochi convert CLIのテスト.
+
+TensorRT変換サブコマンドの引数パース・バリデーションロジックをテスト.
+"""
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+
+class TestConvertArgumentParsing:
+    """convert サブコマンドの引数パースのテスト."""
+
+    def _build_parser(self):
+        """テスト用にconvertと同等のパーサーを構築."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("onnx_path", help="ONNXモデルファイルパス")
+        parser.add_argument("--fp16", action="store_true")
+        parser.add_argument("--int8", action="store_true")
+        parser.add_argument("--output", "-o")
+        parser.add_argument("--config-path", "-c")
+        parser.add_argument("--calib-data")
+        parser.add_argument("--calib-samples", type=int, default=500)
+        parser.add_argument("--calib-batch-size", type=int, default=1)
+        parser.add_argument("--workspace-size", type=int, default=1 << 30)
+        parser.add_argument("--debug", action="store_true")
+        return parser
+
+    def test_onnx_path_required(self):
+        """onnx_pathが必須引数であることを確認."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+    def test_onnx_path_parsed(self):
+        """onnx_pathが正しくパースされる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx"])
+        assert args.onnx_path == "model.onnx"
+
+    def test_fp16_flag(self):
+        """--fp16フラグが正しくパースされる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx", "--fp16"])
+        assert args.fp16 is True
+        assert args.int8 is False
+
+    def test_int8_flag(self):
+        """--int8フラグが正しくパースされる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx", "--int8"])
+        assert args.int8 is True
+        assert args.fp16 is False
+
+    def test_default_no_precision_flag(self):
+        """精度フラグ未指定時はどちらもFalse (FP32)."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx"])
+        assert args.fp16 is False
+        assert args.int8 is False
+
+    def test_output_option(self):
+        """--outputオプションが正しくパースされる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx", "-o", "output.engine"])
+        assert args.output == "output.engine"
+
+    def test_config_path_option(self):
+        """--config-pathオプションが正しくパースされる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx", "-c", "config.py"])
+        assert args.config_path == "config.py"
+
+    def test_calib_data_option(self):
+        """--calib-dataオプションが正しくパースされる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx", "--calib-data", "data/val"])
+        assert args.calib_data == "data/val"
+
+    def test_calib_samples_default(self):
+        """--calib-samplesのデフォルト値を確認."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx"])
+        assert args.calib_samples == 500
+
+    def test_calib_samples_custom(self):
+        """--calib-samplesのカスタム値が正しくパースされる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx", "--calib-samples", "200"])
+        assert args.calib_samples == 200
+
+    def test_calib_batch_size_default(self):
+        """--calib-batch-sizeのデフォルト値を確認."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx"])
+        assert args.calib_batch_size == 1
+
+    def test_workspace_size_default(self):
+        """--workspace-sizeのデフォルト値を確認."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.onnx"])
+        assert args.workspace_size == 1 << 30
+
+
+class TestConvertPrecisionDecision:
+    """精度モード決定ロジックのテスト."""
+
+    def _decide_precision(self, fp16, int8):
+        """精度モードを決定する (CLI実装と同じロジック)."""
+        if int8:
+            return "int8"
+        elif fp16:
+            return "fp16"
+        else:
+            return "fp32"
+
+    def test_default_is_fp32(self):
+        """デフォルトはFP32."""
+        assert self._decide_precision(fp16=False, int8=False) == "fp32"
+
+    def test_fp16_flag(self):
+        """--fp16指定時はFP16."""
+        assert self._decide_precision(fp16=True, int8=False) == "fp16"
+
+    def test_int8_flag(self):
+        """--int8指定時はINT8."""
+        assert self._decide_precision(fp16=False, int8=True) == "int8"
+
+    def test_int8_takes_precedence(self):
+        """--int8と--fp16の両方が指定された場合はINT8が優先."""
+        assert self._decide_precision(fp16=True, int8=True) == "int8"
+
+
+class TestConvertOutputPathDecision:
+    """出力パス決定ロジックのテスト."""
+
+    def test_output_specified(self):
+        """--output指定時はそのパスを使用."""
+        output = "custom_output.engine"
+        onnx_path = Path("model.onnx")
+
+        if output:
+            result = Path(output)
+        else:
+            result = onnx_path.with_suffix(".engine")
+
+        assert result == Path("custom_output.engine")
+
+    def _decide_output_path(self, output, onnx_path, precision):
+        """出力パスを決定する (CLI実装と同じロジック)."""
+        if output:
+            return Path(output)
+        stem = onnx_path.stem
+        if precision != "fp32":
+            stem = f"{stem}_{precision}"
+        return onnx_path.with_name(f"{stem}.engine")
+
+    def test_output_default_fp32(self):
+        """--output未指定, FP32時のデフォルトパス."""
+        onnx_path = Path("work_dirs/20260206_001/models/model.onnx")
+        result = self._decide_output_path(None, onnx_path, "fp32")
+        assert result == Path("work_dirs/20260206_001/models/model.engine")
+
+    def test_output_default_fp16(self):
+        """--output未指定, FP16時のデフォルトパス."""
+        onnx_path = Path("work_dirs/20260206_001/models/model.onnx")
+        result = self._decide_output_path(None, onnx_path, "fp16")
+        assert result == Path("work_dirs/20260206_001/models/model_fp16.engine")
+
+    def test_output_default_int8(self):
+        """--output未指定, INT8時のデフォルトパス."""
+        onnx_path = Path("work_dirs/20260206_001/models/model.onnx")
+        result = self._decide_output_path(None, onnx_path, "int8")
+        assert result == Path("work_dirs/20260206_001/models/model_int8.engine")

--- a/tests/unit/test_tensorrt/test_calibrator.py
+++ b/tests/unit/test_tensorrt/test_calibrator.py
@@ -1,0 +1,185 @@
+"""TensorRT INT8キャリブレータのテスト.
+
+TensorRTはオプション依存のため, TensorRT不要な関数のテストと
+TensorRT必須のテストを分離.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+import torchvision.transforms as transforms
+from torch.utils.data import Dataset, Subset
+
+from pochitrain.tensorrt.calibrator import create_calibration_dataset
+
+
+class _DummyDataset(Dataset):
+    """テスト用ダミーデータセット."""
+
+    def __init__(self, size, image_shape=(3, 224, 224)):
+        self.size = size
+        self.image_shape = image_shape
+        self.image_paths = [Path(f"img_{i}.jpg") for i in range(size)]
+        self.labels = [i % 4 for i in range(size)]
+        self.classes = [f"class_{i}" for i in range(4)]
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, index):
+        image = torch.randn(*self.image_shape)
+        return image, self.labels[index]
+
+    def get_classes(self):
+        return self.classes
+
+    def get_file_paths(self):
+        return [str(p) for p in self.image_paths]
+
+
+class TestCreateCalibrationDataset:
+    """create_calibration_dataset関数のテスト."""
+
+    def _create_data_dir(self, tmp_path, num_classes=2, images_per_class=5):
+        """テスト用のフォルダ構造を作成."""
+        for i in range(num_classes):
+            class_dir = tmp_path / f"class_{i}"
+            class_dir.mkdir()
+            for j in range(images_per_class):
+                img_path = class_dir / f"img_{j}.jpg"
+                # 最小限の有効なJPEGファイルを作成
+                from PIL import Image
+
+                img = Image.new("RGB", (32, 32), color=(i * 50, j * 10, 0))
+                img.save(img_path)
+        return str(tmp_path)
+
+    def test_returns_full_dataset_when_under_max(self, tmp_path):
+        """データ数がmax_samples以下の場合は全データを使用."""
+        data_root = self._create_data_dir(tmp_path, num_classes=2, images_per_class=3)
+        transform = transforms.Compose([transforms.ToTensor()])
+
+        result = create_calibration_dataset(
+            data_root=data_root,
+            transform=transform,
+            max_samples=100,
+        )
+
+        # PochiImageDatasetがそのまま返される
+        assert len(result) == 6  # 2 classes * 3 images
+
+    def test_returns_subset_when_over_max(self, tmp_path):
+        """データ数がmax_samplesを超える場合はSubsetを返す."""
+        data_root = self._create_data_dir(tmp_path, num_classes=4, images_per_class=10)
+        transform = transforms.Compose([transforms.ToTensor()])
+
+        result = create_calibration_dataset(
+            data_root=data_root,
+            transform=transform,
+            max_samples=10,
+        )
+
+        assert isinstance(result, Subset)
+        assert len(result) == 10
+
+    def test_reproducible_with_same_seed(self, tmp_path):
+        """同じseedで同じサブセットが生成される."""
+        data_root = self._create_data_dir(tmp_path, num_classes=4, images_per_class=10)
+        transform = transforms.Compose([transforms.ToTensor()])
+
+        result1 = create_calibration_dataset(
+            data_root=data_root,
+            transform=transform,
+            max_samples=5,
+            seed=123,
+        )
+        result2 = create_calibration_dataset(
+            data_root=data_root,
+            transform=transform,
+            max_samples=5,
+            seed=123,
+        )
+
+        # 同じインデックスが選ばれること
+        assert isinstance(result1, Subset)
+        assert isinstance(result2, Subset)
+        assert result1.indices == result2.indices
+
+    def test_different_seed_gives_different_subset(self, tmp_path):
+        """異なるseedで異なるサブセットが生成される."""
+        data_root = self._create_data_dir(tmp_path, num_classes=4, images_per_class=10)
+        transform = transforms.Compose([transforms.ToTensor()])
+
+        result1 = create_calibration_dataset(
+            data_root=data_root,
+            transform=transform,
+            max_samples=5,
+            seed=42,
+        )
+        result2 = create_calibration_dataset(
+            data_root=data_root,
+            transform=transform,
+            max_samples=5,
+            seed=99,
+        )
+
+        assert isinstance(result1, Subset)
+        assert isinstance(result2, Subset)
+        assert result1.indices != result2.indices
+
+
+class TestCreateInt8CalibratorWithoutTensorRT:
+    """TensorRT未インストール環境でのキャリブレータテスト."""
+
+    def test_import_error_without_tensorrt(self):
+        """TensorRTがない場合にcreate_int8_calibratorでImportErrorが発生する."""
+        with patch(
+            "pochitrain.tensorrt.calibrator._check_tensorrt_for_calibrator",
+            side_effect=ImportError("TensorRTがインストールされていません"),
+        ):
+            from pochitrain.tensorrt.calibrator import create_int8_calibrator
+
+            with pytest.raises(ImportError, match="TensorRT"):
+                create_int8_calibrator(
+                    data_root="dummy",
+                    transform=transforms.Compose([transforms.ToTensor()]),
+                    input_shape=(3, 224, 224),
+                )
+
+
+class TestCreateInt8Calibrator:
+    """create_int8_calibrator ファクトリ関数のテスト."""
+
+    def test_creates_calibrator_with_valid_args(self, tmp_path):
+        """有効な引数でキャリブレータが作成される."""
+        # テスト用データ作成
+        for i in range(2):
+            class_dir = tmp_path / f"class_{i}"
+            class_dir.mkdir()
+            for j in range(3):
+                from PIL import Image
+
+                img = Image.new("RGB", (32, 32))
+                img.save(class_dir / f"img_{j}.jpg")
+
+        transform = transforms.Compose([transforms.ToTensor()])
+
+        # TensorRTがない場合はImportErrorが発生するが,
+        # create_calibration_dataset自体はTensorRT不要なので分離テスト
+        with patch(
+            "pochitrain.tensorrt.calibrator._check_tensorrt_for_calibrator"
+        ) as mock_check:
+            mock_check.side_effect = ImportError("TensorRT not installed")
+
+            from pochitrain.tensorrt.calibrator import create_int8_calibrator
+
+            with pytest.raises(ImportError):
+                create_int8_calibrator(
+                    data_root=str(tmp_path),
+                    transform=transform,
+                    input_shape=(3, 224, 224),
+                    max_samples=5,
+                )

--- a/tests/unit/test_tensorrt/test_converter.py
+++ b/tests/unit/test_tensorrt/test_converter.py
@@ -1,0 +1,75 @@
+"""TensorRTコンバーターのテスト.
+
+TensorRTはオプション依存のため, TensorRT不要なバリデーションテストと
+TensorRT必須のテストを分離.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pochitrain.tensorrt.inference import check_tensorrt_availability
+
+
+class TestTensorRTConverterValidation:
+    """TensorRTConverter のバリデーションテスト (TensorRT不要)."""
+
+    def test_nonexistent_onnx_raises(self, tmp_path):
+        """存在しないONNXファイルでFileNotFoundErrorが発生する."""
+        if not check_tensorrt_availability():
+            pytest.skip("TensorRT is not installed")
+
+        from pochitrain.tensorrt.converter import TensorRTConverter
+
+        with pytest.raises(FileNotFoundError, match="ONNXモデルが見つかりません"):
+            TensorRTConverter(tmp_path / "nonexistent.onnx")
+
+    def test_import_error_without_tensorrt(self, tmp_path):
+        """TensorRTがない環境でImportErrorが発生する."""
+        if check_tensorrt_availability():
+            pytest.skip("TensorRT is installed, skipping non-TensorRT test")
+
+        from pochitrain.tensorrt.converter import TensorRTConverter
+
+        dummy_onnx = tmp_path / "model.onnx"
+        dummy_onnx.write_bytes(b"dummy")
+
+        with pytest.raises(ImportError, match="TensorRTがインストールされていません"):
+            TensorRTConverter(dummy_onnx)
+
+
+tensorrt_available = check_tensorrt_availability()
+
+
+@pytest.mark.skipif(not tensorrt_available, reason="TensorRT is not installed")
+class TestTensorRTConverterConvert:
+    """TensorRTConverter.convert() のテスト (TensorRT環境のみ)."""
+
+    def test_invalid_precision_raises(self, tmp_path):
+        """無効な精度モードでValueErrorが発生する."""
+        from pochitrain.tensorrt.converter import TensorRTConverter
+
+        dummy_onnx = tmp_path / "model.onnx"
+        dummy_onnx.write_bytes(b"dummy")
+
+        converter = TensorRTConverter(dummy_onnx)
+        with pytest.raises(ValueError, match="無効なprecision"):
+            converter.convert(
+                output_path=tmp_path / "model.engine",
+                precision="int4",
+            )
+
+    def test_int8_without_calibrator_raises(self, tmp_path):
+        """INT8でcalibratorなしの場合にValueErrorが発生する."""
+        from pochitrain.tensorrt.converter import TensorRTConverter
+
+        dummy_onnx = tmp_path / "model.onnx"
+        dummy_onnx.write_bytes(b"dummy")
+
+        converter = TensorRTConverter(dummy_onnx)
+        with pytest.raises(ValueError, match="calibratorが必須"):
+            converter.convert(
+                output_path=tmp_path / "model.engine",
+                precision="int8",
+                calibrator=None,
+            )


### PR DESCRIPTION
## Summary
- `pochi convert` サブコマンドを追加し, ONNXモデルからTensorRTエンジン (FP32/FP16/INT8) へのワンストップ変換を実現
- `PochiImageDataset` からキャリブレーションデータを自動サンプリングする `create_calibration_dataset()` を実装 (最大500枚, seed指定で再現可能)
- `trt.IInt8EntropyCalibrator2` を継承した `_PochiInt8Calibrator` を動的クラス生成で実装し, PyTorch CUDAテンソルによるGPUバッファ供給 (pycuda不要)
- `TensorRTConverter` クラスでONNXパース, 動的入力プロファイル自動設定, INT8時のFP16フォールバックを含むビルド処理を一括実行

## Code Changes

```python
# pochitrain/tensorrt/calibrator.py - キャリブレーション用サブセット作成
def create_calibration_dataset(
    data_root: str,
    transform: Callable[..., Any],
    max_samples: int = 500,
    seed: int = 42,
) -> Dataset[Any]:
    dataset = PochiImageDataset(data_root, transform=transform)
    total = len(dataset)
    if total <= max_samples:
        return dataset
    generator = torch.Generator().manual_seed(seed)
    indices = torch.randperm(total, generator=generator)[:max_samples].tolist()
    return Subset(dataset, indices)
```

```python
# pochitrain/tensorrt/converter.py - INT8ビルド設定
elif precision == "int8":
    config.set_flag(trt.BuilderFlag.INT8)
    config.set_flag(trt.BuilderFlag.FP16)  # INT8非対応層のフォールバック
    config.int8_calibrator = calibrator
```

```python
# pochitrain/cli/pochi.py - CLIからの利用例
calibrator = create_int8_calibrator(
    data_root=calib_data_root,
    transform=transform,
    input_shape=input_shape,
    batch_size=args.calib_batch_size,
    max_samples=max_calib_samples,
    cache_file=cache_file,
)
converter = TensorRTConverter(onnx_path=onnx_path, workspace_size=args.workspace_size)
engine_path = converter.convert(output_path=output_path, precision=precision, calibrator=calibrator)
```

## Test plan
- [ ] `uv run pytest tests/unit/test_cli/test_convert_cli.py` CLI引数パース・精度決定・出力パスロジックのテスト通過
- [ ] `uv run pytest tests/unit/test_tensorrt/test_calibrator.py` キャリブレーションデータセット作成・TensorRT未インストール時のImportErrorテスト通過
- [ ] `uv run pytest tests/unit/test_tensorrt/test_converter.py` コンバーターバリデーションテスト通過
- [ ] `uv run pre-commit run --all-files` 全チェック通過
