### PR TITLE
refactor: calibrator.py から未使用の numpy import を削除

### DIFF
--- a/pochitrain/tensorrt/calibrator.py
+++ b/pochitrain/tensorrt/calibrator.py
@@ -9,7 +9,6 @@ import os
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Sized, cast
 
-import numpy as np
 import torch
 from torch.utils.data import DataLoader, Dataset, Subset
 


### PR DESCRIPTION
## Summary
- `pochitrain/tensorrt/calibrator.py` から未使用の `import numpy as np` を削除

## Code Changes
```python
# pochitrain/tensorrt/calibrator.py (削除)
- import numpy as np
```

## Test plan
- [x] 全テスト (548件) がパスすることを確認
- [x] mypy で型チェックエラーがないことを確認