### PR TITLE
fix: find_best_model のエポック番号比較を文字列比較から数値比較に修正

### DIFF
--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -8,6 +8,7 @@ pochitrain 統一CLI エントリーポイント.
 import argparse
 import dataclasses
 import logging
+import re
 import signal
 import sys
 import time
@@ -111,7 +112,12 @@ def find_best_model(work_dir: str) -> Path:
         )
 
     # 最新のモデルを選択（エポック番号が最大のもの）
-    best_model = max(model_files, key=lambda x: x.name)
+    best_model = max(
+        model_files,
+        key=lambda x: (
+            int(m.group(1)) if (m := re.search(r"best_epoch(\d+)", x.name)) else 0
+        ),
+    )
     return best_model
 
 

--- a/tests/unit/test_cli/test_pochi_cli.py
+++ b/tests/unit/test_cli/test_pochi_cli.py
@@ -73,6 +73,21 @@ class TestFindBestModel:
         # 最大エポック番号のモデルが選択されることを確認
         assert result.name == "best_epoch30.pth"
 
+    def test_find_best_model_cross_digit_boundary(self, tmp_path):
+        """桁が変わるエポック番号でも正しく数値比較されることを確認."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+
+        # best_epoch9.pth と best_epoch10.pth が共存するケース
+        (models_dir / "best_epoch9.pth").touch()
+        (models_dir / "best_epoch10.pth").touch()
+
+        result = find_best_model(str(tmp_path))
+
+        # 文字列比較だと "best_epoch9" > "best_epoch10" になるが,
+        # 数値比較で epoch 10 が選択されることを確認
+        assert result.name == "best_epoch10.pth"
+
     def test_find_best_model_no_models_dir(self, tmp_path):
         """モデルディレクトリがない場合にエラーを発生させることを確認."""
         with pytest.raises(


### PR DESCRIPTION
## Summary
- `find_best_model()` のエポック番号判定を正規表現による数値比較に変更
- 桁が変わる境界 (`best_epoch9.pth` vs `best_epoch10.pth`) で正しくモデルが選択されるテストを追加

## Code Changes
```python
# pochitrain/cli/pochi.py
best_model = max(
    model_files,
    key=lambda x: int(m.group(1)) if (m := re.search(r"best_epoch(\d+)", x.name)) else 0,
)
```

## Test plan
- [x] 桁が変わるエポック番号 (epoch 9 vs epoch 10) で正しいモデルが選択されることを確認
- [x] 既存テストがパスすることを確認
- [x] pre-commit チェック (black, isort, mypy, pytest) がパスすることを確認