### PR TITLE
test: infer CLI テストのパーサー定義を実装に合わせて修正

### DIFF
--- a/tests/unit/test_cli/test_pochi_cli.py
+++ b/tests/unit/test_cli/test_pochi_cli.py
@@ -240,17 +240,37 @@ class TestMainArgumentParsing:
         args = parser.parse_args(["train"])
         assert args.config == "configs/pochi_train_config.py"
 
-    def test_infer_parser_required_args(self):
-        """inferサブコマンドの必須引数を確認."""
+    def test_infer_parser_positional_model_path(self):
+        """inferサブコマンドの位置引数model_pathを確認."""
+        with patch("sys.argv", ["pochi", "infer", "model.pth"]):
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--debug", action="store_true")
+            subparsers = parser.add_subparsers(dest="command")
+            infer_parser = subparsers.add_parser("infer")
+            infer_parser.add_argument("model_path", help="モデルファイルパス")
+            infer_parser.add_argument("--data", "-d")
+            infer_parser.add_argument("--config-path", "-c")
+            infer_parser.add_argument("--output", "-o")
+
+            args = parser.parse_args(["infer", "model.pth"])
+            assert args.model_path == "model.pth"
+            assert args.data is None
+            assert args.config_path is None
+            assert args.output is None
+
+    def test_infer_parser_with_optional_args(self):
+        """inferサブコマンドのオプション引数を確認."""
         parser = argparse.ArgumentParser()
+        parser.add_argument("--debug", action="store_true")
         subparsers = parser.add_subparsers(dest="command")
         infer_parser = subparsers.add_parser("infer")
-        infer_parser.add_argument("--model-path", "-m", required=True)
-        infer_parser.add_argument("--data", "-d", required=True)
-        infer_parser.add_argument("--config-path", "-c", required=True)
+        infer_parser.add_argument("model_path", help="モデルファイルパス")
+        infer_parser.add_argument("--data", "-d")
+        infer_parser.add_argument("--config-path", "-c")
+        infer_parser.add_argument("--output", "-o")
 
         args = parser.parse_args(
-            ["infer", "-m", "model.pth", "-d", "data/val", "-c", "config.py"]
+            ["infer", "model.pth", "-d", "data/val", "-c", "config.py"]
         )
         assert args.model_path == "model.pth"
         assert args.data == "data/val"


### PR DESCRIPTION
## Summary
- `test_infer_parser_required_args` を削除し, 実装に合わせた2つのテストに置換
- `test_infer_parser_positional_model_path`: 位置引数 `model_path` のみ指定時の動作を検証
- `test_infer_parser_with_optional_args`: オプション引数 (`--data`, `--config-path`) 付きの動作を検証

## Code Changes
```python
# tests/unit/test_cli/test_pochi_cli.py

# Before: 実装と異なるパーサー定義
def test_infer_parser_required_args(self):
    infer_parser.add_argument("--model-path", "-m", required=True)
    infer_parser.add_argument("--data", "-d", required=True)
    infer_parser.add_argument("--config-path", "-c", required=True)

# After: 実装と一致するパーサー定義
def test_infer_parser_positional_model_path(self):
    infer_parser.add_argument("model_path", help="モデルファイルパス")
    infer_parser.add_argument("--data", "-d")
    infer_parser.add_argument("--config-path", "-c")
    infer_parser.add_argument("--output", "-o")
```

## Test plan
- [x] 新しいテストが位置引数 `model_path` を正しく検証することを確認
- [x] オプション引数が省略可能であることを検証するテストを追加
- [x] pre-commit チェック (black, isort, mypy, pytest) がパスすることを確認