### PR TITLE
fix: pochi convert の INT8 変換パラメータに下限バリデーションを追加

### DIFF
--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -41,6 +41,24 @@ from pochitrain.validation import ConfigValidator
 training_interrupted = False
 
 
+def positive_int(value: str) -> int:
+    """argparse用の正の整数バリデーション.
+
+    Args:
+        value (str): コマンドライン引数の文字列値
+
+    Returns:
+        int: 変換された正の整数
+
+    Raises:
+        argparse.ArgumentTypeError: 値が1未満の場合
+    """
+    int_value = int(value)
+    if int_value < 1:
+        raise argparse.ArgumentTypeError(f"1以上の整数を指定してください: {value}")
+    return int_value
+
+
 def create_signal_handler(debug: bool = False) -> Any:
     """デバッグフラグを保持するシグナルハンドラーを生成する.
 
@@ -954,21 +972,21 @@ def main() -> None:
     )
     convert_parser.add_argument(
         "--calib-samples",
-        type=int,
+        type=positive_int,
         default=500,
-        help="キャリブレーションサンプル数 (default: 500)",
+        help="キャリブレーションサンプル数 (default: 500, 1以上)",
     )
     convert_parser.add_argument(
         "--calib-batch-size",
-        type=int,
+        type=positive_int,
         default=1,
-        help="キャリブレーションバッチサイズ (default: 1)",
+        help="キャリブレーションバッチサイズ (default: 1, 1以上)",
     )
     convert_parser.add_argument(
         "--workspace-size",
-        type=int,
+        type=positive_int,
         default=1 << 30,
-        help="TensorRTワークスペースサイズ (bytes, default: 1GB)",
+        help="TensorRTワークスペースサイズ (bytes, default: 1GB, 1以上)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- `positive_int` バリデーション関数を追加し, `--calib-samples`, `--calib-batch-size`, `--workspace-size` に 1以上の整数制約を適用
- 0 や負の値を指定した場合, argparse レベルでわかりやすいエラーメッセージを表示するようになる
- バリデーション関数の単体テストと, パーサーレベルの拒否テストを追加

## Code Changes
```python
# pochitrain/cli/pochi.py
def positive_int(value: str) -> int:
    int_value = int(value)
    if int_value < 1:
        raise argparse.ArgumentTypeError(f"1以上の整数を指定してください: {value}")
    return int_value

# argparse への適用
convert_parser.add_argument("--calib-samples", type=positive_int, default=500)
convert_parser.add_argument("--calib-batch-size", type=positive_int, default=1)
convert_parser.add_argument("--workspace-size", type=positive_int, default=1 << 30)
```

## Test plan
- [x] `positive_int("0")` と `positive_int("-1")` が `ArgumentTypeError` を発生させることを確認
- [x] パーサーレベルで `--calib-samples 0`, `--calib-batch-size -1`, `--workspace-size 0` が拒否されることを確認
- [x] 既存テストがパスすることを確認
- [x] pre-commit チェック (black, isort, mypy, pytest) がパスすることを確認