### PR TITLE
fix: TensorRT モジュールの単一 I/O 前提を明示的にガード

### DIFF
--- a/pochitrain/tensorrt/calibrator.py
+++ b/pochitrain/tensorrt/calibrator.py
@@ -2,6 +2,8 @@
 
 PochiImageDatasetからキャリブレーションデータを供給し,
 TensorRT INT8量子化に必要なスケールファクタを計算する.
+
+単一入力のCNN分類モデル (ResNet等) のみをサポートする.
 """
 
 import logging
@@ -89,6 +91,7 @@ def _create_calibrator_class() -> type:
 
         IInt8EntropyCalibrator2を継承し, PochiImageDatasetから
         キャリブレーションデータを供給する.
+        単一入力のCNN分類モデル専用.
 
         PyTorch CUDAテンソルをGPUバッファとして使用するため, pycudaは不要.
 
@@ -153,12 +156,24 @@ def _create_calibrator_class() -> type:
         def get_batch(self, names: List[str]) -> Optional[List[int]]:
             """次のキャリブレーションバッチを供給する.
 
+            単一入力のみサポート. TensorRTから渡されるnamesが1つでない場合は
+            RuntimeErrorを送出する.
+
             Args:
                 names: テンソル名のリスト (TensorRT APIから渡される)
 
             Returns:
                 GPUバッファポインタのリスト, またはデータ終了時にNone
+
+            Raises:
+                RuntimeError: 入力テンソルが1つでない場合
             """
+            if len(names) != 1:
+                raise RuntimeError(
+                    f"単一入力のみサポートしていますが, "
+                    f"{len(names)}個の入力が要求されました: {names}"
+                )
+
             try:
                 batch_images, _ = next(self._data_iter)
             except StopIteration:

--- a/tests/unit/test_tensorrt/test_inference.py
+++ b/tests/unit/test_tensorrt/test_inference.py
@@ -1,14 +1,18 @@
 """TensorRT推論モジュールのテスト.
 
-TensorRTはオプション依存のため、利用不可環境ではスキップ.
-check_tensorrt_availability関数はTensorRT不要でテスト可能.
+TensorRTはオプション依存のため, 利用不可環境ではスキップ.
+check_tensorrt_availability関数とI/Oバインディング検証ロジックは
+TensorRT不要でテスト可能.
 """
 
+from enum import Enum
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pochitrain.tensorrt.inference import check_tensorrt_availability
+from pochitrain.tensorrt.inference import TensorRTInference, check_tensorrt_availability
 
 
 class TestCheckTensorrtAvailability:
@@ -20,26 +24,132 @@ class TestCheckTensorrtAvailability:
         assert isinstance(result, bool)
 
 
+class _MockTensorIOMode(Enum):
+    """テスト用のTensorIOModeモック."""
+
+    INPUT = 0
+    OUTPUT = 1
+
+
+class TestResolveIoBindings:
+    """_resolve_io_bindings メソッドの単体テスト (TensorRT不要)."""
+
+    def _create_inference_with_mock_engine(self, tensor_specs):
+        """モックエンジンでTensorRTInferenceインスタンスを部分的に構築する.
+
+        Args:
+            tensor_specs: [(name, mode), ...] のリスト.
+                mode は _MockTensorIOMode.INPUT または OUTPUT.
+
+        Returns:
+            engine属性のみ設定済みのTensorRTInferenceインスタンス
+        """
+        mock_engine = MagicMock()
+        mock_engine.num_io_tensors = len(tensor_specs)
+        mock_engine.get_tensor_name.side_effect = [s[0] for s in tensor_specs]
+        mock_engine.get_tensor_mode.side_effect = [s[1] for s in tensor_specs]
+
+        # __init__をバイパスして直接インスタンスを作る
+        instance = object.__new__(TensorRTInference)
+        instance.engine = mock_engine
+        return instance
+
+    def test_single_input_output(self):
+        """入力1つ・出力1つで正常に解決できる."""
+        trt_mock = SimpleNamespace(TensorIOMode=_MockTensorIOMode)
+        instance = self._create_inference_with_mock_engine(
+            [
+                ("input", _MockTensorIOMode.INPUT),
+                ("output", _MockTensorIOMode.OUTPUT),
+            ]
+        )
+
+        result = instance._resolve_io_bindings(trt_mock)
+
+        assert result == {"input": "input", "output": "output"}
+
+    def test_reversed_order(self):
+        """出力が先, 入力が後の順序でも正しく解決できる."""
+        trt_mock = SimpleNamespace(TensorIOMode=_MockTensorIOMode)
+        instance = self._create_inference_with_mock_engine(
+            [
+                ("output", _MockTensorIOMode.OUTPUT),
+                ("input", _MockTensorIOMode.INPUT),
+            ]
+        )
+
+        result = instance._resolve_io_bindings(trt_mock)
+
+        assert result == {"input": "input", "output": "output"}
+
+    def test_multiple_inputs_raises(self):
+        """入力が2つ以上の場合はRuntimeErrorが発生する."""
+        trt_mock = SimpleNamespace(TensorIOMode=_MockTensorIOMode)
+        instance = self._create_inference_with_mock_engine(
+            [
+                ("input_0", _MockTensorIOMode.INPUT),
+                ("input_1", _MockTensorIOMode.INPUT),
+                ("output", _MockTensorIOMode.OUTPUT),
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="単一入力のみサポート"):
+            instance._resolve_io_bindings(trt_mock)
+
+    def test_multiple_outputs_raises(self):
+        """出力が2つ以上の場合はRuntimeErrorが発生する."""
+        trt_mock = SimpleNamespace(TensorIOMode=_MockTensorIOMode)
+        instance = self._create_inference_with_mock_engine(
+            [
+                ("input", _MockTensorIOMode.INPUT),
+                ("boxes", _MockTensorIOMode.OUTPUT),
+                ("scores", _MockTensorIOMode.OUTPUT),
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="単一出力のみサポート"):
+            instance._resolve_io_bindings(trt_mock)
+
+    def test_no_input_raises(self):
+        """入力が0個の場合はRuntimeErrorが発生する."""
+        trt_mock = SimpleNamespace(TensorIOMode=_MockTensorIOMode)
+        instance = self._create_inference_with_mock_engine(
+            [
+                ("output", _MockTensorIOMode.OUTPUT),
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="単一入力のみサポート"):
+            instance._resolve_io_bindings(trt_mock)
+
+    def test_no_output_raises(self):
+        """出力が0個の場合はRuntimeErrorが発生する."""
+        trt_mock = SimpleNamespace(TensorIOMode=_MockTensorIOMode)
+        instance = self._create_inference_with_mock_engine(
+            [
+                ("input", _MockTensorIOMode.INPUT),
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="単一出力のみサポート"):
+            instance._resolve_io_bindings(trt_mock)
+
+
 # TensorRTが利用可能な場合のみ実行するテスト
 tensorrt_available = check_tensorrt_availability()
 
 
 @pytest.mark.skipif(not tensorrt_available, reason="TensorRT is not installed")
 class TestTensorRTInferenceInit:
-    """TensorRTInference初期化のテスト（TensorRT環境のみ）."""
+    """TensorRTInference初期化のテスト (TensorRT環境のみ)."""
 
     def test_nonexistent_engine_raises(self, tmp_path):
         """存在しないエンジンファイルでFileNotFoundErrorが発生する."""
-        from pochitrain.tensorrt.inference import TensorRTInference
-
         with pytest.raises(FileNotFoundError, match="エンジンファイルが見つかりません"):
             TensorRTInference(tmp_path / "nonexistent.engine")
 
     def test_invalid_engine_raises(self, tmp_path):
         """無効なエンジンファイルでRuntimeErrorが発生する."""
-        from pochitrain.tensorrt.inference import TensorRTInference
-
-        # 無効なエンジンファイルを作成
         invalid_engine = tmp_path / "invalid.engine"
         invalid_engine.write_bytes(b"invalid engine data")
 
@@ -53,8 +163,6 @@ class TestTensorRTInferenceWithoutTensorRT:
 
     def test_import_raises_without_tensorrt(self, tmp_path):
         """TensorRTがない環境でImportErrorが発生する."""
-        from pochitrain.tensorrt.inference import TensorRTInference
-
         dummy_engine = tmp_path / "dummy.engine"
         dummy_engine.write_bytes(b"dummy")
 


### PR DESCRIPTION
## Summary
- `TensorRTInference` のバインディング解決をインデックス決め打ち (0=入力, 1=出力) から名前ベース (`get_tensor_mode()`) に変更し, バインディング順序に依存しない安全な解決を実現
- `_resolve_io_bindings()` メソッドを追加: 入力・出力が各1つでない場合は `RuntimeError` で早期に検出
- `execute()` メソッドも名前ベースでバッファ順序を構築するように変更
- `_PochiInt8Calibrator.get_batch()` に `names` パラメータのバリデーションを追加: 単一入力でない場合は `RuntimeError`
- モジュール・クラスの docstring に単一 I/O 専用である旨を明記

## Code Changes
```python
# pochitrain/tensorrt/inference.py - 名前ベースのバインディング解決
def _resolve_io_bindings(self, trt: object) -> Dict[str, str]:
    input_names = []
    output_names = []
    for i in range(self.engine.num_io_tensors):
        name = self.engine.get_tensor_name(i)
        mode = self.engine.get_tensor_mode(name)
        if mode == trt.TensorIOMode.INPUT:
            input_names.append(name)
        elif mode == trt.TensorIOMode.OUTPUT:
            output_names.append(name)
    if len(input_names) != 1:
        raise RuntimeError(...)
    if len(output_names) != 1:
        raise RuntimeError(...)
    return {"input": input_names[0], "output": output_names[0]}
```

```python
# pochitrain/tensorrt/calibrator.py - get_batch の names バリデーション
def get_batch(self, names: List[str]) -> Optional[List[int]]:
    if len(names) != 1:
        raise RuntimeError(
            f"単一入力のみサポートしていますが, "
            f"{len(names)}個の入力が要求されました: {names}"
        )
    ...
```

## Test plan
- [x] `_resolve_io_bindings`: 入力1つ・出力1つで正常に解決
- [x] `_resolve_io_bindings`: 出力が先・入力が後の逆順でも正しく解決
- [x] `_resolve_io_bindings`: 入力が2つ以上で `RuntimeError`
- [x] `_resolve_io_bindings`: 出力が2つ以上で `RuntimeError`
- [x] `_resolve_io_bindings`: 入力が0個で `RuntimeError`
- [x] `_resolve_io_bindings`: 出力が0個で `RuntimeError`
- [x] `get_batch`: names が1つの場合は正常
- [x] `get_batch`: names が2つ以上で `RuntimeError`
- [x] `get_batch`: names が空で `RuntimeError`
- [x] pre-commit チェック (black, isort, mypy, pytest) がパス