### PR TITLE
fix: pochi convert の --input-size に positive_int バリデーションを追加

### DIFF
--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -1012,9 +1012,9 @@ def main() -> None:
     convert_parser.add_argument(
         "--input-size",
         nargs=2,
-        type=int,
+        type=positive_int,
         metavar=("HEIGHT", "WIDTH"),
-        help="入力画像サイズ (動的シェイプONNXモデルの変換時に必要)",
+        help="入力画像サイズ (動的シェイプONNXモデルの変換時に必要, 1以上)",
     )
     convert_parser.add_argument(
         "--calib-samples",

--- a/tests/unit/test_cli/test_convert_cli.py
+++ b/tests/unit/test_cli/test_convert_cli.py
@@ -24,7 +24,7 @@ class TestConvertArgumentParsing:
         parser.add_argument("--config-path", "-c")
         parser.add_argument("--calib-data")
         parser.add_argument(
-            "--input-size", nargs=2, type=int, metavar=("HEIGHT", "WIDTH")
+            "--input-size", nargs=2, type=positive_int, metavar=("HEIGHT", "WIDTH")
         )
         parser.add_argument("--calib-samples", type=positive_int, default=500)
         parser.add_argument("--calib-batch-size", type=positive_int, default=1)
@@ -239,7 +239,7 @@ class TestInputSizeOption:
         parser = argparse.ArgumentParser()
         parser.add_argument("onnx_path")
         parser.add_argument(
-            "--input-size", nargs=2, type=int, metavar=("HEIGHT", "WIDTH")
+            "--input-size", nargs=2, type=positive_int, metavar=("HEIGHT", "WIDTH")
         )
         return parser
 
@@ -260,6 +260,30 @@ class TestInputSizeOption:
         parser = self._build_parser()
         args = parser.parse_args(["model.onnx", "--input-size", "320", "640"])
         assert args.input_size == [320, 640]
+
+    def test_input_size_zero_rejected(self):
+        """--input-size 0 224 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.onnx", "--input-size", "0", "224"])
+
+    def test_input_size_negative_rejected(self):
+        """--input-size -1 224 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.onnx", "--input-size", "-1", "224"])
+
+    def test_input_size_second_value_zero_rejected(self):
+        """--input-size 224 0 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.onnx", "--input-size", "224", "0"])
+
+    def test_input_size_both_zero_rejected(self):
+        """--input-size 0 0 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.onnx", "--input-size", "0", "0"])
 
 
 class TestDynamicShapeDetection:


### PR DESCRIPTION
## Summary
- `pochi convert` の `--input-size` 引数を `type=int` から `type=positive_int` に変更し, 0 や負値をパース時に拒否するようにした
- テストパーサーも同様に `positive_int` に更新し, 0/負値の拒否テスト 4 件を追加

## Code Changes
```python
# pochitrain/cli/pochi.py
convert_parser.add_argument(
    "--input-size",
    nargs=2,
    type=positive_int,  # int -> positive_int
    metavar=("HEIGHT", "WIDTH"),
    help="入力画像サイズ (動的シェイプONNXモデルの変換時に必要, 1以上)",
)
```

## Test plan
- [x] `--input-size 0 224` がパース時にエラーとなること
- [x] `--input-size -1 224` がパース時にエラーとなること
- [x] `--input-size 224 0` がパース時にエラーとなること
- [x] `--input-size 0 0` がパース時にエラーとなること
- [x] 既存の正常系テストが全てパスすること
- [x] pre-commit チェック (black, isort, mypy, pytest) がパス