### PR TITLE
docs: input_shape のチャンネル数 C=3 固定をコード・ドキュメントに明記

### DIFF
--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -758,6 +758,7 @@ def convert_command(args: argparse.Namespace) -> None:
     # 動的シェイプONNXの変換時に全精度で必要
     input_shape = None
     if args.input_size:
+        # チャンネル数は RGB (C=3) 固定. pochitrain は RGB 画像のみ対応.
         input_shape = (3, args.input_size[0], args.input_size[1])
         logger.debug(f"CLI指定の入力形状: {input_shape}")
     else:

--- a/pochitrain/tensorrt/docs/conversion_guide.md
+++ b/pochitrain/tensorrt/docs/conversion_guide.md
@@ -77,6 +77,10 @@ pochi convert dynamic_model.onnx --int8 --calib-data data/val --input-size 224 2
 | Optimization Profile | batch=1, H/W は `--input-size` の値 |
 | 制限事項 | 推論時は指定サイズのみ対応 |
 
+> **Note**: `--input-size` は HEIGHT WIDTH の 2 値のみを受け取る.
+> チャンネル数は RGB (C=3) 固定であり, 内部で `input_shape = (3, HEIGHT, WIDTH)` として構築される.
+> pochitrain は RGB 3 チャンネル画像のみ対応しているため, グレースケールや 4 チャンネル画像は非対応.
+
 ### パターン 3: 完全静的 ONNX (バッチも固定)
 
 全次元が固定の ONNX モデル. Optimization Profile の設定不要.


### PR DESCRIPTION
## Summary
- `pochitrain/cli/pochi.py:761` に RGB (C=3) 固定の理由を説明するコメントを追加
- `conversion_guide.md` のパターン 2 に `--input-size` が HEIGHT WIDTH の 2 値のみを受け取り, チャンネル数は RGB (C=3) 固定である旨の Note を追加

## Code Changes
```python
# pochitrain/cli/pochi.py
if args.input_size:
    # チャンネル数は RGB (C=3) 固定. pochitrain は RGB 画像のみ対応.
    input_shape = (3, args.input_size[0], args.input_size[1])
```

## Test plan
- [x] コメント・ドキュメントのみの変更のため, 既存テストへの影響なし
- [x] pre-commit チェック (black, isort, mypy, pytest) がパス