### PR TITLE
chore: Jetson対応に向けた requirements.txt の整備

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,23 @@
-# Core dependencies
-torch>=1.8.0
-torchvision>=0.9.0
-numpy>=1.19.0
-pillow>=8.0.0
+# torch, torchvision, numpy は環境に合わせて手動インストール
+# 例 (Jetson / JetPack):
+#   pip install torch torchvision (NVIDIA提供のホイールを使用)
+#   pip install numpy
+# torch
+# torchvision
+# numpy
 
 # Data processing
+pandas>=2.0.0
+pillow>=8.0.0
 scikit-learn>=0.24.0
-matplotlib>=3.3.0
-japanize-matplotlib>=1.1.0
+matplotlib>=3.10.8
+matplotlib-fontja>=1.1.0
 
 # Configuration and logging
 pyyaml>=5.4.0
 colorlog>=6.0.0
+rich>=13.0.0
 
-# Optional dependencies for rich output
-rich>=10.0.0
-
-# Development dependencies
-pytest>=6.0.0
-pytest-mock>=3.6.0
-flake8>=3.8.0
-black>=21.0.0
-isort>=5.8.0
-pydocstyle>=6.0.0
+# Hyperparameter optimization
+optuna>=3.5.0
+plotly>=5.0.0


### PR DESCRIPTION
## Summary
- `requirements.txt` を `pyproject.toml` の依存関係と同期
- `torch`, `torchvision`, `numpy` をコメントアウトし, 環境に合わせた手動インストールを案内 (Jetson / JetPack等)
- `pandas`, `optuna`, `plotly`, `matplotlib-fontja` を追加 (pyproject.toml に存在するが requirements.txt に未記載だった)
- `japanize-matplotlib` → `matplotlib-fontja` に置換, バージョン下限を更新
- 推論環境では不要な dev 依存 (`pytest`, `black`, `isort` 等) を除外

## Test plan
- [x] 依存パッケージが `pyproject.toml` と一致していることを確認
- [x] コメントの記載内容が正確であることを確認