### PR TITLE
release: v1.4.2 リリース準備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pochitrain
 
-[![Version](https://img.shields.io/badge/version-1.4.1-blue.svg)](https://github.com/kurorosu/pochitrain)
+[![Version](https://img.shields.io/badge/version-1.4.2-blue.svg)](https://github.com/kurorosu/pochitrain)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.13+-yellow.svg)](https://www.python.org/)
 [![PyTorch](https://img.shields.io/badge/PyTorch-2.9+-ee4c2c.svg)](https://pytorch.org/)

--- a/pochitrain/__init__.py
+++ b/pochitrain/__init__.py
@@ -28,7 +28,7 @@ from .pochi_trainer import PochiTrainer
 # ユーティリティ
 from .utils.directory_manager import InferenceWorkspaceManager, PochiWorkspaceManager
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 __author__ = "Pochi Team"
 __email__ = "pochi@example.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochitrain"
-version = "1.4.1"
+version = "1.4.2"
 description = "Simple CNN training framework for image classification"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1173,7 +1173,7 @@ wheels = [
 
 [[package]]
 name = "pochitrain"
-version = "1.4.1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
## Summary
- バージョン番号を v1.4.1 → v1.4.2 に更新 (`pyproject.toml`, `pochitrain/__init__.py`, `README.md`)
- `uv lock` で `uv.lock` を再生成
- CLAUDE.md の Release Workflow に `uv lock` 使用の注意書きを追加
- リリースノート (`tmp_release.md`) を作成

## Changes in v1.4.2

### Refactor
- TensorRT推論を `execute_v2` から `execute_async_v3` に移行, 非デフォルトCUDAストリームに切り替え (#185)

### Fix
- `pochi convert` の `--input-size` に `positive_int` バリデーションを追加 (#182)

### Docs
- `input_shape` のチャンネル数 C=3 固定をコード・ドキュメントに明記 (#183)
- README.md と configuration.md の全角記号を半角に統一 (#184)

### Chore
- Jetson対応に向けた `requirements.txt` の整備 (#186)

## Test plan
- [x] `uv run pytest` が全件パス
- [x] `uv run pre-commit run --all-files` がパス
- [x] バージョン番号が3箇所で `1.4.2` に統一されていることを確認