### PR TITLE
fix: export-onnx の --input-size に正の整数バリデーションを追加

### DIFF
--- a/pochitrain/cli/arg_types.py
+++ b/pochitrain/cli/arg_types.py
@@ -1,0 +1,21 @@
+"""argparse用のカスタム型バリデーション関数."""
+
+import argparse
+
+
+def positive_int(value: str) -> int:
+    """argparse用の正の整数バリデーション.
+
+    Args:
+        value (str): コマンドライン引数の文字列値
+
+    Returns:
+        int: 変換された正の整数
+
+    Raises:
+        argparse.ArgumentTypeError: 値が1未満の場合
+    """
+    int_value = int(value)
+    if int_value < 1:
+        raise argparse.ArgumentTypeError(f"1以上の整数を指定してください: {value}")
+    return int_value

--- a/pochitrain/cli/export_onnx.py
+++ b/pochitrain/cli/export_onnx.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import torch
 
+from pochitrain.cli.arg_types import positive_int
 from pochitrain.logging import LoggerManager
 from pochitrain.onnx import OnnxExporter
 from pochitrain.utils import ConfigLoader
@@ -61,10 +62,10 @@ def main() -> None:
     parser.add_argument(
         "--input-size",
         nargs=2,
-        type=int,
+        type=positive_int,
         required=True,
         metavar=("HEIGHT", "WIDTH"),
-        help="入力画像サイズ（必須）",
+        help="入力画像サイズ（必須, 1以上）",
     )
     parser.add_argument(
         "--output",
@@ -147,7 +148,7 @@ def main() -> None:
     logger.info(f"モデル: {model_name}")
     logger.info(f"クラス数: {num_classes}")
     logger.info(f"入力サイズ: {input_size[0]}x{input_size[1]}")
-    logger.info(f"デバイス: {device}")
+    logger.info(f"エクスポートデバイス: {device}")
     logger.info(f"出力先: {output_path}")
 
     # エクスポーター作成

--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -26,6 +26,7 @@ from pochitrain import (
     PochiTrainer,
     create_data_loaders,
 )
+from pochitrain.cli.arg_types import positive_int
 from pochitrain.logging.logger_manager import LogLevel
 from pochitrain.utils import (
     ConfigLoader,
@@ -39,24 +40,6 @@ from pochitrain.validation import ConfigValidator
 
 # グローバル変数で訓練停止フラグを管理
 training_interrupted = False
-
-
-def positive_int(value: str) -> int:
-    """argparse用の正の整数バリデーション.
-
-    Args:
-        value (str): コマンドライン引数の文字列値
-
-    Returns:
-        int: 変換された正の整数
-
-    Raises:
-        argparse.ArgumentTypeError: 値が1未満の場合
-    """
-    int_value = int(value)
-    if int_value < 1:
-        raise argparse.ArgumentTypeError(f"1以上の整数を指定してください: {value}")
-    return int_value
 
 
 def create_signal_handler(debug: bool = False) -> Any:

--- a/pochitrain/onnx/inference.py
+++ b/pochitrain/onnx/inference.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, cast
 
 import numpy as np
 import onnxruntime as ort
@@ -112,9 +112,9 @@ class OnnxInference:
         if self.io_binding:
             # GPUからCPUへ結果を取得（D2H転送が発生）
             outputs = self.io_binding.copy_outputs_to_cpu()
-            return outputs[0]
+            return cast(np.ndarray, outputs[0])
         else:
-            return self._temp_cpu_outputs[0]
+            return cast(np.ndarray, self._temp_cpu_outputs[0])
 
     def run(self, images: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """推論を一括実行（互換性および簡易用）.

--- a/tests/unit/test_cli/test_convert_cli.py
+++ b/tests/unit/test_cli/test_convert_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from pochitrain.cli.pochi import positive_int
+from pochitrain.cli.arg_types import positive_int
 
 
 class TestConvertArgumentParsing:

--- a/tests/unit/test_cli/test_export_onnx_cli.py
+++ b/tests/unit/test_cli/test_export_onnx_cli.py
@@ -1,0 +1,123 @@
+"""export-onnx CLIのテスト.
+
+--input-size バリデーションを中心にテスト.
+"""
+
+import argparse
+
+import pytest
+
+from pochitrain.cli.arg_types import positive_int
+
+
+class TestExportOnnxArgumentParsing:
+    """export-onnx コマンドの引数パースのテスト."""
+
+    def _build_parser(self):
+        """テスト用にexport-onnxと同等のパーサーを構築."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("model_path", help="変換するPyTorchモデルファイル(.pth)")
+        parser.add_argument("--config", "-c")
+        parser.add_argument("--model-name", default="resnet18")
+        parser.add_argument("--num-classes", type=int)
+        parser.add_argument(
+            "--input-size",
+            nargs=2,
+            type=positive_int,
+            required=True,
+            metavar=("HEIGHT", "WIDTH"),
+        )
+        parser.add_argument("--output", "-o")
+        parser.add_argument("--opset-version", type=int, default=17)
+        parser.add_argument("--device", default="cpu")
+        parser.add_argument("--skip-verify", action="store_true")
+        return parser
+
+    def test_model_path_required(self):
+        """model_pathが必須引数であることを確認."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--input-size", "224", "224"])
+
+    def test_input_size_required(self):
+        """--input-sizeが必須引数であることを確認."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.pth"])
+
+    def test_valid_input_size_parsed(self):
+        """有効な--input-sizeが正しくパースされる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.pth", "--input-size", "224", "224"])
+        assert args.input_size == [224, 224]
+
+    def test_input_size_different_values(self):
+        """異なる高さと幅を指定できる."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.pth", "--input-size", "320", "640"])
+        assert args.input_size == [320, 640]
+
+    def test_default_values(self):
+        """デフォルト値が正しく設定される."""
+        parser = self._build_parser()
+        args = parser.parse_args(["model.pth", "--input-size", "224", "224"])
+        assert args.model_name == "resnet18"
+        assert args.opset_version == 17
+        assert args.device == "cpu"
+        assert args.skip_verify is False
+        assert args.output is None
+        assert args.config is None
+        assert args.num_classes is None
+
+
+class TestExportOnnxInputSizeValidation:
+    """export-onnx の --input-size バリデーションテスト."""
+
+    def _build_parser(self):
+        """テスト用にexport-onnxと同等のパーサーを構築."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("model_path")
+        parser.add_argument(
+            "--input-size",
+            nargs=2,
+            type=positive_int,
+            required=True,
+            metavar=("HEIGHT", "WIDTH"),
+        )
+        return parser
+
+    def test_input_size_zero_zero_rejected(self):
+        """--input-size 0 0 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.pth", "--input-size", "0", "0"])
+
+    def test_input_size_negative_negative_rejected(self):
+        """--input-size -1 -1 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.pth", "--input-size", "-1", "-1"])
+
+    def test_input_size_first_value_zero_rejected(self):
+        """--input-size 0 224 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.pth", "--input-size", "0", "224"])
+
+    def test_input_size_second_value_zero_rejected(self):
+        """--input-size 224 0 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.pth", "--input-size", "224", "0"])
+
+    def test_input_size_first_value_negative_rejected(self):
+        """--input-size -1 224 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.pth", "--input-size", "-1", "224"])
+
+    def test_input_size_second_value_negative_rejected(self):
+        """--input-size 224 -1 がパース時にエラーとなる."""
+        parser = self._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["model.pth", "--input-size", "224", "-1"])


### PR DESCRIPTION
## Summary
- `export-onnx` CLI の `--input-size` が 0 や負値を受け付けるバグを修正
- `positive_int` を `pochitrain/cli/arg_types.py` に抽出し, `export_onnx.py` と `pochi.py` で共有
- `export-onnx` CLI のテスト(`test_export_onnx_cli.py`)を追加

## Code Changes

```python
# pochitrain/cli/arg_types.py (新規: pochi.py から抽出)
def positive_int(value: str) -> int:
    """argparse用の正の整数バリデーション."""
    int_value = int(value)
    if int_value < 1:
        raise argparse.ArgumentTypeError(f"1以上の整数を指定してください: {value}")
    return int_value
```

```python
# pochitrain/cli/export_onnx.py (変更箇所)
parser.add_argument(
    "--input-size",
    nargs=2,
    type=positive_int,  # int -> positive_int に変更
    required=True,
    metavar=("HEIGHT", "WIDTH"),
    help="入力画像サイズ（必須, 1以上）",
)
```

## Test plan
- [x] `uv run pytest` が全件パス (567 passed)
- [x] `uv run pre-commit run --all-files` が全チェックパス
- [x] `uv run export-onnx model.pth --input-size 0 0` がエラーとなることを確認
- [x] `uv run export-onnx model.pth --input-size -1 -1` がエラーとなることを確認
- [x] `uv run export-onnx model.pth --input-size 224 224` が従来通り動作することを確認