### PR TITLE
refactor: TensorRTInference に stream プロパティを追加

### DIFF
--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -195,10 +195,10 @@ def main() -> None:
             # 推論時間計測
             inference.set_input(image_np)  # 転送（計測外）
 
-            start_event.record(inference._stream)
+            start_event.record(inference.stream)
             inference.execute()  # 純粋推論のみを計測
-            end_event.record(inference._stream)
-            inference._stream.synchronize()
+            end_event.record(inference.stream)
+            inference.stream.synchronize()
             total_inference_time_ms += start_event.elapsed_time(end_event)
             total_samples += 1
 

--- a/pochitrain/tensorrt/inference.py
+++ b/pochitrain/tensorrt/inference.py
@@ -112,6 +112,15 @@ class TensorRTInference:
         logger.debug(f"入力: {self.input_name}, shape: {self.input_shape}")
         logger.debug(f"出力: {self.output_name}, shape: {self.output_shape}")
 
+    @property
+    def stream(self) -> torch.cuda.Stream:
+        """CUDAストリームを取得.
+
+        Returns:
+            推論に使用するCUDAストリーム
+        """
+        return self._stream
+
     def _resolve_io_bindings(self, trt: object) -> Dict[str, str]:
         """名前ベースで入出力バインディングを解決する.
 

--- a/tests/unit/test_tensorrt/test_inference.py
+++ b/tests/unit/test_tensorrt/test_inference.py
@@ -48,6 +48,26 @@ class TestExecute:
         instance.context.execute_async_v3.assert_called_once_with(12345)
 
 
+class TestStreamProperty:
+    """stream プロパティの単体テスト (TensorRT不要)."""
+
+    def test_stream_returns_internal_stream(self):
+        """stream プロパティが _stream と同じオブジェクトを返す."""
+        instance = object.__new__(TensorRTInference)
+        mock_stream = MagicMock()
+        instance._stream = mock_stream
+
+        assert instance.stream is mock_stream
+
+    def test_stream_is_readonly(self):
+        """stream プロパティが読み取り専用である."""
+        instance = object.__new__(TensorRTInference)
+        instance._stream = MagicMock()
+
+        with pytest.raises(AttributeError):
+            instance.stream = MagicMock()
+
+
 class TestResolveIoBindings:
     """_resolve_io_bindings メソッドの単体テスト (TensorRT不要)."""
 


### PR DESCRIPTION
## Summary
- `TensorRTInference` に読み取り専用の `stream` プロパティを追加し, private 属性 `_stream` をカプセル化
- `infer_trt.py` の `inference._stream` 参照を `inference.stream` に変更 (3箇所)
- `stream` プロパティのテストを追加 (値の一致, 読み取り専用の検証)

## Code Changes

```python
# pochitrain/tensorrt/inference.py
@property
def stream(self) -> torch.cuda.Stream:
    """CUDAストリームを取得."""
    return self._stream
```

```python
# pochitrain/cli/infer_trt.py (変更前 → 変更後)
- start_event.record(inference._stream)
+ start_event.record(inference.stream)
- end_event.record(inference._stream)
+ end_event.record(inference.stream)
- inference._stream.synchronize()
+ inference.stream.synchronize()
```

## Test plan
- [x] `stream` プロパティが `_stream` と同一オブジェクトを返すことを検証
- [x] `stream` プロパティが読み取り専用であることを検証
- [x] 既存テスト全件パス (12 passed, 1 skipped)
- [x] mypy 型チェックパス