### PR TITLE
fix: infer-onnx の --pipeline gpu で CUDA EP 不可時に RuntimeError が発生する問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ __marimo__/
 # dev-files
 CLAUDE.md
 AGENTS.md
+Gemini.md
 *repomix*.*
 Plan.md
 issue.*

--- a/tests/unit/test_cli/test_infer_onnx.py
+++ b/tests/unit/test_cli/test_infer_onnx.py
@@ -1,6 +1,6 @@
 """infer_onnx CLIのテスト.
 
-ONNX推論CLIの引数パース・データパス決定ロジックをテスト.
+ONNX推論CLIの引数パース・データパス決定ロジック・パイプライン解決をテスト.
 実際のONNX推論はtest_onnx/test_inference.pyでテスト済み.
 """
 
@@ -13,6 +13,8 @@ import pytest
 
 pytest.importorskip("onnx")
 pytest.importorskip("onnxruntime")
+
+from pochitrain.cli.infer_onnx import _resolve_pipeline
 
 
 class TestInferOnnxArgumentParsing:
@@ -138,3 +140,185 @@ class TestInferOnnxMainExit:
         with patch("sys.argv", ["infer-onnx", fake_model]):
             with pytest.raises(SystemExit):
                 main()
+
+
+class TestResolvePipeline:
+    """_resolve_pipeline関数のテスト."""
+
+    def test_auto_with_gpu_returns_gpu(self):
+        """auto + GPU推論 → gpu."""
+        result = _resolve_pipeline("auto", use_gpu=True, val_transform=None)
+        assert result == "gpu"
+
+    def test_auto_without_gpu_returns_fast(self):
+        """auto + CPU推論 → fast."""
+        result = _resolve_pipeline("auto", use_gpu=False, val_transform=None)
+        assert result == "fast"
+
+    def test_current_passthrough(self):
+        """current指定時はそのまま返す."""
+        result = _resolve_pipeline("current", use_gpu=True, val_transform=None)
+        assert result == "current"
+
+    def test_fast_passthrough(self):
+        """fast指定時はそのまま返す."""
+        result = _resolve_pipeline("fast", use_gpu=False, val_transform=None)
+        assert result == "fast"
+
+    def test_gpu_with_gpu_available(self):
+        """gpu指定 + GPU推論 → gpu."""
+        result = _resolve_pipeline("gpu", use_gpu=True, val_transform=None)
+        assert result == "gpu"
+
+    def test_gpu_without_gpu_falls_back_to_fast(self):
+        """gpu指定 + CPU推論 → fastにフォールバック."""
+        result = _resolve_pipeline("gpu", use_gpu=False, val_transform=None)
+        assert result == "fast"
+
+
+class TestGpuFallbackReresolution:
+    """OnnxInference の GPU フォールバック後にパイプラインが再解決されるテスト.
+
+    OnnxInference が内部で use_gpu=False に切り替えた場合,
+    CLI側で pipeline と dataset を再解決するロジックを検証する.
+    main() を通して実コード経路のフォールバックを検証する.
+    """
+
+    @staticmethod
+    def _create_test_env(tmp_path):
+        """テスト用のONNXモデル・config・データセットを作成する.
+
+        Returns:
+            (model_path, data_path, output_dir) のタプル
+        """
+        import torch
+        import torch.nn as nn
+
+        class _SimpleModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(3, 16, kernel_size=3, padding=1)
+                self.pool = nn.AdaptiveAvgPool2d(1)
+                self.fc = nn.Linear(16, 2)
+
+            def forward(self, x):
+                x = torch.relu(self.conv(x))
+                x = self.pool(x)
+                return self.fc(x.view(x.size(0), -1))
+
+        # work_dir/models/model.onnx
+        work_dir = tmp_path / "work_dir"
+        models_dir = work_dir / "models"
+        models_dir.mkdir(parents=True)
+
+        model = _SimpleModel()
+        model.eval()
+        model_path = models_dir / "model.onnx"
+        torch.onnx.export(
+            model,
+            torch.randn(1, 3, 32, 32),
+            str(model_path),
+            export_params=True,
+            opset_version=17,
+            input_names=["input"],
+            output_names=["output"],
+            dynamic_axes={"input": {0: "batch"}, "output": {0: "batch"}},
+        )
+
+        # データセット: data/{class_a, class_b}/ にダミー画像 (モデルの2クラスに対応)
+        from PIL import Image
+
+        for cls_name, color in [("class_a", "red"), ("class_b", "blue")]:
+            cls_dir = tmp_path / "data" / cls_name
+            cls_dir.mkdir(parents=True)
+            img = Image.new("RGB", (32, 32), color=color)
+            img.save(str(cls_dir / "dummy.jpg"))
+
+        # config.py: device="cuda" でGPU推論を要求
+        config_path = work_dir / "config.py"
+        config_path.write_text(
+            "from torchvision import transforms\n"
+            f'val_data_root = r"{tmp_path / "data"}"\n'
+            "val_transform = transforms.Compose([\n"
+            "    transforms.Resize((32, 32)),\n"
+            "    transforms.ToTensor(),\n"
+            "    transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),\n"
+            "])\n"
+            'device = "cuda"\n'
+            "batch_size = 1\n"
+            "num_workers = 0\n",
+            encoding="utf-8",
+        )
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        data_path = tmp_path / "data"
+        return model_path, data_path, output_dir
+
+    def test_main_does_not_crash_when_cuda_ep_unavailable(self, tmp_path):
+        """CUDA EP不可時にmain()がRuntimeErrorなく完走する."""
+        from pochitrain.cli.infer_onnx import main
+
+        model_path, data_path, output_dir = self._create_test_env(tmp_path)
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "infer-onnx",
+                    str(model_path),
+                    "--data",
+                    str(data_path),
+                    "-o",
+                    str(output_dir),
+                    "--pipeline",
+                    "gpu",
+                ],
+            ),
+            patch(
+                "pochitrain.onnx.inference.check_gpu_availability",
+                return_value=False,
+            ),
+        ):
+            # RuntimeError が発生しないことを確認
+            main()
+
+        # 結果ファイルが生成されていることを確認
+        csv_files = list(output_dir.glob("*.csv"))
+        assert len(csv_files) > 0
+
+    def test_main_fallback_uses_set_input_not_set_input_gpu(self, tmp_path):
+        """フォールバック後にset_input_gpu()が呼ばれないことを確認."""
+        from unittest.mock import MagicMock
+
+        from pochitrain.cli.infer_onnx import main
+
+        model_path, data_path, output_dir = self._create_test_env(tmp_path)
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "infer-onnx",
+                    str(model_path),
+                    "--data",
+                    str(data_path),
+                    "-o",
+                    str(output_dir),
+                    "--pipeline",
+                    "gpu",
+                ],
+            ),
+            patch(
+                "pochitrain.onnx.inference.check_gpu_availability",
+                return_value=False,
+            ),
+            patch(
+                "pochitrain.onnx.inference.OnnxInference.set_input_gpu",
+                side_effect=RuntimeError("set_input_gpuが呼ばれた"),
+            ) as mock_set_input_gpu,
+        ):
+            main()
+
+        mock_set_input_gpu.assert_not_called()


### PR DESCRIPTION
## Summary
- `OnnxInference` が内部で CUDA EP 不可を検知し `use_gpu=False` に切り替えた後, CLI 側がその変更を認識せず GPU パイプラインを継続し `RuntimeError` が発生するバグを修正
- `OnnxInference` インスタンス化直後に `inference.use_gpu` を確認し, フォールバックが発生した場合はパイプライン・データセット・DataLoader を CPU 向けに再解決するロジックを追加
- `_resolve_pipeline` のユニットテスト (6件) と GPU フォールバック再解決ロジックのテスト (4件) を追加

## Code Changes

```python
# pochitrain/cli/infer_onnx.py — OnnxInference 生成直後にフォールバック検知・再解決
if use_gpu and not inference.use_gpu:
    logger.warning("CUDA ExecutionProviderが利用できません.CPUに切り替えます.")
    use_gpu = False
    pipeline = _resolve_pipeline(args.pipeline, use_gpu, val_transform)
    dataset, pipeline, norm_mean, norm_std = _create_dataset_and_params(
        pipeline, data_path, val_transform
    )
    use_gpu_pipeline = pipeline == "gpu"

    data_loader = DataLoader(
        dataset, batch_size=batch_size, shuffle=False,
        num_workers=num_workers, pin_memory=pin_memory,
    )
```

## Test plan
- [ ] `uv run pytest tests/unit/test_cli/test_infer_onnx.py` 全22テストパス
- [ ] `uv run pytest` 全テストパス
- [ ] `uv run pre-commit run --all-files` 全チェックパス
- [ ] CUDA EP が利用できない環境で `--pipeline gpu` 指定時に RuntimeError が発生せず, CPU パイプラインにフォールバックされることを確認