### PR TITLE
fix: 3つの推論CLIのCUDA時間計測方法を統一

### DIFF
--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -339,10 +339,10 @@ def main() -> None:
             else:
                 inference.set_input(image.numpy())
 
-            start_event.record(inference.stream)
+            start_event.record()
             inference.execute()  # 純粋推論のみを計測
-            end_event.record(inference.stream)
-            inference.stream.synchronize()
+            end_event.record()
+            torch.cuda.synchronize()
             total_inference_time_ms += start_event.elapsed_time(end_event)
             total_samples += 1
 

--- a/pochitrain/pochi_predictor.py
+++ b/pochitrain/pochi_predictor.py
@@ -126,27 +126,47 @@ class PochiPredictor:
         total_samples = 0
         warmup_samples = 0
         inference_time_ms = 0.0
-        is_first_batch = True
 
         use_cuda = self.device.type == "cuda"
 
-        with torch.no_grad():
-            for data, _ in data_loader:
-                data = data.to(self.device)
+        # ウォームアップ: 最初のバッチで10回事前実行
+        # dataset[0]を直接アクセスし, DataLoaderのイテレーションに影響させない
+        warmup_data, _ = data_loader.dataset[0]
+        if not isinstance(warmup_data, torch.Tensor):
+            warmup_data = torch.tensor(warmup_data)
+        warmup_data = warmup_data.unsqueeze(0).to(self.device)
+        with torch.inference_mode():
+            for _ in range(10):
+                self.model(warmup_data)
+            if use_cuda:
+                torch.cuda.synchronize()
+
+        # CUDA Eventをループ外で1回だけ生成
+        if use_cuda:
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+
+        # Note: ONNX/TRTと異なり, PyTorchは事前確保バッファを持たないため,
+        # to(device)で毎回CUDAメモリアロケーションが発生する.
+        # この転送コストと .cpu().numpy() のD2H転送は計測対象外だが,
+        # E2E時間には含まれるため, E2E - 純粋推論 の差が大きくなる.
+        # inference_mode: no_gradに加えテンソルのメタデータ追跡も無効化.
+        # 推論専用のため採用. 訓練側の検証ループ(evaluator.py)は
+        # 現在no_gradだが, 同様にinference_modeへ移行可能.
+        with torch.inference_mode():
+            for batch_idx, (data, _) in enumerate(data_loader):
+                data = data.to(self.device)  # H2D転送（計測外）
                 batch_size = data.size(0)
 
-                if is_first_batch:
-                    # ウォームアップ: 最初のバッチは計測対象外
+                if batch_idx == 0:
+                    # 最初のバッチは計測対象外（ウォームアップ）
                     output = self.model(data)
                     if use_cuda:
                         torch.cuda.synchronize()
                     warmup_samples = batch_size
-                    is_first_batch = False
                 else:
                     # 推論時間計測（モデル推論部分のみ）
                     if use_cuda:
-                        start_event = torch.cuda.Event(enable_timing=True)
-                        end_event = torch.cuda.Event(enable_timing=True)
                         start_event.record()
                         output = self.model(data)
                         end_event.record()
@@ -160,7 +180,7 @@ class PochiPredictor:
                     total_samples += batch_size
 
                 # 後処理（計測対象外）
-                logits = output.cpu().numpy()
+                logits = output.cpu().numpy()  # D2H転送 + 暗黙同期
                 predicted, confidence = post_process_logits(logits)
 
                 predictions.extend(predicted)


### PR DESCRIPTION
## Summary
- `pochi infer` のCUDA Event生成をループ内毎回 → ループ外1回に変更し, ドライバ呼び出しオーバーヘッドを削減
- `pochi infer` のウォームアップを最初の1バッチ1回 → `dataset[0]`で10回事前実行に変更し, ONNX/TRT方式に統一
- `infer-trt` の同期方法を `stream.synchronize()` → `torch.cuda.synchronize()` に変更し, 全ストリーム同期に統一
- `pochi infer` の推論ループを `torch.no_grad()` → `torch.inference_mode()` に変更し, テンソルメタデータ追跡のオーバーヘッドを削減

## Code Changes

```python
# pochitrain/pochi_predictor.py — ウォームアップ10回事前実行 + Event生成をループ外に
warmup_data, _ = data_loader.dataset[0]
warmup_data = warmup_data.unsqueeze(0).to(self.device)
with torch.inference_mode():
    for _ in range(10):
        self.model(warmup_data)

if use_cuda:
    start_event = torch.cuda.Event(enable_timing=True)
    end_event = torch.cuda.Event(enable_timing=True)
```

```python
# pochitrain/cli/infer_trt.py — 同期方法をONNX方式に統一
start_event.record()
inference.execute()
end_event.record()
torch.cuda.synchronize()  # stream.synchronize() から変更
```

### 統一後の計測方式 (3CLI共通)

| 項目 | 統一後 |
|------|--------|
| Event生成 | ループ外で1回 |
| 同期方法 | `torch.cuda.synchronize()` |
| ウォームアップ | 10回事前実行 + 最初の1バッチ除外 |

## Test plan
- [x] `uv run pytest tests/unit/test_core/test_pochi_predictor.py` 全テストパス
- [x] `uv run pytest tests/unit/test_cli/test_infer_trt.py` 全テストパス
- [x] `uv run pytest` 全テストパス
- [x] `uv run pre-commit run --all-files` 全チェックパス
- [x] `pochi infer` で計測詳細の枚数が `total_samples + warmup_samples = len(dataset)` になることを確認