### PR TITLE
test: pipeline 選択ロジックの整合性テストを追加

### DIFF
--- a/tests/unit/test_cli/test_pipeline_consistency.py
+++ b/tests/unit/test_cli/test_pipeline_consistency.py
@@ -1,0 +1,166 @@
+"""infer_onnx と infer_trt のパイプライン整合性テスト."""
+
+from pathlib import Path
+
+import pytest
+import torchvision.transforms as transforms
+from PIL import Image
+
+pytest.importorskip("onnx")
+pytest.importorskip("onnxruntime")
+
+from pochitrain.cli.infer_onnx import (
+    _create_dataset_and_params as onnx_create_dataset_and_params,
+)
+from pochitrain.cli.infer_onnx import _resolve_pipeline as onnx_resolve_pipeline
+from pochitrain.cli.infer_trt import (
+    _create_dataset_and_params as trt_create_dataset_and_params,
+)
+from pochitrain.cli.infer_trt import _resolve_pipeline as trt_resolve_pipeline
+from pochitrain.pochi_dataset import (
+    FastInferenceDataset,
+    GpuInferenceDataset,
+    PochiImageDataset,
+)
+
+
+def _make_data_root(tmp_path: Path) -> Path:
+    """最小構成のクラスフォルダデータセットを作成する."""
+    root = tmp_path / "data"
+    for class_name, color in [("class_a", "red"), ("class_b", "blue")]:
+        class_dir = root / class_name
+        class_dir.mkdir(parents=True, exist_ok=True)
+        img = Image.new("RGB", (32, 32), color=color)
+        img.save(class_dir / "dummy.jpg")
+    return root
+
+
+def _valid_transform() -> transforms.Compose:
+    """Normalize を含むテンソル互換 transform を返す."""
+    return transforms.Compose(
+        [
+            transforms.Resize((32, 32)),
+            transforms.ToTensor(),
+            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+        ]
+    )
+
+
+def _pil_only_transform() -> transforms.Compose:
+    """PIL 専用処理を含む transform を返す."""
+    return transforms.Compose(
+        [
+            transforms.ToPILImage(),
+            transforms.Resize((32, 32)),
+            transforms.ToTensor(),
+        ]
+    )
+
+
+def _no_normalize_transform() -> transforms.Compose:
+    """Normalize を含まないテンソル互換 transform を返す."""
+    return transforms.Compose([transforms.Resize((32, 32)), transforms.ToTensor()])
+
+
+class TestPipelineConsistency:
+    """データセット生成とパイプライン解決の整合性テスト."""
+
+    def test_current_pipeline_same_result(self, tmp_path: Path) -> None:
+        """current は ONNX/TRT で同一結果になる."""
+        data_root = _make_data_root(tmp_path)
+        transform = _valid_transform()
+
+        onnx_ds, onnx_pipe, onnx_mean, onnx_std = onnx_create_dataset_and_params(
+            "current", data_root, transform
+        )
+        trt_ds, trt_pipe, trt_mean, trt_std = trt_create_dataset_and_params(
+            "current", data_root, transform
+        )
+
+        assert isinstance(onnx_ds, PochiImageDataset)
+        assert isinstance(trt_ds, PochiImageDataset)
+        assert onnx_pipe == trt_pipe == "current"
+        assert onnx_mean is trt_mean is None
+        assert onnx_std is trt_std is None
+
+    def test_fast_pipeline_same_result(self, tmp_path: Path) -> None:
+        """fast は ONNX/TRT で同一結果になる."""
+        data_root = _make_data_root(tmp_path)
+        transform = _valid_transform()
+
+        onnx_ds, onnx_pipe, _, _ = onnx_create_dataset_and_params(
+            "fast", data_root, transform
+        )
+        trt_ds, trt_pipe, _, _ = trt_create_dataset_and_params(
+            "fast", data_root, transform
+        )
+
+        assert isinstance(onnx_ds, FastInferenceDataset)
+        assert isinstance(trt_ds, FastInferenceDataset)
+        assert onnx_pipe == trt_pipe == "fast"
+
+    def test_fast_with_pil_only_fallback_is_same(self, tmp_path: Path) -> None:
+        """fast + PIL専用 transform は両CLIで current へフォールバックする."""
+        data_root = _make_data_root(tmp_path)
+        transform = _pil_only_transform()
+
+        onnx_ds, onnx_pipe, _, _ = onnx_create_dataset_and_params(
+            "fast", data_root, transform
+        )
+        trt_ds, trt_pipe, _, _ = trt_create_dataset_and_params(
+            "fast", data_root, transform
+        )
+
+        assert isinstance(onnx_ds, PochiImageDataset)
+        assert isinstance(trt_ds, PochiImageDataset)
+        assert onnx_pipe == trt_pipe == "current"
+
+    def test_gpu_without_normalize_fallback_is_same(self, tmp_path: Path) -> None:
+        """gpu + Normalizeなし は両CLIで fast へフォールバックする."""
+        data_root = _make_data_root(tmp_path)
+        transform = _no_normalize_transform()
+
+        onnx_ds, onnx_pipe, onnx_mean, onnx_std = onnx_create_dataset_and_params(
+            "gpu", data_root, transform
+        )
+        trt_ds, trt_pipe, trt_mean, trt_std = trt_create_dataset_and_params(
+            "gpu", data_root, transform
+        )
+
+        assert isinstance(onnx_ds, FastInferenceDataset)
+        assert isinstance(trt_ds, FastInferenceDataset)
+        assert onnx_pipe == trt_pipe == "fast"
+        assert onnx_mean is trt_mean is None
+        assert onnx_std is trt_std is None
+
+    def test_gpu_with_valid_transform_is_same(self, tmp_path: Path) -> None:
+        """gpu + 正常 transform は両CLIで GpuInferenceDataset を使う."""
+        data_root = _make_data_root(tmp_path)
+        transform = _valid_transform()
+
+        onnx_ds, onnx_pipe, onnx_mean, onnx_std = onnx_create_dataset_and_params(
+            "gpu", data_root, transform
+        )
+        trt_ds, trt_pipe, trt_mean, trt_std = trt_create_dataset_and_params(
+            "gpu", data_root, transform
+        )
+
+        assert isinstance(onnx_ds, GpuInferenceDataset)
+        assert isinstance(trt_ds, GpuInferenceDataset)
+        assert onnx_pipe == trt_pipe == "gpu"
+        assert onnx_mean == trt_mean == [0.485, 0.456, 0.406]
+        assert onnx_std == trt_std == [0.229, 0.224, 0.225]
+
+
+class TestAutoResolutionDifference:
+    """ONNX/TRT 間の auto 解決仕様差を確認するテスト."""
+
+    def test_auto_behavior_difference_is_intended(self) -> None:
+        """ONNXのautoはuse_gpu依存, TRTのautoは常にgpu."""
+        onnx_auto_cpu = onnx_resolve_pipeline("auto", use_gpu=False, val_transform=None)
+        onnx_auto_gpu = onnx_resolve_pipeline("auto", use_gpu=True, val_transform=None)
+        trt_auto = trt_resolve_pipeline("auto")
+
+        assert onnx_auto_cpu == "fast"
+        assert onnx_auto_gpu == "gpu"
+        assert trt_auto == "gpu"


### PR DESCRIPTION
## Summary
- `tests/unit/test_cli/test_pipeline_consistency.py` を追加し, ONNX と TensorRT の pipeline 選択結果が同一条件で整合することを検証.
- `current`, `fast`, `gpu` の通常ケースに加えて, フォールバック経路も検証.
- `auto` の仕様差を明示的に検証. ONNX は `use_gpu` 依存, TRT は常に `gpu`.
- docstring は日本語で記述し, テストの意図が追いやすい形に整理.

## Code Changes

```python
# tests/unit/test_cli/test_pipeline_consistency.py
class TestPipelineConsistency:
    def test_current_pipeline_same_result(self, tmp_path: Path) -> None:
        ...

    def test_fast_pipeline_same_result(self, tmp_path: Path) -> None:
        ...

    def test_fast_with_pil_only_fallback_is_same(self, tmp_path: Path) -> None:
        ...

    def test_gpu_without_normalize_fallback_is_same(self, tmp_path: Path) -> None:
        ...

    def test_gpu_with_valid_transform_is_same(self, tmp_path: Path) -> None:
        ...

class TestAutoResolutionDifference:
    def test_auto_behavior_difference_is_intended(self) -> None:
        ...
```

## Test plan
- [x] `uv run pytest tests/unit/test_cli/test_pipeline_consistency.py`
- [x] `uv run pytest tests/unit/test_cli/test_pipeline_consistency.py tests/unit/test_cli/test_infer_onnx.py tests/unit/test_cli/test_infer_trt.py`

## Test result
- `tests/unit/test_cli/test_pipeline_consistency.py`: 6 passed.
- 上記 + 既存CLIテスト: 38 passed.