### PR TITLE
refactor: gpu_normalize の mean/std 再生成を解消して前処理を最適化

### DIFF
--- a/pochitrain/cli/infer_onnx.py
+++ b/pochitrain/cli/infer_onnx.py
@@ -27,6 +27,7 @@ from pochitrain.pochi_dataset import (
     PochiImageDataset,
     build_gpu_preprocess_transform,
     convert_transform_for_fast_inference,
+    create_scaled_normalize_tensors,
     extract_normalize_params,
     gpu_normalize,
 )
@@ -255,6 +256,12 @@ def main() -> None:
         pin_memory=pin_memory,
     )
 
+    mean_255 = None
+    std_255 = None
+    if use_gpu_pipeline:
+        assert norm_mean is not None and norm_std is not None
+        mean_255, std_255 = create_scaled_normalize_tensors(norm_mean, norm_std)
+
     # 使用されたtransformをログ出力
     if dataset.transform is not None:
         logger.debug(f"クラス: {dataset.get_classes()}")
@@ -293,8 +300,8 @@ def main() -> None:
     assert isinstance(warmup_image, torch.Tensor)
 
     if use_gpu_pipeline:
-        assert norm_mean is not None and norm_std is not None
-        warmup_gpu = gpu_normalize(warmup_image, norm_mean, norm_std)
+        assert mean_255 is not None and std_255 is not None
+        warmup_gpu = gpu_normalize(warmup_image, mean_255, std_255)
         for _ in range(10):
             inference.set_input_gpu(warmup_gpu)
             inference.run_pure()
@@ -338,8 +345,8 @@ def main() -> None:
     for batch_idx, (images, labels) in enumerate(data_loader):
         # 前処理: パイプラインに応じた入力準備
         if use_gpu_pipeline:
-            assert norm_mean is not None and norm_std is not None
-            gpu_tensor = gpu_normalize(images, norm_mean, norm_std)
+            assert mean_255 is not None and std_255 is not None
+            gpu_tensor = gpu_normalize(images, mean_255, std_255)
 
         if batch_idx == 0:
             # 最初のバッチは計測対象外（ウォームアップ）


### PR DESCRIPTION
## Summary
- `gpu_normalize()` を, 毎回 `mean/std` のリストからテンソルを生成する方式から, 事前計算済みテンソルを受け取る方式へ変更.
- `create_scaled_normalize_tensors()` を追加し, `mean_255/std_255` をループ外で1回だけ生成するように変更.
- `infer_onnx.py` と `infer_trt.py` の GPU パイプラインで, ウォームアップと推論ループの両方で事前計算済みテンソルを再利用.
- `tests/unit/test_core/test_pochi_dataset.py` に, 事前計算テンソル生成と `gpu_normalize()` の新仕様に対するユニットテストを追加.

## Code Changes

```python
# pochitrain/pochi_dataset.py

def gpu_normalize(images: Tensor, mean_255: Tensor, std_255: Tensor) -> Tensor:
    if images.dim() == 3:
        images = images.unsqueeze(0)
    device = mean_255.device
    images_float = images.to(device=device, dtype=torch.float32, non_blocking=True)
    return (images_float - mean_255) / std_255


def create_scaled_normalize_tensors(
    mean: List[float],
    std: List[float],
    device: Union[str, torch.device] = "cuda",
) -> Tuple[Tensor, Tensor]:
    mean_255 = torch.tensor(mean, device=device, dtype=torch.float32).view(1, 3, 1, 1)
    std_255 = torch.tensor(std, device=device, dtype=torch.float32).view(1, 3, 1, 1)
    return mean_255 * 255.0, std_255 * 255.0
```

```python
# pochitrain/cli/infer_onnx.py, pochitrain/cli/infer_trt.py
mean_255, std_255 = create_scaled_normalize_tensors(norm_mean, norm_std)
...
gpu_tensor = gpu_normalize(images, mean_255, std_255)
```

## Test plan
- [x] `uv run pytest tests/unit/test_core/test_pochi_dataset.py`
- [x] `uv run pytest tests/unit/test_core/test_pochi_dataset.py tests/unit/test_cli/test_infer_onnx.py tests/unit/test_cli/test_infer_trt.py tests/unit/test_cli/test_pipeline_consistency.py`

## Test result
- 対象テスト合計: `66 passed`
- 追加テスト:
  - `TestGpuNormalize::test_create_scaled_normalize_tensors_cpu`
  - `TestGpuNormalize::test_gpu_normalize_accepts_precomputed_tensors`