### PR TITLE
refactor: infer-onnx/infer-trt のデータセット生成処理を共通化

### DIFF
--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -18,16 +18,14 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
+from pochitrain.inference.pipeline_strategy import (
+    create_dataset_and_params as shared_create_dataset_and_params,
+)
 from pochitrain.logging import LoggerManager
 from pochitrain.logging.logger_manager import LogLevel
 from pochitrain.pochi_dataset import (
-    FastInferenceDataset,
-    GpuInferenceDataset,
     PochiImageDataset,
-    build_gpu_preprocess_transform,
-    convert_transform_for_fast_inference,
     create_scaled_normalize_tensors,
-    extract_normalize_params,
     get_basic_transforms,
     gpu_normalize,
 )
@@ -71,64 +69,17 @@ def _create_dataset_and_params(
     data_path: Path,
     val_transform: Any,
 ) -> Tuple[PochiImageDataset, str, Optional[List[float]], Optional[List[float]]]:
-    """パイプラインに応じたデータセットを作成する.
+    """パイプライン別データセット生成を共通処理へ委譲する.
 
     Args:
-        pipeline: パイプライン名 ("current", "fast", "gpu")
-        data_path: データディレクトリパス
-        val_transform: configのval_transform
+        pipeline: パイプライン名.
+        data_path: 推論対象データディレクトリ.
+        val_transform: 検証用 transform.
 
     Returns:
-        (dataset, 実際のパイプライン名, mean, std) のタプル.
-        mean/stdはgpuパイプライン時のみ値を持つ.
+        データセット, 実際に適用されたパイプライン名, mean, std.
     """
-    mean: Optional[List[float]] = None
-    std: Optional[List[float]] = None
-
-    if pipeline == "gpu":
-        # GPU前処理: Normalize/ToTensor/ConvertDtypeを除外したtransformを構築
-        gpu_transform = build_gpu_preprocess_transform(val_transform)
-        if gpu_transform is None:
-            # PIL専用transformが含まれる場合はcurrentにフォールバック
-            logger.info(
-                "PIL専用transformが含まれるため, currentパイプラインにフォールバックします"
-            )
-            dataset: PochiImageDataset = PochiImageDataset(
-                str(data_path), transform=val_transform
-            )
-            return dataset, "current", None, None
-
-        try:
-            mean, std = extract_normalize_params(val_transform)
-        except ValueError:
-            logger.warning(
-                "Normalizeが見つからないため, fastパイプラインにフォールバックします"
-            )
-            fast_transform = convert_transform_for_fast_inference(val_transform)
-            if fast_transform is not None:
-                dataset = FastInferenceDataset(str(data_path), transform=fast_transform)
-                return dataset, "fast", None, None
-            dataset = PochiImageDataset(str(data_path), transform=val_transform)
-            return dataset, "current", None, None
-
-        dataset = GpuInferenceDataset(
-            str(data_path),
-            transform=gpu_transform if gpu_transform.transforms else None,
-        )
-        return dataset, "gpu", mean, std
-
-    if pipeline == "fast":
-        fast_transform = convert_transform_for_fast_inference(val_transform)
-        if fast_transform is not None:
-            dataset = FastInferenceDataset(str(data_path), transform=fast_transform)
-            return dataset, "fast", None, None
-        logger.info("PochiImageDatasetにフォールバックします")
-        dataset = PochiImageDataset(str(data_path), transform=val_transform)
-        return dataset, "current", None, None
-
-    # current
-    dataset = PochiImageDataset(str(data_path), transform=val_transform)
-    return dataset, "current", None, None
+    return shared_create_dataset_and_params(pipeline, data_path, val_transform)
 
 
 def main() -> None:

--- a/pochitrain/inference/pipeline_strategy.py
+++ b/pochitrain/inference/pipeline_strategy.py
@@ -1,0 +1,180 @@
+"""推論パイプライン選択に応じたデータセット生成モジュール."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List, Optional, Protocol, Tuple
+
+from pochitrain.logging import LoggerManager
+from pochitrain.pochi_dataset import (
+    FastInferenceDataset,
+    GpuInferenceDataset,
+    PochiImageDataset,
+    build_gpu_preprocess_transform,
+    convert_transform_for_fast_inference,
+    extract_normalize_params,
+)
+
+logger = LoggerManager().get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class DatasetBuildResult:
+    """データセット生成結果."""
+
+    dataset: PochiImageDataset
+    pipeline: str
+    mean: Optional[List[float]]
+    std: Optional[List[float]]
+
+
+class IPipelineStrategy(Protocol):
+    """パイプライン処理インターフェース."""
+
+    def build(self, data_path: Path, val_transform: Any) -> DatasetBuildResult:
+        """パイプライン戦略に応じたデータセットを生成する.
+
+        Args:
+            data_path: 推論対象データディレクトリ.
+            val_transform: 検証用 transform.
+
+        Returns:
+            生成したデータセットと付随情報.
+        """
+
+
+class CurrentPipelineStrategy:
+    """current パイプライン処理."""
+
+    def build(self, data_path: Path, val_transform: Any) -> DatasetBuildResult:
+        """Current パイプライン用のデータセットを生成する.
+
+        Args:
+            data_path: 推論対象データディレクトリ.
+            val_transform: 検証用 transform.
+
+        Returns:
+            current パイプラインのデータセット生成結果.
+        """
+        dataset = PochiImageDataset(str(data_path), transform=val_transform)
+        return DatasetBuildResult(
+            dataset=dataset, pipeline="current", mean=None, std=None
+        )
+
+
+class FastPipelineStrategy:
+    """fast パイプライン処理."""
+
+    def build(self, data_path: Path, val_transform: Any) -> DatasetBuildResult:
+        """Fast パイプライン用のデータセットを生成する.
+
+        Args:
+            data_path: 推論対象データディレクトリ.
+            val_transform: 検証用 transform.
+
+        Returns:
+            fast パイプライン, またはフォールバック先の生成結果.
+        """
+        fast_transform = convert_transform_for_fast_inference(val_transform)
+        if fast_transform is not None:
+            dataset = FastInferenceDataset(str(data_path), transform=fast_transform)
+            return DatasetBuildResult(
+                dataset=dataset, pipeline="fast", mean=None, std=None
+            )
+
+        logger.info("PochiImageDatasetにフォールバックします")
+        dataset = PochiImageDataset(str(data_path), transform=val_transform)
+        return DatasetBuildResult(
+            dataset=dataset, pipeline="current", mean=None, std=None
+        )
+
+
+class GpuPipelineStrategy:
+    """gpu パイプライン処理."""
+
+    def build(self, data_path: Path, val_transform: Any) -> DatasetBuildResult:
+        """Gpu パイプライン用のデータセットを生成する.
+
+        Args:
+            data_path: 推論対象データディレクトリ.
+            val_transform: 検証用 transform.
+
+        Returns:
+            gpu パイプライン, またはフォールバック先の生成結果.
+        """
+        gpu_transform = build_gpu_preprocess_transform(val_transform)
+        if gpu_transform is None:
+            logger.info(
+                "PIL専用transformが含まれるため, currentパイプラインにフォールバックします"
+            )
+            dataset = PochiImageDataset(str(data_path), transform=val_transform)
+            return DatasetBuildResult(
+                dataset=dataset, pipeline="current", mean=None, std=None
+            )
+
+        try:
+            mean, std = extract_normalize_params(val_transform)
+        except ValueError:
+            logger.warning(
+                "Normalizeが見つからないため, fastパイプラインにフォールバックします"
+            )
+            fast_result = FastPipelineStrategy().build(data_path, val_transform)
+            return DatasetBuildResult(
+                dataset=fast_result.dataset,
+                pipeline=fast_result.pipeline,
+                mean=None,
+                std=None,
+            )
+
+        dataset = GpuInferenceDataset(
+            str(data_path),
+            transform=gpu_transform if gpu_transform.transforms else None,
+        )
+        return DatasetBuildResult(dataset=dataset, pipeline="gpu", mean=mean, std=std)
+
+
+class PipelineStrategyFactory:
+    """パイプライン処理ファクトリー."""
+
+    _strategy_map: dict[str, IPipelineStrategy] = {
+        "current": CurrentPipelineStrategy(),
+        "fast": FastPipelineStrategy(),
+        "gpu": GpuPipelineStrategy(),
+    }
+
+    @classmethod
+    def create(cls, pipeline: str) -> IPipelineStrategy:
+        """パイプライン名から戦略を返す.
+
+        Args:
+            pipeline: パイプライン名.
+
+        Returns:
+            対応する戦略インスタンス.
+
+        Raises:
+            ValueError: 未対応のパイプライン名が指定された場合.
+        """
+        try:
+            return cls._strategy_map[pipeline]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported pipeline: {pipeline}") from exc
+
+
+def create_dataset_and_params(
+    pipeline: str,
+    data_path: Path,
+    val_transform: Any,
+) -> Tuple[PochiImageDataset, str, Optional[List[float]], Optional[List[float]]]:
+    """パイプラインに応じたデータセットと正規化パラメータを返す.
+
+    Args:
+        pipeline: パイプライン名.
+        data_path: 推論対象データディレクトリ.
+        val_transform: 検証用 transform.
+
+    Returns:
+        データセット, 実際に適用されたパイプライン名, mean, std.
+    """
+    strategy = PipelineStrategyFactory.create(pipeline)
+    result = strategy.build(data_path, val_transform)
+    return result.dataset, result.pipeline, result.mean, result.std


### PR DESCRIPTION
## Summary
- `pochitrain/inference/pipeline_strategy.py` を新規追加し, `current/fast/gpu` のデータセット生成戦略を `Strategy + Factory` で共通化.
- `infer_onnx.py` と `infer_trt.py` の `_create_dataset_and_params()` を共通戦略への委譲に置換.
- 両 CLI から, 共通化後に不要になった `FastInferenceDataset` などの import を削除.
- 挙動は維持しつつ, 重複ロジックを単一モジュールへ集約.

## Code Changes

```python
# pochitrain/inference/pipeline_strategy.py
@dataclass(frozen=True)
class DatasetBuildResult:
    dataset: PochiImageDataset
    pipeline: str
    mean: Optional[List[float]]
    std: Optional[List[float]]


def create_dataset_and_params(
    pipeline: str,
    data_path: Path,
    val_transform: Any,
) -> Tuple[PochiImageDataset, str, Optional[List[float]], Optional[List[float]]]:
    strategy = PipelineStrategyFactory.create(pipeline)
    result = strategy.build(data_path, val_transform)
    return result.dataset, result.pipeline, result.mean, result.std
```

```python
# pochitrain/cli/infer_onnx.py / pochitrain/cli/infer_trt.py
from pochitrain.inference.pipeline_strategy import (
    create_dataset_and_params as shared_create_dataset_and_params,
)


def _create_dataset_and_params(...):
    """パイプライン別データセット生成を共通戦略へ委譲する."""
    return shared_create_dataset_and_params(pipeline, data_path, val_transform)
```

## Test plan
- [x] `uv run pytest tests/unit/test_cli/test_pipeline_consistency.py tests/unit/test_cli/test_infer_onnx.py tests/unit/test_cli/test_infer_trt.py -q`

## Test result
- 対象テスト合計: `38 passed`