### PR TITLE
refactor: infer_onnx/infer_trt の責務をCLI入出力制御へ限定しオーケストレーションをサービス化

### DIFF
--- a/pochitrain/inference/__init__.py
+++ b/pochitrain/inference/__init__.py
@@ -1,9 +1,17 @@
 """Pochitrainの推論サポートモジュール."""
 
-from .services import ExecutionService, ResultExportService
+from .services import (
+    ExecutionService,
+    OnnxInferenceService,
+    ResultExportService,
+    TensorRTInferenceService,
+)
 from .types import (
     ExecutionRequest,
     ExecutionResult,
+    InferenceCliRequest,
+    InferenceResolvedPaths,
+    InferenceRuntimeOptions,
     ResultExportRequest,
     ResultExportResult,
 )
@@ -11,8 +19,13 @@ from .types import (
 __all__ = [
     "ExecutionService",
     "ResultExportService",
+    "OnnxInferenceService",
+    "TensorRTInferenceService",
     "ExecutionRequest",
     "ExecutionResult",
+    "InferenceCliRequest",
+    "InferenceResolvedPaths",
+    "InferenceRuntimeOptions",
     "ResultExportRequest",
     "ResultExportResult",
 ]

--- a/pochitrain/inference/services/__init__.py
+++ b/pochitrain/inference/services/__init__.py
@@ -1,6 +1,13 @@
 """推論サービスモジュール."""
 
 from .execution_service import ExecutionService
+from .onnx_inference_service import OnnxInferenceService
 from .result_export_service import ResultExportService
+from .trt_inference_service import TensorRTInferenceService
 
-__all__ = ["ExecutionService", "ResultExportService"]
+__all__ = [
+    "ExecutionService",
+    "ResultExportService",
+    "OnnxInferenceService",
+    "TensorRTInferenceService",
+]

--- a/pochitrain/inference/services/onnx_inference_service.py
+++ b/pochitrain/inference/services/onnx_inference_service.py
@@ -1,0 +1,125 @@
+"""ONNX推論CLI向けのオーケストレーション補助サービス."""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from pochitrain.inference.types.orchestration_types import (
+    InferenceCliRequest,
+    InferenceResolvedPaths,
+    InferenceRuntimeOptions,
+)
+from pochitrain.utils import (
+    get_default_output_base_dir,
+    validate_data_path,
+)
+from pochitrain.utils.directory_manager import InferenceWorkspaceManager
+
+
+class OnnxInferenceService:
+    """ONNX推論CLIで必要な解決処理を提供するサービス."""
+
+    def resolve_paths(
+        self,
+        request: InferenceCliRequest,
+        config: Dict[str, Any],
+    ) -> InferenceResolvedPaths:
+        """データパスと出力先を解決する.
+
+        Args:
+            request: CLI入力を格納した共通リクエスト.
+            config: 設定辞書.
+
+        Returns:
+            解決済みのパス情報.
+
+        Raises:
+            ValueError: データパス解決に失敗した場合.
+        """
+        if request.data_path is not None:
+            data_path = request.data_path
+        elif "val_data_root" in config:
+            data_path = Path(config["val_data_root"])
+        else:
+            raise ValueError(
+                "--data を指定するか, configにval_data_rootを設定してください"
+            )
+
+        validate_data_path(data_path)
+
+        if request.output_dir is not None:
+            output_dir = request.output_dir
+            output_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            base_dir = get_default_output_base_dir(request.model_path)
+            workspace_manager = InferenceWorkspaceManager(str(base_dir))
+            output_dir = workspace_manager.create_workspace()
+
+        return InferenceResolvedPaths(
+            model_path=request.model_path,
+            data_path=data_path,
+            output_dir=output_dir,
+        )
+
+    def resolve_pipeline(
+        self,
+        requested: str,
+        use_gpu: bool,
+    ) -> str:
+        """ONNX推論で実際に使うパイプライン名を解決する.
+
+        Args:
+            requested: ユーザー指定パイプライン.
+            use_gpu: ONNX推論がGPUを使うかどうか.
+
+        Returns:
+            解決後パイプライン名.
+        """
+        if requested != "auto":
+            if requested == "gpu" and not use_gpu:
+                return "fast"
+            return requested
+
+        return "gpu" if use_gpu else "fast"
+
+    def resolve_runtime_options(
+        self,
+        config: Dict[str, Any],
+        pipeline: str,
+        use_gpu: bool,
+    ) -> InferenceRuntimeOptions:
+        """ONNX推論向け実行オプションを構築する.
+
+        Args:
+            config: 設定辞書.
+            pipeline: 解決済みパイプライン名.
+            use_gpu: ONNX推論がGPUを使うかどうか.
+
+        Returns:
+            推論実行オプション.
+        """
+        return InferenceRuntimeOptions(
+            pipeline=pipeline,
+            batch_size=int(config.get("batch_size", 1)),
+            num_workers=int(config.get("num_workers", 0)),
+            pin_memory=bool(config.get("pin_memory", True)),
+            use_gpu=use_gpu,
+            use_gpu_pipeline=pipeline == "gpu",
+        )
+
+    def resolve_input_size(self, shape: Any) -> Optional[tuple[int, int, int]]:
+        """ONNX入力形状から入力サイズを解決する.
+
+        Args:
+            shape: ONNXの入力shape.
+
+        Returns:
+            入力サイズ (C, H, W). 解決できない場合はNone.
+        """
+        if len(shape) != 4:
+            return None
+        c = shape[1] if isinstance(shape[1], int) else 3
+        h = shape[2] if isinstance(shape[2], int) else None
+        w = shape[3] if isinstance(shape[3], int) else None
+        if h and w:
+            return (c, h, w)
+        return None

--- a/pochitrain/inference/services/trt_inference_service.py
+++ b/pochitrain/inference/services/trt_inference_service.py
@@ -1,0 +1,110 @@
+"""TensorRT推論CLI向けのオーケストレーション補助サービス."""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from pochitrain.inference.types.orchestration_types import (
+    InferenceCliRequest,
+    InferenceResolvedPaths,
+    InferenceRuntimeOptions,
+)
+from pochitrain.utils import (
+    get_default_output_base_dir,
+    validate_data_path,
+)
+from pochitrain.utils.directory_manager import InferenceWorkspaceManager
+
+
+class TensorRTInferenceService:
+    """TensorRT推論CLIで必要な解決処理を提供するサービス."""
+
+    def resolve_paths(
+        self,
+        request: InferenceCliRequest,
+        config: Dict[str, Any],
+    ) -> InferenceResolvedPaths:
+        """データパスと出力先を解決する.
+
+        Args:
+            request: CLI入力を格納した共通リクエスト.
+            config: 設定辞書.
+
+        Returns:
+            解決済みのパス情報.
+
+        Raises:
+            ValueError: データパス解決に失敗した場合.
+        """
+        if request.data_path is not None:
+            data_path = request.data_path
+        elif "val_data_root" in config:
+            data_path = Path(config["val_data_root"])
+        else:
+            raise ValueError(
+                "--data を指定するか, configにval_data_rootを設定してください"
+            )
+
+        validate_data_path(data_path)
+
+        if request.output_dir is not None:
+            output_dir = request.output_dir
+            output_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            base_dir = get_default_output_base_dir(request.model_path)
+            workspace_manager = InferenceWorkspaceManager(str(base_dir))
+            output_dir = workspace_manager.create_workspace()
+
+        return InferenceResolvedPaths(
+            model_path=request.model_path,
+            data_path=data_path,
+            output_dir=output_dir,
+        )
+
+    def resolve_pipeline(self, requested: str) -> str:
+        """TensorRT推論で実際に使うパイプライン名を解決する.
+
+        Args:
+            requested: ユーザー指定パイプライン.
+
+        Returns:
+            解決後パイプライン名.
+        """
+        if requested == "auto":
+            return "gpu"
+        return requested
+
+    def resolve_runtime_options(
+        self,
+        config: Dict[str, Any],
+        pipeline: str,
+    ) -> InferenceRuntimeOptions:
+        """TensorRT推論向け実行オプションを構築する.
+
+        Args:
+            config: 設定辞書.
+            pipeline: 解決済みパイプライン名.
+
+        Returns:
+            推論実行オプション.
+        """
+        return InferenceRuntimeOptions(
+            pipeline=pipeline,
+            batch_size=1,
+            num_workers=int(config.get("num_workers", 0)),
+            pin_memory=bool(config.get("pin_memory", True)),
+            use_gpu=True,
+            use_gpu_pipeline=pipeline == "gpu",
+        )
+
+    def resolve_input_size(self, shape: Any) -> Optional[tuple[int, int, int]]:
+        """TensorRT入力形状から入力サイズを解決する.
+
+        Args:
+            shape: TensorRT入力shape.
+
+        Returns:
+            入力サイズ (C, H, W). 解決できない場合はNone.
+        """
+        if len(shape) != 4:
+            return None
+        return (shape[1], shape[2], shape[3])

--- a/pochitrain/inference/types/__init__.py
+++ b/pochitrain/inference/types/__init__.py
@@ -1,11 +1,19 @@
 """推論共通型モジュール."""
 
 from .execution_types import ExecutionRequest, ExecutionResult
+from .orchestration_types import (
+    InferenceCliRequest,
+    InferenceResolvedPaths,
+    InferenceRuntimeOptions,
+)
 from .result_export_types import ResultExportRequest, ResultExportResult
 
 __all__ = [
     "ExecutionRequest",
     "ExecutionResult",
+    "InferenceCliRequest",
+    "InferenceResolvedPaths",
+    "InferenceRuntimeOptions",
     "ResultExportRequest",
     "ResultExportResult",
 ]

--- a/pochitrain/inference/types/orchestration_types.py
+++ b/pochitrain/inference/types/orchestration_types.py
@@ -1,0 +1,58 @@
+"""推論CLIオーケストレーションで共有する型定義."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class InferenceCliRequest:
+    """推論CLIからオーケストレーション層へ渡す共通入力.
+
+    Args:
+        model_path: モデルファイルパス.
+        data_path: 推論データディレクトリ. 未指定時は設定ファイルから解決する.
+        output_dir: 結果出力ディレクトリ. 未指定時はモデル位置から自動解決する.
+        requested_pipeline: ユーザー指定のパイプライン名.
+    """
+
+    model_path: Path
+    data_path: Optional[Path]
+    output_dir: Optional[Path]
+    requested_pipeline: str
+
+
+@dataclass(frozen=True)
+class InferenceResolvedPaths:
+    """推論前に解決済みのパス群.
+
+    Args:
+        model_path: モデルファイルパス.
+        data_path: 推論データディレクトリ.
+        output_dir: 結果出力ディレクトリ.
+    """
+
+    model_path: Path
+    data_path: Path
+    output_dir: Path
+
+
+@dataclass(frozen=True)
+class InferenceRuntimeOptions:
+    """推論実行時の共通オプション.
+
+    Args:
+        pipeline: 解決後のパイプライン名.
+        batch_size: DataLoaderのバッチサイズ.
+        num_workers: DataLoaderのワーカー数.
+        pin_memory: DataLoaderのpin_memory設定.
+        use_gpu: 推論ランタイムがGPUを使うかどうか.
+        use_gpu_pipeline: 前処理パイプラインがGPUを使うかどうか.
+    """
+
+    pipeline: str
+    batch_size: int
+    num_workers: int
+    pin_memory: bool
+    use_gpu: bool
+    use_gpu_pipeline: bool

--- a/tests/unit/test_cli/test_infer_onnx.py
+++ b/tests/unit/test_cli/test_infer_onnx.py
@@ -1,6 +1,6 @@
 """infer_onnx CLIのテスト.
 
-ONNX推論CLIの引数パース・パイプライン解決をテスト.
+ONNX推論CLIの引数パースと入口導線をテスト.
 実際のONNX推論はtest_onnx/test_inference.pyでテスト済み.
 """
 
@@ -11,8 +11,6 @@ import pytest
 
 pytest.importorskip("onnx")
 pytest.importorskip("onnxruntime")
-
-from pochitrain.cli.infer_onnx import _resolve_pipeline
 
 
 class TestInferOnnxArgumentParsing:
@@ -88,40 +86,6 @@ class TestInferOnnxMainExit:
         with patch("sys.argv", ["infer-onnx", fake_model]):
             with pytest.raises(SystemExit):
                 main()
-
-
-class TestResolvePipeline:
-    """_resolve_pipeline関数のテスト."""
-
-    def test_auto_with_gpu_returns_gpu(self):
-        """auto + GPU推論 → gpu."""
-        result = _resolve_pipeline("auto", use_gpu=True, val_transform=None)
-        assert result == "gpu"
-
-    def test_auto_without_gpu_returns_fast(self):
-        """auto + CPU推論 → fast."""
-        result = _resolve_pipeline("auto", use_gpu=False, val_transform=None)
-        assert result == "fast"
-
-    def test_current_passthrough(self):
-        """current指定時はそのまま返す."""
-        result = _resolve_pipeline("current", use_gpu=True, val_transform=None)
-        assert result == "current"
-
-    def test_fast_passthrough(self):
-        """fast指定時はそのまま返す."""
-        result = _resolve_pipeline("fast", use_gpu=False, val_transform=None)
-        assert result == "fast"
-
-    def test_gpu_with_gpu_available(self):
-        """gpu指定 + GPU推論 → gpu."""
-        result = _resolve_pipeline("gpu", use_gpu=True, val_transform=None)
-        assert result == "gpu"
-
-    def test_gpu_without_gpu_falls_back_to_fast(self):
-        """gpu指定 + CPU推論 → fastにフォールバック."""
-        result = _resolve_pipeline("gpu", use_gpu=False, val_transform=None)
-        assert result == "fast"
 
 
 class TestGpuFallbackReresolution:

--- a/tests/unit/test_cli/test_pipeline_consistency.py
+++ b/tests/unit/test_cli/test_pipeline_consistency.py
@@ -12,11 +12,11 @@ pytest.importorskip("onnxruntime")
 from pochitrain.cli.infer_onnx import (
     _create_dataset_and_params as onnx_create_dataset_and_params,
 )
-from pochitrain.cli.infer_onnx import _resolve_pipeline as onnx_resolve_pipeline
 from pochitrain.cli.infer_trt import (
     _create_dataset_and_params as trt_create_dataset_and_params,
 )
-from pochitrain.cli.infer_trt import _resolve_pipeline as trt_resolve_pipeline
+from pochitrain.inference.services.onnx_inference_service import OnnxInferenceService
+from pochitrain.inference.services.trt_inference_service import TensorRTInferenceService
 from pochitrain.pochi_dataset import (
     FastInferenceDataset,
     GpuInferenceDataset,
@@ -157,9 +157,12 @@ class TestAutoResolutionDifference:
 
     def test_auto_behavior_difference_is_intended(self) -> None:
         """ONNXのautoはuse_gpu依存, TRTのautoは常にgpu."""
-        onnx_auto_cpu = onnx_resolve_pipeline("auto", use_gpu=False, val_transform=None)
-        onnx_auto_gpu = onnx_resolve_pipeline("auto", use_gpu=True, val_transform=None)
-        trt_auto = trt_resolve_pipeline("auto")
+        onnx_service = OnnxInferenceService()
+        trt_service = TensorRTInferenceService()
+
+        onnx_auto_cpu = onnx_service.resolve_pipeline("auto", use_gpu=False)
+        onnx_auto_gpu = onnx_service.resolve_pipeline("auto", use_gpu=True)
+        trt_auto = trt_service.resolve_pipeline("auto")
 
         assert onnx_auto_cpu == "fast"
         assert onnx_auto_gpu == "gpu"

--- a/tests/unit/test_core/test_inference_public_api.py
+++ b/tests/unit/test_core/test_inference_public_api.py
@@ -8,8 +8,13 @@ def test_public_api_exports_expected_symbols():
     expected = {
         "ExecutionService",
         "ResultExportService",
+        "OnnxInferenceService",
+        "TensorRTInferenceService",
         "ExecutionRequest",
         "ExecutionResult",
+        "InferenceCliRequest",
+        "InferenceResolvedPaths",
+        "InferenceRuntimeOptions",
         "ResultExportRequest",
         "ResultExportResult",
     }

--- a/tests/unit/test_inference/test_onnx_inference_service.py
+++ b/tests/unit/test_inference/test_onnx_inference_service.py
@@ -1,0 +1,94 @@
+"""OnnxInferenceService のテスト."""
+
+from pathlib import Path
+
+import pytest
+
+from pochitrain.inference.services.onnx_inference_service import OnnxInferenceService
+from pochitrain.inference.types.orchestration_types import InferenceCliRequest
+
+
+class TestResolvePipeline:
+    """resolve_pipeline のテスト."""
+
+    def test_auto_with_gpu_returns_gpu(self):
+        """auto + GPU推論なら gpu を返す."""
+        service = OnnxInferenceService()
+        assert service.resolve_pipeline("auto", use_gpu=True) == "gpu"
+
+    def test_auto_without_gpu_returns_fast(self):
+        """auto + CPU推論なら fast を返す."""
+        service = OnnxInferenceService()
+        assert service.resolve_pipeline("auto", use_gpu=False) == "fast"
+
+    def test_gpu_without_gpu_falls_back_to_fast(self):
+        """gpu指定でもGPU不可なら fast にフォールバックする."""
+        service = OnnxInferenceService()
+        assert service.resolve_pipeline("gpu", use_gpu=False) == "fast"
+
+
+class TestResolvePaths:
+    """resolve_paths のテスト."""
+
+    def test_resolve_paths_with_explicit_data_and_output(self, tmp_path: Path):
+        """--data, --output 指定時にその値を採用する."""
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        output_dir = tmp_path / "out"
+
+        request = InferenceCliRequest(
+            model_path=tmp_path / "model.onnx",
+            data_path=data_path,
+            output_dir=output_dir,
+            requested_pipeline="auto",
+        )
+        resolved = OnnxInferenceService().resolve_paths(request, config={})
+
+        assert resolved.data_path == data_path
+        assert resolved.output_dir == output_dir
+        assert output_dir.exists()
+
+    def test_resolve_paths_raises_when_data_is_unresolved(self, tmp_path: Path):
+        """データパス未指定かつconfig未設定なら ValueError."""
+        request = InferenceCliRequest(
+            model_path=tmp_path / "model.onnx",
+            data_path=None,
+            output_dir=tmp_path / "out",
+            requested_pipeline="auto",
+        )
+
+        with pytest.raises(ValueError):
+            OnnxInferenceService().resolve_paths(request, config={})
+
+
+class TestResolveRuntimeOptions:
+    """resolve_runtime_options のテスト."""
+
+    def test_runtime_options_from_config(self):
+        """設定値から実行オプションを組み立てる."""
+        service = OnnxInferenceService()
+        options = service.resolve_runtime_options(
+            config={"batch_size": 8, "num_workers": 4, "pin_memory": False},
+            pipeline="gpu",
+            use_gpu=True,
+        )
+
+        assert options.batch_size == 8
+        assert options.num_workers == 4
+        assert options.pin_memory is False
+        assert options.use_gpu is True
+        assert options.use_gpu_pipeline is True
+
+
+class TestResolveInputSize:
+    """resolve_input_size のテスト."""
+
+    def test_resolve_input_size_returns_tuple_when_shape_is_static(self):
+        """静的shapeなら (C, H, W) を返す."""
+        service = OnnxInferenceService()
+        assert service.resolve_input_size([1, 3, 224, 224]) == (3, 224, 224)
+
+    def test_resolve_input_size_returns_none_when_shape_is_dynamic(self):
+        """空間次元が動的なら None を返す."""
+        service = OnnxInferenceService()
+        assert service.resolve_input_size([1, 3, "h", "w"]) is None

--- a/tests/unit/test_inference/test_trt_inference_service.py
+++ b/tests/unit/test_inference/test_trt_inference_service.py
@@ -1,0 +1,88 @@
+"""TensorRTInferenceService のテスト."""
+
+from pathlib import Path
+
+import pytest
+
+from pochitrain.inference.services.trt_inference_service import TensorRTInferenceService
+from pochitrain.inference.types.orchestration_types import InferenceCliRequest
+
+
+class TestResolvePipeline:
+    """resolve_pipeline のテスト."""
+
+    def test_auto_returns_gpu(self):
+        """auto 指定時は gpu に解決される."""
+        service = TensorRTInferenceService()
+        assert service.resolve_pipeline("auto") == "gpu"
+
+    def test_passthrough_for_non_auto(self):
+        """auto 以外はそのまま返す."""
+        service = TensorRTInferenceService()
+        assert service.resolve_pipeline("fast") == "fast"
+
+
+class TestResolvePaths:
+    """resolve_paths のテスト."""
+
+    def test_resolve_paths_with_explicit_data_and_output(self, tmp_path: Path):
+        """--data, --output 指定時にその値を採用する."""
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        output_dir = tmp_path / "out"
+
+        request = InferenceCliRequest(
+            model_path=tmp_path / "model.engine",
+            data_path=data_path,
+            output_dir=output_dir,
+            requested_pipeline="auto",
+        )
+        resolved = TensorRTInferenceService().resolve_paths(request, config={})
+
+        assert resolved.data_path == data_path
+        assert resolved.output_dir == output_dir
+        assert output_dir.exists()
+
+    def test_resolve_paths_raises_when_data_is_unresolved(self, tmp_path: Path):
+        """データパス未指定かつconfig未設定なら ValueError."""
+        request = InferenceCliRequest(
+            model_path=tmp_path / "model.engine",
+            data_path=None,
+            output_dir=tmp_path / "out",
+            requested_pipeline="auto",
+        )
+
+        with pytest.raises(ValueError):
+            TensorRTInferenceService().resolve_paths(request, config={})
+
+
+class TestResolveRuntimeOptions:
+    """resolve_runtime_options のテスト."""
+
+    def test_runtime_options_use_tensorrt_defaults(self):
+        """TensorRT実行向けの固定値を組み立てる."""
+        service = TensorRTInferenceService()
+        options = service.resolve_runtime_options(
+            config={"num_workers": 2, "pin_memory": False},
+            pipeline="gpu",
+        )
+
+        assert options.batch_size == 1
+        assert options.num_workers == 2
+        assert options.pin_memory is False
+        assert options.use_gpu is True
+        assert options.use_gpu_pipeline is True
+
+
+class TestResolveInputSize:
+    """resolve_input_size のテスト."""
+
+    def test_resolve_input_size_returns_tuple_when_shape_is_4d(self):
+        """4次元shapeなら (C, H, W) を返す."""
+        service = TensorRTInferenceService()
+        assert service.resolve_input_size([1, 3, 224, 224]) == (3, 224, 224)
+
+    def test_resolve_input_size_returns_none_when_shape_is_not_4d(self):
+        """4次元でないshapeなら None を返す."""
+        service = TensorRTInferenceService()
+        assert service.resolve_input_size([1, 3, 224]) is None


### PR DESCRIPTION
## Summary
- `OnnxInferenceService` / `TensorRTInferenceService` を追加し, CLI側のパス解決, パイプライン解決, 実行オプション解決をサービス化.
- `InferenceCliRequest` / `InferenceResolvedPaths` / `InferenceRuntimeOptions` を追加し, オーケストレーション入出力を型で明確化.
- `infer_onnx.py` / `infer_trt.py` から private な `_resolve_pipeline` を削除し, `service.resolve_*` 呼び出しへ置換.
- CLIは `args parse -> config load -> service call -> ExecutionService / ResultExportService` の流れへ整理.
- テスト責務を再編し, パイプライン解決テストをCLIからサービス層へ移動.
- `test_pipeline_consistency.py` の `_resolve_pipeline` 依存を解消し, サービスAPI参照へ更新.

## Code Changes

```python
# pochitrain/cli/infer_onnx.py
orchestration_service = OnnxInferenceService()
resolved_paths = orchestration_service.resolve_paths(cli_request, config)
pipeline = orchestration_service.resolve_pipeline(args.pipeline, use_gpu)
runtime_options = orchestration_service.resolve_runtime_options(
    config=config,
    pipeline=pipeline,
    use_gpu=use_gpu,
)
input_size = orchestration_service.resolve_input_size(shape)
```

```python
# pochitrain/inference/services/onnx_inference_service.py
class OnnxInferenceService:
    def resolve_paths(self, request: InferenceCliRequest, config: Dict[str, Any]) -> InferenceResolvedPaths:
        ...

    def resolve_pipeline(self, requested: str, use_gpu: bool) -> str:
        ...

    def resolve_runtime_options(self, config: Dict[str, Any], pipeline: str, use_gpu: bool) -> InferenceRuntimeOptions:
        ...

    def resolve_input_size(self, shape: Any) -> Optional[tuple[int, int, int]]:
        ...
```

```python
# tests/unit/test_inference/test_onnx_inference_service.py
def test_auto_without_gpu_returns_fast(self):
    service = OnnxInferenceService()
    assert service.resolve_pipeline("auto", use_gpu=False) == "fast"
```

## Test plan
- [x] `uv run pytest tests/unit/test_cli/test_infer_onnx.py -q`
- [x] `uv run pytest tests/unit/test_cli/test_infer_trt.py -q`
- [x] `uv run pytest tests/unit/test_cli/test_infer_onnx.py tests/unit/test_cli/test_infer_trt.py tests/unit/test_inference/test_onnx_inference_service.py tests/unit/test_inference/test_trt_inference_service.py -q`
- [x] `uv run mypy tests/unit/test_cli/test_pipeline_consistency.py`
- [x] `uv run pytest tests/unit/test_core/test_inference_public_api.py -q`

## Test result
- CLI + service関連テスト: `33 passed`
- ONNX CLI単体: `17 passed`
- TRT CLI単体: `7 passed`
- 公開APIテスト単体: `3 passed`