### PR TITLE
test: 推論CLI関連テストを責務別に再編し低価値テストを削減

### DIFF
--- a/tests/unit/test_cli/test_infer_onnx.py
+++ b/tests/unit/test_cli/test_infer_onnx.py
@@ -1,70 +1,14 @@
-"""infer_onnx CLIのテスト.
+"""infer_onnx CLIの入口導線テスト.
 
-ONNX推論CLIの引数パースと入口導線をテスト.
-実際のONNX推論はtest_onnx/test_inference.pyでテスト済み.
+実際のONNX推論ロジックは test_onnx/test_inference.py でテスト済み.
 """
 
-import argparse
 from unittest.mock import patch
 
 import pytest
 
 pytest.importorskip("onnx")
 pytest.importorskip("onnxruntime")
-
-
-class TestInferOnnxArgumentParsing:
-    """infer_onnx CLIの引数パースのテスト."""
-
-    def _build_parser(self):
-        """テスト用にinfer_onnxと同等のパーサーを構築."""
-        parser = argparse.ArgumentParser(description="ONNXモデルを使用した推論")
-        parser.add_argument("model_path", help="ONNXモデルファイルパス")
-        parser.add_argument("--data", help="推論データディレクトリ")
-        parser.add_argument("--output", "-o", help="結果出力ディレクトリ")
-        return parser
-
-    def test_model_path_required(self):
-        """model_pathが必須引数であることを確認."""
-        parser = self._build_parser()
-        with pytest.raises(SystemExit):
-            parser.parse_args([])
-
-    def test_model_path_parsed(self):
-        """model_pathが正しくパースされる."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.onnx"])
-        assert args.model_path == "model.onnx"
-
-    def test_data_option(self):
-        """--dataオプションが正しくパースされる."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.onnx", "--data", "data/val"])
-        assert args.data == "data/val"
-
-    def test_output_option(self):
-        """--outputオプションが正しくパースされる."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.onnx", "--output", "results/"])
-        assert args.output == "results/"
-
-    def test_output_short_option(self):
-        """-oオプションが正しくパースされる."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.onnx", "-o", "results/"])
-        assert args.output == "results/"
-
-    def test_data_default_none(self):
-        """--data未指定時はNone."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.onnx"])
-        assert args.data is None
-
-    def test_output_default_none(self):
-        """--output未指定時はNone."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.onnx"])
-        assert args.output is None
 
 
 class TestInferOnnxMainExit:

--- a/tests/unit/test_cli/test_infer_trt.py
+++ b/tests/unit/test_cli/test_infer_trt.py
@@ -1,65 +1,27 @@
-"""infer_trt CLIのテスト.
+"""infer_trt CLIの入口導線テスト."""
 
-TensorRT推論CLIの引数パースをテスト.
-TensorRTはオプション依存のためインポートチェックでスキップ.
-"""
-
-import argparse
+from unittest.mock import patch
 
 import pytest
 
+from pochitrain.cli.infer_trt import PIPELINE_CHOICES, main
 
-class TestInferTrtArgumentParsing:
-    """infer_trt CLIの引数パースのテスト."""
 
-    def _build_parser(self):
-        """テスト用にinfer_trtと同等のパーサーを構築."""
-        parser = argparse.ArgumentParser(
-            description="TensorRTエンジンを使用した高速推論"
-        )
-        parser.add_argument("engine_path", help="TensorRTエンジンファイルパス")
-        parser.add_argument("--data", help="推論データディレクトリ")
-        parser.add_argument("--output", "-o", help="結果出力ディレクトリ")
-        return parser
+def test_pipeline_choices_are_expected() -> None:
+    """公開されるパイプライン候補が期待どおりであることを確認する."""
+    assert PIPELINE_CHOICES == ("auto", "current", "fast", "gpu")
 
-    def test_engine_path_required(self):
-        """engine_pathが必須引数であることを確認."""
-        parser = self._build_parser()
+
+def test_main_no_args_exits() -> None:
+    """引数なしでは argparse により SystemExit する."""
+    with patch("sys.argv", ["infer-trt"]):
         with pytest.raises(SystemExit):
-            parser.parse_args([])
+            main()
 
-    def test_engine_path_parsed(self):
-        """engine_pathが正しくパースされる."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.engine"])
-        assert args.engine_path == "model.engine"
 
-    def test_data_option(self):
-        """--dataオプションが正しくパースされる."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.engine", "--data", "data/val"])
-        assert args.data == "data/val"
-
-    def test_output_option(self):
-        """--outputオプションが正しくパースされる."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.engine", "--output", "results/"])
-        assert args.output == "results/"
-
-    def test_output_short_option(self):
-        """-oオプションが正しくパースされる."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.engine", "-o", "results/"])
-        assert args.output == "results/"
-
-    def test_data_default_none(self):
-        """--data未指定時はNone."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.engine"])
-        assert args.data is None
-
-    def test_output_default_none(self):
-        """--output未指定時はNone."""
-        parser = self._build_parser()
-        args = parser.parse_args(["model.engine"])
-        assert args.output is None
+def test_main_nonexistent_engine_exits(tmp_path) -> None:
+    """存在しないエンジンパス指定で SystemExit する."""
+    fake_engine = str(tmp_path / "nonexistent.engine")
+    with patch("sys.argv", ["infer-trt", fake_engine]):
+        with pytest.raises(SystemExit):
+            main()


### PR DESCRIPTION
## Summary
- `tests/unit/test_cli/test_infer_onnx.py` から, `argparse` をテスト内で再実装する低価値テストを削除し, `main()` 実経路テストへ集約.
- `tests/unit/test_cli/test_infer_trt.py` を同様に再編し, 再実装パーサーテストを廃止して入口導線の最小スモークテストへ置換.
- `tests/unit/test_inference/test_result_export_service.py` の正常系を実ファイル出力検証へ変更し, 過剰モックを削減.
- 失敗系テストは, 補助成果物出力の失敗箇所のみ最小限にモックする形へ整理.
- 上記により, 推論CLI関連テストで `151` 行削減しつつ回帰確認を維持.

## Code Changes

```python
# tests/unit/test_cli/test_infer_trt.py
def test_main_no_args_exits() -> None:
    with patch("sys.argv", ["infer-trt"]):
        with pytest.raises(SystemExit):
            main()
```

```python
# tests/unit/test_inference/test_result_export_service.py
def test_export_writes_all_artifacts(tmp_path: Path):
    request = _build_request(tmp_path)
    result = ResultExportService(logger=MagicMock()).export(request)

    assert result.results_csv_path.exists()
    assert result.summary_path.exists()
    assert result.confusion_matrix_path.exists()
    assert result.classification_report_path.exists()
```

```python
# tests/unit/test_cli/test_infer_onnx.py
# 旧: テスト内に argparse 再実装 (_build_parser)
# 新: 実コード main() を通す入口導線テストに一本化
```

## Test plan
- [x] `uv run pytest tests/unit/test_cli/test_infer_onnx.py tests/unit/test_cli/test_infer_trt.py tests/unit/test_inference/test_result_export_service.py -q`
- [x] `uv run pytest tests/unit/test_inference/test_execution_service.py tests/unit/test_inference/test_onnx_inference_service.py tests/unit/test_inference/test_trt_inference_service.py tests/unit/test_cli/test_pipeline_consistency.py -q`

## Test result
- `test_infer_onnx / test_infer_trt / test_result_export_service`: `9 passed`
- `execution_service / onnx_inference_service / trt_inference_service / pipeline_consistency`: `24 passed`