### PR TITLE
chore: pre-commit pytest 高速化と可視化テストの安定化

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: uv run pytest
+        entry: uv run --no-sync pytest -q -n 6 --dist=worksteal
         language: system
         pass_filenames: false
         always_run: true

--- a/pochitrain/visualization/metrics_exporter.py
+++ b/pochitrain/visualization/metrics_exporter.py
@@ -10,6 +10,10 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import matplotlib
+
+# 画像ファイル出力のみを行うため、GUIバックエンド依存を避ける.
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 from pochitrain.exporters import BaseCSVExporter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ add-ignore = ["D212"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v -n 6 --dist=loadscope"
+addopts = "-v -n 6 --dist=worksteal"
 markers = [
     "slow: marks tests as slow",
     "integration: marks tests as integration tests",


### PR DESCRIPTION
## Summary
- `.pre-commit-config.yaml` の pytest hook を `uv run --no-sync pytest -q -n 6 --dist=worksteal` に変更し, pre-commit 実行時間を短縮.
- `pyproject.toml` の pytest 既定オプションを `-v -n 6 --dist=worksteal` に変更し, 全体テストの並列実行を実測最適値へ固定.
- `loadscope` と `worksteal` を同条件で3回ずつ比較し, `worksteal` が安定して速いことを確認.
- `pochitrain/visualization/metrics_exporter.py` で `matplotlib.use("Agg")` を `pyplot` import より前に設定し, Windows 環境で稀発する `_tkinter.TclError` を抑止.

## Code Changes

```python
# .pre-commit-config.yaml
- entry: uv run pytest
+ entry: uv run --no-sync pytest -q -n 6 --dist=worksteal
```

```python
# pyproject.toml
[tool.pytest.ini_options]
-addopts = "-v -n 6 --dist=loadscope"
+addopts = "-v -n 6 --dist=worksteal"
```

```python
# pochitrain/visualization/metrics_exporter.py
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
```

## Test plan
- [x] `uv run --no-sync pytest -q -n 6 --dist=loadscope` を3回実行.
- [x] `uv run --no-sync pytest -q -n 6 --dist=worksteal` を3回実行.
- [x] `uv run --no-sync pytest tests/unit/test_visualization/test_metrics_exporter.py -q -n 6 --dist=worksteal`

## Test result
- 分散方式比較:
  - `loadscope`: `9.43s`, `9.30s`, `9.18s`
  - `worksteal`: `8.99s`, `8.96s`, `8.77s`
- 可視化テスト: `12 passed in 5.15s`