### PR TITLE
release: v1.4.3 のバージョン番号を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pochitrain
 
-[![Version](https://img.shields.io/badge/version-1.4.2-blue.svg)](https://github.com/kurorosu/pochitrain)
+[![Version](https://img.shields.io/badge/version-1.4.3-blue.svg)](https://github.com/kurorosu/pochitrain)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.13+-yellow.svg)](https://www.python.org/)
 [![Jetson](https://img.shields.io/badge/Jetson-JetPack%206.2.1%20%28Python%203.10%29-76B900.svg)](https://developer.nvidia.com/embedded/jetpack)

--- a/pochitrain/__init__.py
+++ b/pochitrain/__init__.py
@@ -29,7 +29,7 @@ from .pochi_trainer import PochiTrainer
 # ユーティリティ
 from .utils.directory_manager import InferenceWorkspaceManager, PochiWorkspaceManager
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 __author__ = "Pochi Team"
 __email__ = "pochi@example.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochitrain"
-version = "1.4.2"
+version = "1.4.3"
 description = "Simple CNN training framework for image classification"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ wheels = [
 
 [[package]]
 name = "pochitrain"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
## Summary
- `pyproject.toml`, `pochitrain/__init__.py`, `README.md` のバージョンを 1.4.2 → 1.4.3 に更新
- `uv lock` でロックファイルを同期

## Changes since v1.4.2

### Features
- 推論CLIに GPU前処理パイプラインと `--pipeline` 切替フラグを追加
- `FastInferenceDataset` を導入し画像読み込みレイテンシを改善

### Bug Fixes
- `export-onnx` の `--input-size` に正の整数バリデーションを追加
- CUDA EP不可時に `infer-onnx` の GPU パイプラインを CPU へフォールバック
- 3つの推論CLIのCUDA時間計測方法をONNX方式に統一
- `matplotlib_fontja` 未導入でも混同行列出力を継続できるように修正

### Refactoring
- 推論CLIの責務分離: ExecutionService + Adapter, ResultExportService, サービス層分離
- `gpu_normalize` の mean/std 再生成を解消して前処理を最適化
- `infer-onnx` / `infer-trt` にDataLoader導入, パイプライン共通化
- テストのデータセット作成ロジックを conftest.py フィクスチャに共通化

### Tests
- テストスイート全面監査: モック依存削減, 低価値テスト整理, 実オブジェクト中心に再編
- CLI/validation/inferenceテストを堅牢化
- pytest 並列実行の既定化と重いテスト最適化で実行時間を短縮

### Chores
- Jetson向け依存方針をREADMEとrequirementsに反映
- `requirements.txt` に ONNX と開発用依存を追加