### PR TITLE
refactor: PochiTrainer訓練フローをTrainingLoop/EpochRunnerへ分離し状態管理を強化

### DIFF
--- a/pochitrain/optimization/objective.py
+++ b/pochitrain/optimization/objective.py
@@ -110,7 +110,7 @@ class ClassificationObjective(IObjectiveFunction):
 
         for epoch in range(1, self._optuna_epochs + 1):
             # 1エポック訓練
-            trainer.train_epoch(self._train_loader)
+            trainer.train_one_epoch(epoch=epoch, train_loader=self._train_loader)
 
             # 検証
             val_metrics = trainer.validate(self._val_loader)

--- a/pochitrain/pochi_trainer.py
+++ b/pochitrain/pochi_trainer.py
@@ -19,9 +19,10 @@ from .logging import LoggerManager
 from .models.pochi_models import create_model
 from .training.checkpoint_store import CheckpointStore
 from .training.early_stopping import EarlyStopping
+from .training.epoch_runner import EpochRunner
 from .training.evaluator import Evaluator
-from .training.metrics_tracker import MetricsTracker
 from .training.training_configurator import TrainingConfigurator
+from .training.training_loop import TrainingLoop
 from .utils.directory_manager import PochiWorkspaceManager
 
 
@@ -94,6 +95,7 @@ class PochiTrainer:
 
         # 訓練コンフィギュレータの初期化
         self.training_configurator = TrainingConfigurator(self.device, self.logger)
+        self.epoch_runner = EpochRunner(device=self.device, logger=self.logger)
 
         # モデルの作成
         self.model = create_model(model_name, num_classes, pretrained)
@@ -238,61 +240,88 @@ class PochiTrainer:
                 f"monitor={self.early_stopping.monitor})"
             )
 
-    def train_epoch(self, train_loader: DataLoader) -> Dict[str, float]:
-        """1エポックの訓練."""
-        self.model.train()
-        total_loss = 0.0
-        correct = 0
-        total = 0
+    def _ensure_training_configured(self) -> None:
+        """訓練に必要なコンポーネントが設定済みか検証.
 
-        for batch_idx, (data, target) in enumerate(train_loader):
-            data, target = data.to(self.device), target.to(self.device)
+        Raises:
+            RuntimeError: setup_training() が未実行の場合.
+        """
+        if self.optimizer is None or self.criterion is None:
+            raise RuntimeError(
+                "訓練コンポーネントが未設定です. "
+                "train() の前に setup_training() を呼び出してください."
+            )
 
-            # 勾配をゼロにリセット
-            if self.optimizer is not None:
-                self.optimizer.zero_grad()
+    def _require_training_components(self) -> tuple[optim.Optimizer, nn.Module]:
+        """訓練に必要なコンポーネントを取得.
 
-            # 順伝播
-            output = self.model(data)
-            if self.criterion is not None:
-                loss = self.criterion(output, target)
-            else:
-                raise RuntimeError("criterion is not set")
+        Returns:
+            tuple[optim.Optimizer, nn.Module]: (optimizer, criterion).
 
-            # 逆伝播
-            loss.backward()
-            if self.optimizer is not None:
-                self.optimizer.step()
+        Raises:
+            RuntimeError: setup_training() が未実行の場合.
+        """
+        self._ensure_training_configured()
+        if self.optimizer is None or self.criterion is None:
+            # mypy向けの型保証. 実運用上は _ensure_training_configured で到達しない.
+            raise RuntimeError(
+                "訓練コンポーネントが未設定です. "
+                "train() の前に setup_training() を呼び出してください."
+            )
+        return self.optimizer, self.criterion
 
-            # 統計情報の更新
-            batch_size = target.size(0)
-            total_loss += loss.item() * batch_size
-            _, predicted = output.max(1)
-            total += batch_size
-            correct += predicted.eq(target).sum().item()
+    def _require_criterion(self) -> nn.Module:
+        """損失関数を取得.
 
-            # ログ出力
-            if batch_idx % 100 == 0:
-                self.logger.debug(
-                    f"エポック {self.epoch}, バッチ {batch_idx}/{len(train_loader)}, "
-                    f"損失: {loss.item():.4f}, 精度: {100.0 * correct / total:.2f}%"
-                )
+        Returns:
+            nn.Module: criterion.
 
-        # エポックの統計情報
-        # 例外回避のための防御的ガード. 本来はバリデーションで止めるのが望ましい
-        avg_loss = total_loss / total if total > 0 else 0.0
-        accuracy = 100.0 * correct / total if total > 0 else 0.0
+        Raises:
+            RuntimeError: criterion が未設定の場合.
+        """
+        if self.criterion is None:
+            raise RuntimeError("criterion is not set")
+        return self.criterion
 
-        return {"loss": avg_loss, "accuracy": accuracy}
+    def _set_epoch(self, epoch: int) -> None:
+        """現在エポックを更新."""
+        self.epoch = epoch
+
+    def _run_train_epoch(self, train_loader: DataLoader[Any]) -> Dict[str, float]:
+        """1エポック訓練を実行."""
+        optimizer, criterion = self._require_training_components()
+        return self.epoch_runner.run(
+            model=self.model,
+            optimizer=optimizer,
+            criterion=criterion,
+            train_loader=train_loader,
+            epoch=self.epoch,
+        )
+
+    def train_one_epoch(
+        self,
+        epoch: int,
+        train_loader: DataLoader[Any],
+    ) -> Dict[str, float]:
+        """指定エポックで1エポック訓練を実行.
+
+        Args:
+            epoch: 実行するエポック番号.
+            train_loader: 訓練データローダー.
+
+        Returns:
+            Dict[str, float]: 訓練メトリクス.
+        """
+        self._set_epoch(epoch)
+        return self._run_train_epoch(train_loader)
 
     def validate(self, val_loader: DataLoader[Any]) -> Dict[str, float]:
         """検証 (Evaluator に委譲)."""
-        if self.criterion is None:
-            raise RuntimeError("criterion is not set")
+        criterion = self._require_criterion()
         return self.evaluator.validate(
             model=self.model,
             val_loader=val_loader,
-            criterion=self.criterion,
+            criterion=criterion,
             num_classes_for_cm=self.num_classes_for_cm,
             epoch=self.epoch,
             workspace_path=self.current_workspace,
@@ -314,162 +343,50 @@ class PochiTrainer:
             epochs (int): エポック数
             stop_flag_callback (callable, optional): 停止フラグをチェックするコールバック関数
         """
+        self._ensure_training_configured()
         self.logger.debug(f"訓練を開始 - エポック数: {epochs}")
 
-        # MetricsTrackerの初期化（ワークスペースがある場合のみ）
-        tracker = None
-        if self.current_workspace is not None:
-            tracker = MetricsTracker(
-                logger=self.logger,
-                visualization_dir=self.workspace_manager.get_visualization_dir(),
-                enable_metrics_export=self.enable_metrics_export,
-                enable_gradient_tracking=self.enable_gradient_tracking,
-                gradient_tracking_config=self.gradient_tracking_config,
-                layer_wise_lr_graph_config=self.layer_wise_lr_graph_config,
-            )
-            tracker.initialize()
+        training_loop = TrainingLoop(
+            logger=self.logger,
+            checkpoint_store=self.checkpoint_store,
+            early_stopping=self.early_stopping,
+        )
 
-        for epoch in range(1, epochs + 1):
-            self.epoch = epoch
+        visualization_dir = (
+            self.workspace_manager.get_visualization_dir()
+            if self.current_workspace is not None
+            else None
+        )
+        tracker = TrainingLoop.create_metrics_tracker(
+            logger=self.logger,
+            current_workspace=self.current_workspace,
+            visualization_dir=visualization_dir,
+            enable_metrics_export=self.enable_metrics_export,
+            enable_gradient_tracking=self.enable_gradient_tracking,
+            gradient_tracking_config=self.gradient_tracking_config,
+            layer_wise_lr_graph_config=self.layer_wise_lr_graph_config,
+        )
 
-            # 停止フラグのチェック（エポック開始前）
-            if stop_flag_callback and stop_flag_callback():
-                self.logger.warning(
-                    f"安全停止が要求されました。エポック {epoch-1} で訓練を終了します。"
-                )
-                self.checkpoint_store.save_last_model(
-                    epoch=self.epoch,
-                    model=self.model,
-                    optimizer=self.optimizer,
-                    scheduler=self.scheduler,
-                    best_accuracy=self.best_accuracy,
-                )  # 現在の状態を保存
-                break
+        last_epoch, best_accuracy = training_loop.run(
+            epochs=epochs,
+            train_epoch_fn=self._run_train_epoch,
+            validate_fn=self.validate,
+            train_loader=train_loader,
+            val_loader=val_loader,
+            model=self.model,
+            optimizer=self.optimizer,
+            scheduler=self.scheduler,
+            tracker=tracker,
+            get_learning_rate_fn=self._get_base_learning_rate,
+            get_layer_wise_rates_fn=self.get_layer_wise_learning_rates,
+            is_layer_wise_lr_fn=self.is_layer_wise_lr_enabled,
+            initial_best_accuracy=self.best_accuracy,
+            set_epoch_fn=self._set_epoch,
+            stop_flag_callback=stop_flag_callback,
+        )
 
-            self.logger.debug(f"エポック {epoch}/{epochs} を開始")
-
-            # 1エポック訓練
-            train_metrics = self.train_epoch(train_loader)
-
-            # 検証
-            val_metrics = {}
-            if val_loader:
-                val_metrics = self.validate(val_loader)
-
-            # スケジューラーの更新
-            if self.scheduler is not None:
-                self.scheduler.step()
-
-            # ログ出力
-            self.logger.info(
-                f"エポック {epoch} 完了 - "
-                f"訓練損失: {train_metrics['loss']:.4f}, "
-                f"訓練精度: {train_metrics['accuracy']:.2f}%"
-            )
-
-            if val_metrics:
-                self.logger.info(
-                    f"検証損失: {val_metrics['val_loss']:.4f}, "
-                    f"検証精度: {val_metrics['val_accuracy']:.2f}%"
-                )
-
-                # ベストモデルの更新（精度が前回以上なら保存）
-                if val_metrics["val_accuracy"] >= self.best_accuracy:
-                    self.best_accuracy = val_metrics["val_accuracy"]
-                    self.checkpoint_store.save_best_model(
-                        epoch=epoch,
-                        model=self.model,
-                        optimizer=self.optimizer,
-                        scheduler=self.scheduler,
-                        best_accuracy=self.best_accuracy,
-                    )
-
-                # Early Stopping判定
-                if self.early_stopping is not None:
-                    monitor = self.early_stopping.monitor
-                    monitor_value = val_metrics.get(monitor)
-                    if monitor_value is not None:
-                        if self.early_stopping.step(monitor_value, epoch):
-                            self.checkpoint_store.save_last_model(
-                                epoch=self.epoch,
-                                model=self.model,
-                                optimizer=self.optimizer,
-                                scheduler=self.scheduler,
-                                best_accuracy=self.best_accuracy,
-                            )
-                            break
-
-            # ラストモデルの保存（毎エポック上書き）
-            self.checkpoint_store.save_last_model(
-                epoch=self.epoch,
-                model=self.model,
-                optimizer=self.optimizer,
-                scheduler=self.scheduler,
-                best_accuracy=self.best_accuracy,
-            )
-
-            # メトリクスと勾配の記録
-            if tracker is not None:
-                layer_wise_rates = {}
-                if self.is_layer_wise_lr_enabled():
-                    layer_rates = self.get_layer_wise_learning_rates()
-                    for layer_name, lr in layer_rates.items():
-                        layer_wise_rates[f"lr_{layer_name}"] = lr
-
-                tracker.record_epoch(
-                    epoch=epoch,
-                    train_metrics=train_metrics,
-                    val_metrics=val_metrics,
-                    model=self.model,
-                    learning_rate=self._get_base_learning_rate(),
-                    layer_wise_lr_enabled=self.is_layer_wise_lr_enabled(),
-                    layer_wise_rates=layer_wise_rates,
-                )
-
-            # 停止フラグのチェック（エポック完了後）
-            if stop_flag_callback and stop_flag_callback():
-                self.logger.warning(
-                    f"安全停止が要求されました。エポック {epoch} で訓練を終了します。"
-                )
-                break
-
-        # Early Stoppingによる停止の場合、その旨をログ出力
-        if self.early_stopping is not None and self.early_stopping.should_stop:
-            self.logger.info(
-                f"Early Stoppingにより訓練を停止しました "
-                f"(最終エポック: {self.epoch}, "
-                f"ベスト{self.early_stopping.monitor}: "
-                f"{self.early_stopping.best_value:.4f}, "
-                f"ベストエポック: {self.early_stopping.best_epoch})"
-            )
-        else:
-            self.logger.info("訓練が完了しました")
-        if val_loader:
-            self.logger.info(f"最高精度: {self.best_accuracy:.2f}%")
-
-        # 訓練完了後のエクスポート処理
-        if tracker is not None:
-            csv_path, graph_paths = tracker.finalize()
-            if csv_path:
-                self.logger.info(f"メトリクスCSVを出力: {csv_path}")
-            if graph_paths:
-                for graph_path in graph_paths:
-                    self.logger.info(f"メトリクスグラフを出力: {graph_path}")
-
-            # サマリー情報の表示
-            summary = tracker.get_summary()
-            if summary:
-                self.logger.info("=== 訓練サマリー ===")
-                self.logger.info(f"総エポック数: {summary['total_epochs']}")
-                self.logger.info(f"最終訓練損失: {summary['final_train_loss']:.4f}")
-                self.logger.info(
-                    f"最終訓練精度: {summary['final_train_accuracy']:.2f}%"
-                )
-                if "best_val_accuracy" in summary:
-                    self.logger.info(
-                        f"最高検証精度: {summary['best_val_accuracy']:.2f}% "
-                        f"(エポック {summary['best_val_accuracy_epoch']})"
-                    )
+        self.epoch = last_epoch
+        self.best_accuracy = best_accuracy
 
     def _get_base_learning_rate(self) -> float:
         """現在の基本学習率を取得.

--- a/pochitrain/training/__init__.py
+++ b/pochitrain/training/__init__.py
@@ -2,15 +2,19 @@
 
 from .checkpoint_store import CheckpointStore
 from .early_stopping import EarlyStopping
+from .epoch_runner import EpochRunner
 from .evaluator import Evaluator
 from .metrics_tracker import MetricsTracker
 from .training_configurator import TrainingComponents, TrainingConfigurator
+from .training_loop import TrainingLoop
 
 __all__ = [
     "CheckpointStore",
     "EarlyStopping",
+    "EpochRunner",
     "Evaluator",
     "MetricsTracker",
     "TrainingComponents",
     "TrainingConfigurator",
+    "TrainingLoop",
 ]

--- a/pochitrain/training/epoch_runner.py
+++ b/pochitrain/training/epoch_runner.py
@@ -1,0 +1,75 @@
+"""pochitrain.training.epoch_runner: 1エポック訓練実行モジュール."""
+
+import logging
+from typing import Any, Dict
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+
+
+class EpochRunner:
+    """1エポック分の訓練処理を実行する.
+
+    Args:
+        device: 訓練デバイス.
+        logger: ロガーインスタンス.
+    """
+
+    def __init__(self, device: torch.device, logger: logging.Logger) -> None:
+        """EpochRunnerを初期化."""
+        self.device = device
+        self.logger = logger
+
+    def run(
+        self,
+        model: nn.Module,
+        optimizer: optim.Optimizer,
+        criterion: nn.Module,
+        train_loader: DataLoader[Any],
+        epoch: int,
+    ) -> Dict[str, float]:
+        """1エポック訓練を実行.
+
+        Args:
+            model: 訓練対象モデル.
+            optimizer: オプティマイザ.
+            criterion: 損失関数.
+            train_loader: 訓練データローダー.
+            epoch: 現在のエポック番号.
+
+        Returns:
+            Dict[str, float]: {"loss": 平均損失, "accuracy": 精度}.
+        """
+        model.train()
+        total_loss = 0.0
+        correct = 0
+        total = 0
+
+        for batch_idx, (data, target) in enumerate(train_loader):
+            data, target = data.to(self.device), target.to(self.device)
+
+            optimizer.zero_grad()
+            output = model(data)
+            loss = criterion(output, target)
+
+            loss.backward()
+            optimizer.step()
+
+            batch_size = target.size(0)
+            total_loss += loss.item() * batch_size
+            _, predicted = output.max(1)
+            total += batch_size
+            correct += predicted.eq(target).sum().item()
+
+            if batch_idx % 100 == 0:
+                self.logger.debug(
+                    f"エポック {epoch}, バッチ {batch_idx}/{len(train_loader)}, "
+                    f"損失: {loss.item():.4f}, 精度: {100.0 * correct / total:.2f}%"
+                )
+
+        # 例外回避のための防御的ガード. 本来はバリデーションで止めるのが望ましい.
+        avg_loss = total_loss / total if total > 0 else 0.0
+        accuracy = 100.0 * correct / total if total > 0 else 0.0
+        return {"loss": avg_loss, "accuracy": accuracy}

--- a/pochitrain/training/training_loop.py
+++ b/pochitrain/training/training_loop.py
@@ -1,0 +1,396 @@
+"""pochitrain.training.training_loop: エポックサイクルの実行を管理するモジュール."""
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+
+from .checkpoint_store import CheckpointStore
+from .early_stopping import EarlyStopping
+from .metrics_tracker import MetricsTracker
+
+
+class TrainingLoop:
+    """訓練ループの実行を管理するクラス.
+
+    エポックサイクル（訓練・検証・チェックポイント保存・メトリクス記録）を
+    一元管理し, PochiTrainer から訓練ループの詳細を分離する.
+
+    Args:
+        logger: ロガーインスタンス.
+        checkpoint_store: チェックポイント保存を管理するストア.
+        early_stopping: Early Stopping設定. 無効の場合はNone.
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        checkpoint_store: CheckpointStore,
+        early_stopping: Optional[EarlyStopping],
+    ) -> None:
+        """TrainingLoopを初期化."""
+        self.logger = logger
+        self.checkpoint_store = checkpoint_store
+        self.early_stopping = early_stopping
+
+    def run(
+        self,
+        epochs: int,
+        train_epoch_fn: Callable[[DataLoader[Any]], Dict[str, float]],
+        validate_fn: Callable[[DataLoader[Any]], Dict[str, float]],
+        train_loader: DataLoader[Any],
+        val_loader: Optional[DataLoader[Any]],
+        model: nn.Module,
+        optimizer: Optional[optim.Optimizer],
+        scheduler: Optional[optim.lr_scheduler.LRScheduler],
+        tracker: Optional[MetricsTracker],
+        get_learning_rate_fn: Callable[[], float],
+        get_layer_wise_rates_fn: Callable[[], Dict[str, float]],
+        is_layer_wise_lr_fn: Callable[[], bool],
+        initial_best_accuracy: float = 0.0,
+        set_epoch_fn: Optional[Callable[[int], None]] = None,
+        stop_flag_callback: Optional[Any] = None,
+    ) -> tuple[int, float]:
+        """訓練ループを実行.
+
+        Args:
+            epochs: 総エポック数.
+            train_epoch_fn: 1エポック訓練を実行する関数.
+            validate_fn: 検証を実行する関数.
+            train_loader: 訓練データローダー.
+            val_loader: 検証データローダー.
+            model: モデル.
+            optimizer: オプティマイザ.
+            scheduler: スケジューラ.
+            tracker: メトリクストラッカー.
+            get_learning_rate_fn: 現在の学習率を取得する関数.
+            get_layer_wise_rates_fn: 層別学習率を取得する関数.
+            is_layer_wise_lr_fn: 層別学習率が有効か判定する関数.
+            initial_best_accuracy: 学習開始時点のベスト精度.
+            set_epoch_fn: 現在エポックを更新する関数.
+            stop_flag_callback: 停止フラグをチェックするコールバック関数.
+
+        Returns:
+            tuple[int, float]: (最終エポック番号, ベスト精度).
+        """
+        best_accuracy = initial_best_accuracy
+        last_epoch = 0
+
+        for epoch in range(1, epochs + 1):
+            last_epoch = epoch
+            if set_epoch_fn is not None:
+                set_epoch_fn(epoch)
+
+            # 停止フラグのチェック（エポック開始前）
+            if stop_flag_callback and stop_flag_callback():
+                self.logger.warning(
+                    f"安全停止が要求されました。エポック {epoch-1} で訓練を終了します。"
+                )
+                self._save_last_checkpoint(
+                    epoch, model, optimizer, scheduler, best_accuracy
+                )
+                break
+
+            self.logger.debug(f"エポック {epoch}/{epochs} を開始")
+
+            # 1エポックの訓練・検証・更新サイクル
+            best_accuracy, should_stop = self._run_epoch_cycle(
+                epoch=epoch,
+                train_epoch_fn=train_epoch_fn,
+                validate_fn=validate_fn,
+                train_loader=train_loader,
+                val_loader=val_loader,
+                model=model,
+                optimizer=optimizer,
+                scheduler=scheduler,
+                tracker=tracker,
+                best_accuracy=best_accuracy,
+                get_learning_rate_fn=get_learning_rate_fn,
+                get_layer_wise_rates_fn=get_layer_wise_rates_fn,
+                is_layer_wise_lr_fn=is_layer_wise_lr_fn,
+            )
+            if should_stop:
+                break
+
+            # 停止フラグのチェック（エポック完了後）
+            if stop_flag_callback and stop_flag_callback():
+                self.logger.warning(
+                    f"安全停止が要求されました。エポック {epoch} で訓練を終了します。"
+                )
+                break
+
+        self._log_training_result(val_loader, last_epoch, best_accuracy)
+        self._finalize_metrics(tracker)
+
+        return last_epoch, best_accuracy
+
+    def _run_epoch_cycle(
+        self,
+        epoch: int,
+        train_epoch_fn: Callable[[DataLoader[Any]], Dict[str, float]],
+        validate_fn: Callable[[DataLoader[Any]], Dict[str, float]],
+        train_loader: DataLoader[Any],
+        val_loader: Optional[DataLoader[Any]],
+        model: nn.Module,
+        optimizer: Optional[optim.Optimizer],
+        scheduler: Optional[optim.lr_scheduler.LRScheduler],
+        tracker: Optional[MetricsTracker],
+        best_accuracy: float,
+        get_learning_rate_fn: Callable[[], float],
+        get_layer_wise_rates_fn: Callable[[], Dict[str, float]],
+        is_layer_wise_lr_fn: Callable[[], bool],
+    ) -> tuple[float, bool]:
+        """1エポックの訓練・検証・記録サイクルを実行.
+
+        Args:
+            epoch: 現在のエポック番号.
+            train_epoch_fn: 1エポック訓練を実行する関数.
+            validate_fn: 検証を実行する関数.
+            train_loader: 訓練データローダー.
+            val_loader: 検証データローダー.
+            model: モデル.
+            optimizer: オプティマイザ.
+            scheduler: スケジューラ.
+            tracker: メトリクストラッカー.
+            best_accuracy: 現在のベスト精度.
+            get_learning_rate_fn: 現在の学習率を取得する関数.
+            get_layer_wise_rates_fn: 層別学習率を取得する関数.
+            is_layer_wise_lr_fn: 層別学習率が有効か判定する関数.
+
+        Returns:
+            tuple[float, bool]: (更新後のベスト精度, 訓練を停止すべきか).
+        """
+        train_metrics = train_epoch_fn(train_loader)
+
+        val_metrics: Dict[str, float] = {}
+        if val_loader:
+            val_metrics = validate_fn(val_loader)
+
+        if scheduler is not None:
+            scheduler.step()
+
+        # ログ出力
+        self.logger.info(
+            f"エポック {epoch} 完了 - "
+            f"訓練損失: {train_metrics['loss']:.4f}, "
+            f"訓練精度: {train_metrics['accuracy']:.2f}%"
+        )
+
+        should_stop = False
+        if val_metrics:
+            self.logger.info(
+                f"検証損失: {val_metrics['val_loss']:.4f}, "
+                f"検証精度: {val_metrics['val_accuracy']:.2f}%"
+            )
+            best_accuracy, should_stop = self._update_best_and_check_early_stop(
+                epoch, val_metrics, model, optimizer, scheduler, best_accuracy
+            )
+
+        self._save_last_checkpoint(epoch, model, optimizer, scheduler, best_accuracy)
+        self._record_metrics(
+            tracker,
+            epoch,
+            train_metrics,
+            val_metrics,
+            model,
+            get_learning_rate_fn,
+            get_layer_wise_rates_fn,
+            is_layer_wise_lr_fn,
+        )
+
+        return best_accuracy, should_stop
+
+    def _update_best_and_check_early_stop(
+        self,
+        epoch: int,
+        val_metrics: Dict[str, float],
+        model: nn.Module,
+        optimizer: Optional[optim.Optimizer],
+        scheduler: Optional[optim.lr_scheduler.LRScheduler],
+        best_accuracy: float,
+    ) -> tuple[float, bool]:
+        """ベストモデル更新とEarly Stopping判定.
+
+        Args:
+            epoch: 現在のエポック番号.
+            val_metrics: 検証メトリクス.
+            model: モデル.
+            optimizer: オプティマイザ.
+            scheduler: スケジューラ.
+            best_accuracy: 現在のベスト精度.
+
+        Returns:
+            tuple[float, bool]: (更新後のベスト精度, 訓練を停止すべきか).
+        """
+        if val_metrics["val_accuracy"] >= best_accuracy:
+            best_accuracy = val_metrics["val_accuracy"]
+            self.checkpoint_store.save_best_model(
+                epoch=epoch,
+                model=model,
+                optimizer=optimizer,
+                scheduler=scheduler,
+                best_accuracy=best_accuracy,
+            )
+
+        if self.early_stopping is not None:
+            monitor = self.early_stopping.monitor
+            monitor_value = val_metrics.get(monitor)
+            if monitor_value is not None:
+                if self.early_stopping.step(monitor_value, epoch):
+                    return best_accuracy, True
+
+        return best_accuracy, False
+
+    def _save_last_checkpoint(
+        self,
+        epoch: int,
+        model: nn.Module,
+        optimizer: Optional[optim.Optimizer],
+        scheduler: Optional[optim.lr_scheduler.LRScheduler],
+        best_accuracy: float,
+    ) -> None:
+        """現在の状態をラストチェックポイントとして保存."""
+        self.checkpoint_store.save_last_model(
+            epoch=epoch,
+            model=model,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            best_accuracy=best_accuracy,
+        )
+
+    def _record_metrics(
+        self,
+        tracker: Optional[MetricsTracker],
+        epoch: int,
+        train_metrics: Dict[str, float],
+        val_metrics: Dict[str, float],
+        model: nn.Module,
+        get_learning_rate_fn: Callable[[], float],
+        get_layer_wise_rates_fn: Callable[[], Dict[str, float]],
+        is_layer_wise_lr_fn: Callable[[], bool],
+    ) -> None:
+        """メトリクスと勾配をトラッカーに記録.
+
+        Args:
+            tracker: メトリクストラッカー.
+            epoch: 現在のエポック番号.
+            train_metrics: 訓練メトリクス.
+            val_metrics: 検証メトリクス.
+            model: モデル.
+            get_learning_rate_fn: 現在の学習率を取得する関数.
+            get_layer_wise_rates_fn: 層別学習率を取得する関数.
+            is_layer_wise_lr_fn: 層別学習率が有効か判定する関数.
+        """
+        if tracker is None:
+            return
+
+        layer_wise_rates: Dict[str, float] = {}
+        if is_layer_wise_lr_fn():
+            layer_rates = get_layer_wise_rates_fn()
+            for layer_name, lr in layer_rates.items():
+                layer_wise_rates[f"lr_{layer_name}"] = lr
+
+        tracker.record_epoch(
+            epoch=epoch,
+            train_metrics=train_metrics,
+            val_metrics=val_metrics,
+            model=model,
+            learning_rate=get_learning_rate_fn(),
+            layer_wise_lr_enabled=is_layer_wise_lr_fn(),
+            layer_wise_rates=layer_wise_rates,
+        )
+
+    def _log_training_result(
+        self,
+        val_loader: Optional[DataLoader[Any]],
+        last_epoch: int,
+        best_accuracy: float,
+    ) -> None:
+        """訓練完了後のサマリーログを出力.
+
+        Args:
+            val_loader: 検証データローダー（ベスト精度表示の判定用）.
+            last_epoch: 最終エポック番号.
+            best_accuracy: ベスト精度.
+        """
+        if self.early_stopping is not None and self.early_stopping.should_stop:
+            self.logger.info(
+                f"Early Stoppingにより訓練を停止しました "
+                f"(最終エポック: {last_epoch}, "
+                f"ベスト{self.early_stopping.monitor}: "
+                f"{self.early_stopping.best_value:.4f}, "
+                f"ベストエポック: {self.early_stopping.best_epoch})"
+            )
+        else:
+            self.logger.info("訓練が完了しました")
+        if val_loader:
+            self.logger.info(f"最高精度: {best_accuracy:.2f}%")
+
+    def _finalize_metrics(self, tracker: Optional[MetricsTracker]) -> None:
+        """訓練完了後のメトリクスエクスポートとサマリー表示.
+
+        Args:
+            tracker: メトリクストラッカー.
+        """
+        if tracker is None:
+            return
+
+        csv_path, graph_paths = tracker.finalize()
+        if csv_path:
+            self.logger.info(f"メトリクスCSVを出力: {csv_path}")
+        if graph_paths:
+            for graph_path in graph_paths:
+                self.logger.info(f"メトリクスグラフを出力: {graph_path}")
+
+        summary = tracker.get_summary()
+        if summary:
+            self.logger.info("=== 訓練サマリー ===")
+            self.logger.info(f"総エポック数: {summary['total_epochs']}")
+            self.logger.info(f"最終訓練損失: {summary['final_train_loss']:.4f}")
+            self.logger.info(f"最終訓練精度: {summary['final_train_accuracy']:.2f}%")
+            if "best_val_accuracy" in summary:
+                self.logger.info(
+                    f"最高検証精度: {summary['best_val_accuracy']:.2f}% "
+                    f"(エポック {summary['best_val_accuracy_epoch']})"
+                )
+
+    @staticmethod
+    def create_metrics_tracker(
+        logger: logging.Logger,
+        current_workspace: Optional[Path],
+        visualization_dir: Optional[Path],
+        enable_metrics_export: bool,
+        enable_gradient_tracking: bool,
+        gradient_tracking_config: Dict[str, Any],
+        layer_wise_lr_graph_config: Dict[str, Any],
+    ) -> Optional[MetricsTracker]:
+        """MetricsTrackerを初期化.
+
+        Args:
+            logger: ロガーインスタンス.
+            current_workspace: ワークスペースパス. Noneの場合トラッカーは作成しない.
+            visualization_dir: 可視化出力ディレクトリ. 未作成時はNone.
+            enable_metrics_export: メトリクスエクスポートを有効にするか.
+            enable_gradient_tracking: 勾配追跡を有効にするか.
+            gradient_tracking_config: 勾配追跡設定.
+            layer_wise_lr_graph_config: 層別学習率グラフ設定.
+
+        Returns:
+            MetricsTracker: ワークスペースがある場合はトラッカー, なければNone.
+        """
+        if current_workspace is None or visualization_dir is None:
+            return None
+
+        tracker = MetricsTracker(
+            logger=logger,
+            visualization_dir=visualization_dir,
+            enable_metrics_export=enable_metrics_export,
+            enable_gradient_tracking=enable_gradient_tracking,
+            gradient_tracking_config=gradient_tracking_config,
+            layer_wise_lr_graph_config=layer_wise_lr_graph_config,
+        )
+        tracker.initialize()
+        return tracker

--- a/tests/unit/optimization/test_objective.py
+++ b/tests/unit/optimization/test_objective.py
@@ -96,12 +96,15 @@ class FakeTrainer:
         """
         type(self).last_setup_kwargs = dict(kwargs)
 
-    def train_epoch(self, _train_loader: Any) -> None:
+    def train_one_epoch(self, epoch: int, train_loader: Any) -> None:
         """1 エポック学習を模擬する.
 
         Args:
-            _train_loader: 未使用.
+            epoch: エポック番号.
+            train_loader: 未使用.
         """
+        _ = epoch
+        _ = train_loader
 
     def validate(self, _val_loader: Any) -> dict[str, float]:
         """事前に設定した検証値を返す.

--- a/tests/unit/test_core/test_training_loop.py
+++ b/tests/unit/test_core/test_training_loop.py
@@ -1,0 +1,118 @@
+"""TrainingLoopのテスト."""
+
+import logging
+from typing import Any, cast
+from unittest.mock import Mock
+
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from pochitrain.training.training_loop import TrainingLoop
+
+
+def test_create_metrics_tracker_returns_none_without_workspace():
+    """workspace未作成時にMetricsTrackerを作成しないことをテスト."""
+    tracker = TrainingLoop.create_metrics_tracker(
+        logger=logging.getLogger("test"),
+        current_workspace=None,
+        visualization_dir=None,
+        enable_metrics_export=True,
+        enable_gradient_tracking=False,
+        gradient_tracking_config={},
+        layer_wise_lr_graph_config={},
+    )
+
+    assert tracker is None
+
+
+def test_run_uses_initial_best_accuracy():
+    """初期ベスト精度を引き継いでbest更新判定することをテスト."""
+    checkpoint_store = Mock()
+    logger = Mock()
+    training_loop = TrainingLoop(
+        logger=logger,
+        checkpoint_store=checkpoint_store,
+        early_stopping=None,
+    )
+    model = nn.Linear(2, 2)
+    train_loader = cast(DataLoader[Any], Mock())
+    val_loader = cast(DataLoader[Any], Mock())
+
+    _, best_accuracy = training_loop.run(
+        epochs=1,
+        train_epoch_fn=lambda _: {"loss": 1.0, "accuracy": 10.0},
+        validate_fn=lambda _: {"val_loss": 1.0, "val_accuracy": 80.0},
+        train_loader=train_loader,
+        val_loader=val_loader,
+        model=model,
+        optimizer=None,
+        scheduler=None,
+        tracker=None,
+        get_learning_rate_fn=lambda: 0.001,
+        get_layer_wise_rates_fn=lambda: {},
+        is_layer_wise_lr_fn=lambda: False,
+        initial_best_accuracy=90.0,
+    )
+
+    assert best_accuracy == 90.0
+    checkpoint_store.save_best_model.assert_not_called()
+    checkpoint_store.save_last_model.assert_called_once()
+
+
+def test_update_best_and_check_early_stop_does_not_save_last_checkpoint():
+    """Early Stopping判定でlast checkpointを重複保存しないことをテスト."""
+    checkpoint_store = Mock()
+    early_stopping = Mock()
+    early_stopping.monitor = "val_accuracy"
+    early_stopping.step.return_value = True
+    training_loop = TrainingLoop(
+        logger=Mock(),
+        checkpoint_store=checkpoint_store,
+        early_stopping=early_stopping,
+    )
+    model = nn.Linear(2, 2)
+
+    _, should_stop = training_loop._update_best_and_check_early_stop(
+        epoch=1,
+        val_metrics={"val_loss": 1.0, "val_accuracy": 85.0},
+        model=model,
+        optimizer=None,
+        scheduler=None,
+        best_accuracy=80.0,
+    )
+
+    assert should_stop is True
+    checkpoint_store.save_best_model.assert_called_once()
+    checkpoint_store.save_last_model.assert_not_called()
+
+
+def test_run_calls_set_epoch_fn_each_epoch():
+    """run() が各エポックで set_epoch_fn を呼ぶことをテスト."""
+    checkpoint_store = Mock()
+    training_loop = TrainingLoop(
+        logger=Mock(),
+        checkpoint_store=checkpoint_store,
+        early_stopping=None,
+    )
+    model = nn.Linear(2, 2)
+    train_loader = cast(DataLoader[Any], Mock())
+    val_loader = cast(DataLoader[Any], Mock())
+    epochs: list[int] = []
+
+    training_loop.run(
+        epochs=2,
+        train_epoch_fn=lambda _: {"loss": 1.0, "accuracy": 10.0},
+        validate_fn=lambda _: {"val_loss": 1.0, "val_accuracy": 80.0},
+        train_loader=train_loader,
+        val_loader=val_loader,
+        model=model,
+        optimizer=None,
+        scheduler=None,
+        tracker=None,
+        get_learning_rate_fn=lambda: 0.001,
+        get_layer_wise_rates_fn=lambda: {},
+        is_layer_wise_lr_fn=lambda: False,
+        set_epoch_fn=epochs.append,
+    )
+
+    assert epochs == [1, 2]


### PR DESCRIPTION
## Summary
- `PochiTrainer.train` の訓練ループ詳細を `TrainingLoop` へ分離し, メソッド肥大化を解消しました.
- `setup_training` 未実行時の早期エラーを導入し, `optimizer` と `criterion` の状態保証を強化しました.
- `create_workspace=False` での回帰, `best_accuracy` リセット回帰, Early Stopping 時の二重保存を修正しました.
- 1エポック実行を `EpochRunner` へ分離し, `ClassificationObjective` は公開API `train_one_epoch` を利用する形に整理しました.

## Code Changes
- `pochitrain/training/training_loop.py` を追加し, エポックサイクル制御, チェックポイント保存, Early Stopping 判定, メトリクス処理を集約しました.
- `pochitrain/training/epoch_runner.py` を追加し, バッチ単位の訓練処理を `PochiTrainer` から分離しました.
- `pochitrain/pochi_trainer.py` に `_ensure_training_configured`, `_require_training_components`, `_require_criterion` を追加し, `train()` を `TrainingLoop.run()` へ委譲しました.
- `pochitrain/pochi_trainer.py` に `train_one_epoch` を追加し, エポック設定と1エポック実行の公開契約を明示しました.
- `pochitrain/optimization/objective.py` は `trainer.train_one_epoch(...)` を使うように変更し, privateメソッド依存を解消しました.
- `tests/unit/test_core/test_training_loop.py` を新規追加し, 回帰ポイントを単体テストで検証できるようにしました.
- 関連テストを `train_one_epoch` と `EpochRunner` ベースへ更新しました.

```python
# pochitrain/pochi_trainer.py
def train_one_epoch(self, epoch: int, train_loader: DataLoader[Any]) -> Dict[str, float]:
    self._set_epoch(epoch)
    return self._run_train_epoch(train_loader)
```

```python
# pochitrain/optimization/objective.py
for epoch in range(1, self._optuna_epochs + 1):
    trainer.train_one_epoch(epoch=epoch, train_loader=self._train_loader)
    val_metrics = trainer.validate(self._val_loader)
```

## Tests
- `uv run pytest tests/unit/test_core/test_pochi_trainer.py tests/unit/optimization/test_objective.py tests/unit/test_core/test_training_loop.py tests/unit/test_core/test_empty_dataloader.py -q`
  - 28 passed.
- `uv run mypy pochitrain/pochi_trainer.py pochitrain/training/epoch_runner.py pochitrain/training/training_loop.py pochitrain/optimization/objective.py`
  - Success, no issues found.