### PR TITLE
docs: Issue Template と PR Template を導入

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: バグの報告
+labels: bug
+---
+
+## Summary
+
+<!-- バグの概要を簡潔に記述してください. -->
+
+## Steps to Reproduce
+
+<!-- バグを再現する手順を記述してください. -->
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- 期待される動作を記述してください. -->
+
+## Actual Behavior
+
+<!-- 実際に発生した動作を記述してください. -->
+
+## Environment
+
+- OS:
+- Python:
+- PyTorch:
+- pochitrain:
+
+## Additional Context
+
+<!-- スクリーンショットやログなど, 追加情報があれば記述してください. -->
+
+## Labels
+
+`bug`
+
+## Branch
+
+`fix/`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,31 @@
+---
+name: Documentation Request
+about: ドキュメントの追加・改善の提案
+labels: documentation
+---
+
+## Summary
+
+<!-- ドキュメント追加・改善の概要を簡潔に記述してください. -->
+
+## Target Documents
+
+<!-- 対象のドキュメントやファイルを記述してください. -->
+
+## Proposed Changes
+
+<!-- 提案する変更内容を記述してください. -->
+
+## Acceptance Criteria
+
+<!-- 完了条件を記述してください. -->
+
+- [ ]
+
+## Labels
+
+`documentation`
+
+## Branch
+
+`docs/`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature Request
+about: 新機能の提案
+labels: enhancement
+---
+
+## Summary
+
+<!-- 追加したい機能の概要を簡潔に記述してください. -->
+
+## Background
+
+<!-- この機能が必要な背景や動機を記述してください. -->
+
+## Scope
+
+<!-- 実装範囲を記述してください. -->
+
+## Out of Scope
+
+<!-- 今回の対象外とする事項を記述してください. -->
+
+## Acceptance Criteria
+
+<!-- 完了条件を記述してください. -->
+
+- [ ]
+
+## Additional Context
+
+<!-- 参考資料やスクリーンショットなど, 追加情報があれば記述してください. -->
+
+## Labels
+
+`enhancement`
+
+## Branch
+
+`feature/`

--- a/.github/ISSUE_TEMPLATE/refactor_request.md
+++ b/.github/ISSUE_TEMPLATE/refactor_request.md
@@ -1,0 +1,35 @@
+---
+name: Refactor Request
+about: リファクタリングの提案
+labels: refactoring
+---
+
+## Summary
+
+<!-- リファクタリングの概要を簡潔に記述してください. -->
+
+## Background
+
+<!-- このリファクタリングが必要な背景や動機を記述してください. -->
+
+## Current Implementation
+
+<!-- 現在の実装の問題点を記述してください. -->
+
+## Proposed Changes
+
+<!-- 提案する変更内容を記述してください. -->
+
+## Acceptance Criteria
+
+<!-- 完了条件を記述してください. -->
+
+- [ ]
+
+## Labels
+
+`refactoring`
+
+## Branch
+
+`refactor/`

--- a/.github/ISSUE_TEMPLATE/test_request.md
+++ b/.github/ISSUE_TEMPLATE/test_request.md
@@ -1,0 +1,33 @@
+---
+name: Test Request
+about: テストの追加・改善の提案
+labels: test
+---
+
+## Summary
+
+<!-- テスト追加・改善の概要を簡潔に記述してください. -->
+
+## Target Code
+
+<!-- テスト対象のコードやモジュールを記述してください. -->
+
+## Test Cases
+
+<!-- 追加・改善するテストケースを記述してください. -->
+
+- [ ]
+
+## Acceptance Criteria
+
+<!-- 完了条件を記述してください. -->
+
+- [ ]
+
+## Labels
+
+`test`
+
+## Branch
+
+`test/`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- 変更の概要を簡潔に記述してください. -->
+
+-
+
+## Related Issue
+
+<!-- 関連する Issue 番号を記述してください. `Closes #XX` でマージ時に自動クローズされます. -->
+
+Closes #
+
+## Changes
+
+<!-- 主な変更内容を記述してください. -->
+
+-
+
+## Test Plan
+
+<!-- テスト方法を記述してください. -->
+
+- [ ]
+
+## Checklist
+
+- [ ] `uv run pre-commit run --all-files`


### PR DESCRIPTION
## Summary

- `.github/ISSUE_TEMPLATE/` に 5 種類の Issue テンプレート (bug, feature, refactor, test, documentation) を追加
- `.github/pull_request_template.md` に統一 PR テンプレートを追加
- `config.yml` で blank issue も許可

## Related Issue

Closes #229

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md` を追加
- `.github/ISSUE_TEMPLATE/feature_request.md` を追加
- `.github/ISSUE_TEMPLATE/refactor_request.md` を追加
- `.github/ISSUE_TEMPLATE/test_request.md` を追加
- `.github/ISSUE_TEMPLATE/documentation_request.md` を追加
- `.github/ISSUE_TEMPLATE/config.yml` を追加 (blank issue 許可)
- `.github/pull_request_template.md` を追加
- `CLAUDE.md`, `AGENTS.md`, `Gemini.md` に GitHub Templates セクションを追加

## Test Plan

- [ ] GitHub Web UI で Issue 作成時に 5 種類のテンプレートが選択可能であること
- [ ] GitHub Web UI で PR 作成時に統一テンプレートが自動表示されること

## Checklist

- [ ] `uv run pre-commit run --all-files` を実行して通る
- [ ] `uv run pytest` を実行して通る