### PR TITLE
refactor: PyTorch推論のビジネスロジックをService層に分離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   - `bug`, `feature`, `refactor`, `test`, `documentation` のテンプレートを追加し, 起票とレビュー記述を標準化した.
 
 ### Changed
+- `pochi infer` の推論ビジネスロジックを `PyTorchInferenceService` へ分離し, CLI を薄いラッパーに整理した.
+  - 推論器生成・DataLoader 作成・入力サイズ検出・結果集約を Service 層に移し, 単体テストを可能にした.
 - `PochiTrainer` の訓練フローを `TrainingLoop` と `EpochRunner` へ分離し, 状態管理を改善した ([#235](https://github.com/kurorosu/pochitrain/pull/235)).
   - 訓練ループ責務を分割し, 目的関数とユニットテストの保守性を高めた.
 

--- a/pochitrain/inference/services/__init__.py
+++ b/pochitrain/inference/services/__init__.py
@@ -2,11 +2,13 @@
 
 from .execution_service import ExecutionService
 from .onnx_inference_service import OnnxInferenceService
+from .pytorch_inference_service import PyTorchInferenceService
 from .result_export_service import ResultExportService
 from .trt_inference_service import TensorRTInferenceService
 
 __all__ = [
     "ExecutionService",
+    "PyTorchInferenceService",
     "ResultExportService",
     "OnnxInferenceService",
     "TensorRTInferenceService",

--- a/pochitrain/inference/services/pytorch_inference_service.py
+++ b/pochitrain/inference/services/pytorch_inference_service.py
@@ -1,0 +1,204 @@
+"""PyTorch モデル推論のオーケストレーションサービス."""
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from torch.utils.data import DataLoader
+
+from pochitrain.config import PochiConfig
+from pochitrain.logging import LoggerManager
+from pochitrain.pochi_dataset import PochiImageDataset
+from pochitrain.pochi_predictor import PochiPredictor
+from pochitrain.utils import log_inference_result
+
+from ..types.result_export_types import ResultExportRequest
+from .result_export_service import ResultExportService
+
+
+class PyTorchInferenceService:
+    """PyTorch モデル推論の実行・集約・エクスポートを担うサービス.
+
+    CLI から推論ビジネスロジックを分離し, 単体テストを可能にする.
+    """
+
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        """サービスを初期化する.
+
+        Args:
+            logger: ロガーインスタンス. 未指定時はモジュールロガーを利用する.
+        """
+        self.logger = logger or LoggerManager().get_logger(__name__)
+
+    def create_predictor(self, config: PochiConfig, model_path: Path) -> PochiPredictor:
+        """推論器を生成する.
+
+        Args:
+            config: アプリケーション設定.
+            model_path: 学習済みモデルのパス.
+
+        Returns:
+            初期化済みの推論器.
+        """
+        return PochiPredictor.from_config(config, str(model_path))
+
+    def create_dataloader(
+        self, config: PochiConfig, data_path: Path
+    ) -> Tuple[DataLoader[Any], PochiImageDataset]:
+        """推論用 DataLoader とデータセットを生成する.
+
+        Args:
+            config: アプリケーション設定.
+            data_path: 推論データのディレクトリパス.
+
+        Returns:
+            (DataLoader, PochiImageDataset) のタプル.
+        """
+        dataset = PochiImageDataset(str(data_path), transform=config.val_transform)
+        loader: DataLoader[Any] = DataLoader(
+            dataset,
+            batch_size=config.batch_size,
+            shuffle=False,
+            num_workers=config.num_workers,
+            pin_memory=True,
+        )
+
+        self.logger.debug("使用されたTransform (設定ファイルから):")
+        for i, transform in enumerate(config.val_transform.transforms):
+            self.logger.debug(f"   {i + 1}. {transform}")
+
+        return loader, dataset
+
+    def detect_input_size(
+        self, config: PochiConfig, dataset: PochiImageDataset
+    ) -> Optional[Tuple[int, int, int]]:
+        """Transform またはデータセットから入力サイズを推定する.
+
+        Args:
+            config: アプリケーション設定.
+            dataset: 推論データセット.
+
+        Returns:
+            (C, H, W) のタプル. 取得できない場合は None.
+        """
+        try:
+            from torchvision.transforms import CenterCrop, RandomResizedCrop, Resize
+
+            for t in config.val_transform.transforms:
+                if isinstance(t, (Resize, CenterCrop, RandomResizedCrop)):
+                    size = getattr(t, "size", None)
+                    if size:
+                        if isinstance(size, int):
+                            return (3, size, size)
+                        elif isinstance(size, (list, tuple)):
+                            return (3, size[0], size[1])
+                        break
+
+            if len(dataset) > 0:
+                sample_img, _ = dataset[0]
+                if hasattr(sample_img, "shape") and len(sample_img.shape) == 3:
+                    s = sample_img.shape
+                    return (int(s[0]), int(s[1]), int(s[2]))
+        except Exception:
+            pass
+
+        return None
+
+    def run_inference(
+        self, predictor: PochiPredictor, val_loader: DataLoader[Any]
+    ) -> Tuple[List[int], List[float], Dict[str, Any], float]:
+        """推論を実行し, 結果と計測情報を返す.
+
+        Args:
+            predictor: 推論器.
+            val_loader: 推論データローダー.
+
+        Returns:
+            (predicted_labels, confidence_scores, metrics, e2e_total_time_ms) のタプル.
+        """
+        self.logger.info("推論を開始します...")
+
+        e2e_start_time = time.perf_counter()
+        predictions, confidences, metrics = predictor.predict(val_loader)
+        e2e_total_time_ms = (time.perf_counter() - e2e_start_time) * 1000
+
+        predicted_labels: List[int] = predictions.tolist()
+        confidence_scores: List[float] = confidences.tolist()
+
+        return predicted_labels, confidence_scores, metrics, e2e_total_time_ms
+
+    def aggregate_and_export(
+        self,
+        *,
+        workspace_dir: Path,
+        model_path: Path,
+        data_path: Path,
+        dataset: PochiImageDataset,
+        predicted_labels: List[int],
+        confidence_scores: List[float],
+        metrics: Dict[str, Any],
+        e2e_total_time_ms: float,
+        input_size: Optional[Tuple[int, int, int]],
+        model_info: Optional[Dict[str, Any]],
+        cm_config: Optional[Dict[str, Any]],
+    ) -> None:
+        """精度計算・ログ出力・結果エクスポートを実行する.
+
+        Args:
+            workspace_dir: 結果出力先ディレクトリ.
+            model_path: モデルファイルパス.
+            data_path: 推論データパス.
+            dataset: 推論データセット.
+            predicted_labels: 予測ラベルリスト.
+            confidence_scores: 確信度リスト.
+            metrics: 推論メトリクス辞書.
+            e2e_total_time_ms: End-to-End 全処理時間 (ms).
+            input_size: 入力サイズ (C, H, W).
+            model_info: モデル情報辞書.
+            cm_config: 混同行列可視化設定.
+        """
+        image_paths = dataset.get_file_paths()
+        true_labels = dataset.labels
+        class_names = dataset.get_classes()
+
+        num_samples = len(predicted_labels)
+        correct = sum(p == t for p, t in zip(predicted_labels, true_labels))
+        avg_total_time_per_image = (
+            e2e_total_time_ms / num_samples if num_samples > 0 else 0
+        )
+
+        log_inference_result(
+            num_samples=num_samples,
+            correct=correct,
+            avg_time_per_image=metrics["avg_time_per_image"],
+            total_samples=int(metrics["total_samples"]),
+            warmup_samples=int(metrics["warmup_samples"]),
+            avg_total_time_per_image=avg_total_time_per_image,
+            input_size=input_size,
+        )
+
+        export_service = ResultExportService(self.logger)
+        export_service.export(
+            ResultExportRequest(
+                output_dir=workspace_dir,
+                model_path=model_path,
+                data_path=data_path,
+                image_paths=image_paths,
+                predictions=predicted_labels,
+                true_labels=true_labels,
+                confidences=confidence_scores,
+                class_names=class_names,
+                num_samples=num_samples,
+                correct=correct,
+                avg_time_per_image=metrics["avg_time_per_image"],
+                total_samples=int(metrics["total_samples"]),
+                warmup_samples=int(metrics["warmup_samples"]),
+                avg_total_time_per_image=avg_total_time_per_image,
+                input_size=input_size,
+                results_filename="pytorch_inference_results.csv",
+                summary_filename="pytorch_inference_summary.txt",
+                model_info=model_info,
+                cm_config=cm_config,
+            )
+        )

--- a/tests/unit/test_inference/test_pytorch_inference_service.py
+++ b/tests/unit/test_inference/test_pytorch_inference_service.py
@@ -1,0 +1,217 @@
+"""PyTorchInferenceService のテスト."""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torchvision.transforms import CenterCrop, Compose, Resize, ToTensor
+
+from pochitrain.config import PochiConfig
+from pochitrain.inference.services.pytorch_inference_service import (
+    PyTorchInferenceService,
+)
+
+
+def _build_logger() -> logging.Logger:
+    """テスト用ロガーを返す."""
+    logger = logging.getLogger("test_pytorch_inference_service")
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+
+def _build_config(**overrides: Any) -> PochiConfig:
+    """テスト用の最小 PochiConfig を返す."""
+    defaults: Dict[str, Any] = {
+        "model_name": "resnet18",
+        "num_classes": 2,
+        "device": "cpu",
+        "epochs": 1,
+        "batch_size": 4,
+        "learning_rate": 0.001,
+        "optimizer": "Adam",
+        "train_data_root": "data/train",
+        "val_data_root": "data/val",
+        "num_workers": 0,
+        "train_transform": Compose([Resize(224), ToTensor()]),
+        "val_transform": Compose([Resize(224), ToTensor()]),
+        "enable_layer_wise_lr": False,
+    }
+    defaults.update(overrides)
+    return PochiConfig.from_dict(defaults)
+
+
+class TestCreatePredictor:
+    """create_predictor のテスト."""
+
+    @patch("pochitrain.inference.services.pytorch_inference_service.PochiPredictor")
+    def test_delegates_to_from_config(self, mock_predictor_cls: MagicMock) -> None:
+        """PochiPredictor.from_config に正しく委譲されること."""
+        service = PyTorchInferenceService(_build_logger())
+        config = _build_config()
+        model_path = Path("models/best.pth")
+
+        service.create_predictor(config, model_path)
+
+        mock_predictor_cls.from_config.assert_called_once_with(config, str(model_path))
+
+
+class TestCreateDataloader:
+    """create_dataloader のテスト."""
+
+    @patch("pochitrain.inference.services.pytorch_inference_service.PochiImageDataset")
+    def test_returns_loader_and_dataset(self, mock_dataset_cls: MagicMock) -> None:
+        """DataLoader とデータセットが返されること."""
+        mock_dataset = MagicMock()
+        mock_dataset_cls.return_value = mock_dataset
+
+        service = PyTorchInferenceService(_build_logger())
+        config = _build_config()
+        data_path = Path("data/val")
+
+        loader, dataset = service.create_dataloader(config, data_path)
+
+        mock_dataset_cls.assert_called_once_with(
+            str(data_path), transform=config.val_transform
+        )
+        assert dataset is mock_dataset
+        assert loader.batch_size == config.batch_size
+
+
+class TestDetectInputSize:
+    """detect_input_size のテスト."""
+
+    def test_from_resize_transform(self) -> None:
+        """Resize Transform からサイズを取得できること."""
+        config = _build_config(val_transform=Compose([Resize(224), ToTensor()]))
+        dataset = MagicMock()
+        service = PyTorchInferenceService(_build_logger())
+
+        result = service.detect_input_size(config, dataset)
+
+        assert result == (3, 224, 224)
+
+    def test_from_center_crop_transform(self) -> None:
+        """CenterCrop Transform からサイズを取得できること."""
+        config = _build_config(
+            val_transform=Compose([CenterCrop((128, 256)), ToTensor()])
+        )
+        dataset = MagicMock()
+        service = PyTorchInferenceService(_build_logger())
+
+        result = service.detect_input_size(config, dataset)
+
+        assert result == (3, 128, 256)
+
+    def test_fallback_to_dataset_sample(self) -> None:
+        """Transform にサイズ情報がない場合, データセットからフォールバックすること."""
+        config = _build_config(val_transform=Compose([ToTensor()]))
+        dataset = MagicMock()
+        dataset.__len__ = MagicMock(return_value=1)
+        sample_tensor = torch.zeros(3, 100, 100)
+        dataset.__getitem__ = MagicMock(return_value=(sample_tensor, 0))
+
+        service = PyTorchInferenceService(_build_logger())
+
+        result = service.detect_input_size(config, dataset)
+
+        assert result == (3, 100, 100)
+
+    def test_returns_none_when_unavailable(self) -> None:
+        """サイズ情報が一切取得できない場合に None を返すこと."""
+        config = _build_config(val_transform=Compose([ToTensor()]))
+        dataset = MagicMock()
+        dataset.__len__ = MagicMock(return_value=0)
+
+        service = PyTorchInferenceService(_build_logger())
+
+        result = service.detect_input_size(config, dataset)
+
+        assert result is None
+
+
+class TestRunInference:
+    """run_inference のテスト."""
+
+    def test_returns_predictions_and_metrics(self) -> None:
+        """推論結果とメトリクスが正しく返されること."""
+        service = PyTorchInferenceService(_build_logger())
+
+        mock_predictor = MagicMock()
+        mock_predictor.predict.return_value = (
+            torch.tensor([0, 1, 0]),
+            torch.tensor([0.9, 0.8, 0.95]),
+            {
+                "avg_time_per_image": 5.0,
+                "total_samples": 3,
+                "warmup_samples": 1,
+            },
+        )
+        mock_loader = MagicMock()
+
+        labels, scores, metrics, e2e_time = service.run_inference(
+            mock_predictor, mock_loader
+        )
+
+        assert labels == [0, 1, 0]
+        assert len(scores) == 3
+        assert metrics["avg_time_per_image"] == 5.0
+        assert e2e_time > 0
+
+
+class TestAggregateAndExport:
+    """aggregate_and_export のテスト."""
+
+    @patch(
+        "pochitrain.inference.services.pytorch_inference_service.ResultExportService"
+    )
+    @patch(
+        "pochitrain.inference.services.pytorch_inference_service.log_inference_result"
+    )
+    def test_calls_log_and_export(
+        self,
+        mock_log_result: MagicMock,
+        mock_export_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """log_inference_result と ResultExportService.export が呼ばれること."""
+        service = PyTorchInferenceService(_build_logger())
+
+        mock_dataset = MagicMock()
+        mock_dataset.get_file_paths.return_value = ["a.jpg", "b.jpg"]
+        mock_dataset.labels = [0, 1]
+        mock_dataset.get_classes.return_value = ["cat", "dog"]
+
+        service.aggregate_and_export(
+            workspace_dir=tmp_path,
+            model_path=Path("model.pth"),
+            data_path=Path("data/val"),
+            dataset=mock_dataset,
+            predicted_labels=[0, 1],
+            confidence_scores=[0.9, 0.8],
+            metrics={
+                "avg_time_per_image": 5.0,
+                "total_samples": 2,
+                "warmup_samples": 1,
+            },
+            e2e_total_time_ms=100.0,
+            input_size=(3, 224, 224),
+            model_info={"model_name": "resnet18"},
+            cm_config=None,
+        )
+
+        mock_log_result.assert_called_once()
+        mock_export_cls.return_value.export.assert_called_once()
+
+        # export に渡された ResultExportRequest の内容を検証
+        call_args = mock_export_cls.return_value.export.call_args
+        request = call_args[0][0]
+        assert request.num_samples == 2
+        assert request.correct == 2  # [0,1] vs [0,1] -> 2 correct
+        assert request.results_filename == "pytorch_inference_results.csv"
+        assert request.summary_filename == "pytorch_inference_summary.txt"


### PR DESCRIPTION
## Summary

- `pochi infer` の推論ビジネスロジックを `PyTorchInferenceService` に抽出し, CLI を引数解析とService呼び出しのみに整理した.

## Related Issue

Closes #216

## Changes

- `pochitrain/inference/services/pytorch_inference_service.py` を新規作成し, 推論器生成・DataLoader作成・入力サイズ検出・推論実行・結果集約/エクスポートを担う `PyTorchInferenceService` を実装した.
- `pochitrain/cli/pochi.py` の `infer_command` を約190行から約70行に縮小し, ビジネスロジックをService側に委譲した.
- `pochitrain/inference/services/__init__.py` に `PyTorchInferenceService` を追加した.
- 不要になった import (`DataLoader`, `PochiPredictor`, `PochiImageDataset`, `ResultExportService`, `ResultExportRequest`, `log_inference_result`) を CLI から削除した.

## Code Changes

```python
# pochitrain/inference/services/pytorch_inference_service.py
class PyTorchInferenceService:
    """PyTorch モデル推論の実行・集約・エクスポートを担うサービス."""

    def create_predictor(self, config, model_path) -> PochiPredictor: ...
    def create_dataloader(self, config, data_path) -> tuple[DataLoader, PochiImageDataset]: ...
    def detect_input_size(self, config, dataset) -> Optional[tuple[int, int, int]]: ...
    def run_inference(self, predictor, val_loader) -> tuple[list, list, dict, float]: ...
    def aggregate_and_export(self, *, workspace_dir, ...) -> None: ...
```

## Out of Scope

以下は全推論 CLI (PyTorch / ONNX / TRT) を統一的にリファクタリングする後続 Issue で対応する:

- ワークスペース管理 (`InferenceWorkspaceManager`) や `cm_config` 組み立ての Service 内部への移動
- 分割メソッド型から `run()` 単一入口への統合
- ONNX/TRT CLI の同等リファクタリング

## Test Plan

- [x] `PyTorchInferenceService` の全メソッドに対する単体テスト (8件) を追加
- [x] `uv run pytest` で全テスト通過 (598 passed, 2 skipped)
- [x] `uv run pre-commit run --all-files` で全チェック通過

## Checklist

- [x] `uv run pre-commit run --all-files`