### PR TITLE
fix: pyproject.toml の依存関係整理 (onnx 系昇格, scipy 削除)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@
 - N/A.
 
 ### Changed
-- N/A.
+- `onnx`, `onnxscript`, `onnxruntime-gpu` を `[dependency-groups] onnx` から `dependencies` へ移動し, `uv sync` のみで ONNX 関連コマンドが利用可能になるようにした.
+  - `[dependency-groups] onnx` グループを削除した.
 
 ### Fixed
 - N/A.
 
 ### Removed
-- N/A.
+- `requirements.txt` から未使用の `scipy>=1.11.0` を削除した.
 
 ## v1.5.0 (2026-02-19)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     "plotly>=5.0.0",
     "matplotlib-fontja>=1.1.0",
     "pydantic>=2.0.0",
+    "onnx>=1.14.0",
+    "onnxscript>=0.1.0",
+    "onnxruntime-gpu>=1.16.0",
 ]
 
 [[tool.uv.index]]
@@ -47,11 +50,6 @@ dev = [
     "pytest-cov>=7.0.0",
     "pytest-mock>=3.15.1",
     "pytest-xdist>=3.8.0",
-]
-onnx = [
-    "onnx>=1.14.0",
-    "onnxscript>=0.1.0",
-    "onnxruntime-gpu>=1.16.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ numpy==1.26.1
 pandas>=2.0.0
 pillow>=8.0.0
 scikit-learn>=0.24.0
-scipy>=1.11.0
 
 # Configuration and logging
 pyyaml>=5.4.0


### PR DESCRIPTION
## Summary

- `[dependency-groups] onnx` の全パッケージを `dependencies` へ移動し, `uv sync` のみで ONNX 関連コマンドが利用可能になるようにした.
- `requirements.txt` から未使用の `scipy` を削除した.

## Related Issue

Closes #243

## Changes

- `pyproject.toml`: `onnx>=1.14.0`, `onnxscript>=0.1.0`, `onnxruntime-gpu>=1.16.0` を `dependencies` へ移動し, `[dependency-groups] onnx` を削除した.
- `requirements.txt`: 未使用の `scipy>=1.11.0` を削除した.

## Code Changes

```python
# pyproject.toml
dependencies = [
    ...
    "onnx>=1.14.0",
    "onnxscript>=0.1.0",
    "onnxruntime-gpu>=1.16.0",
]
```

## Test Plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv sync` 後に `infer-onnx` コマンドが利用可能であることを確認

## Checklist

- [x] `uv run pre-commit run --all-files`