### PR TITLE
docs: refactor issue template のラベルを refactor に統一

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor_request.md
+++ b/.github/ISSUE_TEMPLATE/refactor_request.md
@@ -1,7 +1,7 @@
 ---
 name: Refactor Request
 about: リファクタリングの提案
-labels: refactoring
+labels: refactor
 ---
 
 ## Summary
@@ -28,7 +28,7 @@ labels: refactoring
 
 ## Labels
 
-`refactoring`
+`refactor`
 
 ## Branch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - N/A.
 
 ### Changed
-- N/A.
+- `.github/ISSUE_TEMPLATE/refactor_request.md` のラベル表記を `refactoring` から `refactor` へ統一した.
 
 ### Fixed
 - N/A.


### PR DESCRIPTION
## Summary

- `.github/ISSUE_TEMPLATE/refactor_request.md` の front matter を `labels: refactor` に修正した.
- 同テンプレート内の Labels セクション表記も `` `refactor` `` に統一した.
- `CHANGELOG.md` の `[Unreleased] > Changed` に本変更を追記した.

## Related Issue

無し

## Changes

- `.github/ISSUE_TEMPLATE/refactor_request.md`
  - `labels: refactoring` を `labels: refactor` に修正.
  - `## Labels` の記載を `` `refactor` `` に修正.
- `CHANGELOG.md`
  - `[Unreleased] > Changed` にテンプレートのラベル統一を追記.

## Code Changes

無し

## Test Plan

- [x] 無し (ドキュメント更新のみ)

## Checklist

- [x] `uv run pre-commit run --all-files`