### PR TITLE
docs: Jetson ベンチマークのクロック固定手順を README と GPU ガイドへ追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## [Unreleased]
 
 ### Added
-- ベンチマーク機能を `bench` 独立コマンドとして CLI 登録し, `uv run bench --suite base` で実行可能にした ([#N/A.](https://github.com/kurorosu/pochitrain/pull/N/A.)).
+- ベンチマーク機能を `bench` 独立コマンドとして CLI 登録し, `uv run bench --suite base` で実行可能にした ([#272](https://github.com/kurorosu/pochitrain/pull/272)).
   - `tools/benchmark/` のモジュール群を `pochitrain/benchmark/` へ移動し, 絶対インポートに統一した.
   - `pochitrain/cli/bench.py` にエントリポイントを作成し, `pyproject.toml` の `[project.scripts]` に登録した.
   - `tools/benchmark/suites.yaml` を `configs/bench_suites.yaml` へ移動した.
@@ -36,6 +36,7 @@
   - 混同行列計算の2系統実装について, 訓練系(Torch Tensor)と推論系(NumPy/list)の使い分け方針をdocstringに明記した.
   - テストコード全体の低価値コメントを整理し, 意図説明コメントのみを残した.
 - 本番コード全体の低価値コメント (whatコメント) を整理し, whyコメントのみを残した.
+- Jetson の推論ベンチマーク再現性向上のため, `README.md` と `GPU環境セットアップガイド` に `nvpmodel` / `jetson_clocks` の運用手順を追記した ([#N/A.](https://github.com/kurorosu/pochitrain/pull/N/A.)).
 
 ### Fixed
 - N/A.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,23 @@ python -c "import numpy, scipy; print(numpy.__file__, numpy.__version__); print(
 `matplotlib` は Jetson では system package (`/usr/lib/...`) を使って問題ありません
 (必要なら `python -c "import matplotlib; print(matplotlib.__file__, matplotlib.__version__)"` で確認).
 
+### Jetson環境でベンチマーク前にクロックを固定する手順
+
+Jetson で推論ベンチマークを行う場合は, 先に電力モードとクロックを固定してください.
+これを行わないと, 動的電圧・周波数制御 (DVFS) の影響で `pure inference` の再現性が下がります.
+
+```bash
+sudo nvpmodel -m 2
+sudo jetson_clocks
+sudo jetson_clocks --show
+```
+
+補足.
+- `nvpmodel -m 2` は Jetson Orin Nano (JetPack 6.2.1) の `MAXN_SUPER` を想定.
+- 利用可能なモードは `sudo nvpmodel -q --verbose` で確認.
+- 温度影響を抑えたい場合は `sudo jetson_clocks --fan` を併用.
+- 詳細は `pochitrain/docs/gpu_environment_setup.md` の Jetson セクションを参照.
+
 ## 🔬 ハイパーパラメータ最適化
 
 Optunaを使ったハイパーパラメータ自動探索機能です.

--- a/pochitrain/docs/gpu_environment_setup.md
+++ b/pochitrain/docs/gpu_environment_setup.md
@@ -182,6 +182,38 @@ print(ort.get_available_providers())
 # CUDAExecutionProvider が含まれていれば GPU 推論が可能
 ```
 
+## 5. Jetson ベンチマーク時の電力・クロック固定
+
+Jetson で推論ベンチマークを行う場合は, `nvpmodel` と `jetson_clocks` を事前に適用する.
+未適用だと動的電圧・周波数制御 (DVFS) により計測値が揺れ, `pure inference` の比較が不安定になる.
+
+### 手順 (Jetson Orin Nano, JetPack 6.2.1)
+
+```bash
+# 現在のモード確認
+sudo nvpmodel -q
+sudo nvpmodel -q --verbose
+
+# MAXN_SUPER (mode 2) へ設定
+sudo nvpmodel -m 2
+
+# クロック固定
+sudo jetson_clocks
+
+# 反映確認
+sudo jetson_clocks --show
+```
+
+### オプション
+
+- 温度影響を減らしたい場合: `sudo jetson_clocks --fan`
+- 計測再現性を優先する場合: ベンチ実行前に毎回 `nvpmodel` と `jetson_clocks` を再適用する
+
+### 注意
+
+- `jetson_clocks` は再起動で解除される.
+- `nvpmodel` は設定が残るため, 必要なら `sudo nvpmodel -m <元のmode_id>` で戻す.
+
 ## バージョン互換性
 
 各コンポーネントのバージョンは相互に制約がある. 以下の公式ドキュメントで対応表を確認すること.


### PR DESCRIPTION
## Summary

- Jetson で推論ベンチマークを行う際の事前条件として, `nvpmodel` と `jetson_clocks` の運用手順を明文化した.
- `README.md` には要点のみ追記し, 詳細手順は `pochitrain/docs/gpu_environment_setup.md` へ集約した.
- `DVFS` の表現を `動的電圧・周波数制御 (DVFS)` に統一し, 初見ユーザーにも意味が通る文面へ修正した.
- `CHANGELOG.md` の `[Unreleased]` に docs 変更を追記し, 既存の `bench` 項目は確定済み PR リンク `#272` へ更新した.
- 推論実装や計測ロジックの変更は本PRでは行わず, 実害が確認された時点で別Issueとして着手する方針を明記した.

## Related Issue

Closes #274

## Changes

- `README.md`
  - `Jetson環境でベンチマーク前にクロックを固定する手順` を追加.
  - `sudo nvpmodel -m 2`, `sudo jetson_clocks`, `sudo jetson_clocks --show` の最小手順と補足を記載.
- `pochitrain/docs/gpu_environment_setup.md`
  - `Jetson ベンチマーク時の電力・クロック固定` セクションを追加.
  - 事前確認, 適用, 反映確認, オプション (`--fan`), 注意事項 (再起動時の解除) を記載.
  - `DVFS` を `動的電圧・周波数制御 (DVFS)` として説明.
- `CHANGELOG.md`
  - `[Unreleased] > Changed` に Jetson ベンチマーク手順の docs 追記を追加.
  - `[Unreleased] > Added` の `bench` 項目リンクを `([#272](https://github.com/kurorosu/pochitrain/pull/272))` へ更新.

## Code Changes

無し.

## Test Plan

- [x] 無し (ドキュメント更新のみ)

## Checklist

- [x] `uv run pre-commit run --all-files`