### PR TITLE
docs: CHANGELOGのUnreleased項目を直近2PR分に分離して整理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@
 - なし.
 
 ### Changed
-- 古典派テストへの再シフトを進め, CLI分割と重複ケース集約を実施した ([#N/A.](https://github.com/kurorosu/pochitrain/pull/N/A.)).
+- 推論テストの重複ケースを共通基底テストへ集約し, runtime 固有差分の検証へ整理した ([#280](https://github.com/kurorosu/pochitrain/pull/280)).
+  - `test_base_inference_service.py` を追加し, `IInferenceService` の共通ロジック検証を一元化した.
+  - `test_infer_trt.py` を実運用に近いワークスペース構造で再構成し, 状態ベースの導線検証へ整理した.
+  - `test_pochi_config.py`, `test_sub_configs.py`, `test_pochi_trainer.py` の同種検証を `parametrize` 化し, 重複ケースを削減した.
+- 古典派テストへの再シフトを進め, CLI分割と重複ケース集約を実施した ([#282](https://github.com/kurorosu/pochitrain/pull/282)).
   - `test_pochi_cli.py` を共通責務へ縮小し, `test_pochi_cli_infer.py` / `test_pochi_cli_train.py` へ物理分割した.
   - `test_convert_cli.py` に成功系の引数伝播検証を追加し, セットアップをヘルパー化した.
   - `test_inference_utils.py` を `parametrize` ベースへ集約し, 同型重複を削減した.
   - ONNX/TRT/PyTorch の service テストを runtime 固有差分のみの最小維持セットへ再編した.
-  - `test_base_inference_service.py` で `IInferenceService` 共通ロジックを担保する構成を明確化した.
 
 ### Fixed
 - なし.


### PR DESCRIPTION
## Summary

- `CHANGELOG.md` の `[Unreleased] > Changed` が直近2PR分で混在していたため, 追跡可能性向上のために項目を分離した.
- 既存の「推論テスト重複整理」項目を `#280` として明示し, 「古典派テスト再シフト」項目を `#282` として分離した.
- 参照リンクを `N/A.` から `#282` へ更新し, PR参照表記を確定値に揃えた.

## Related Issue

無し.

## Changes

- `CHANGELOG.md`
  - `[Unreleased] > Changed` を2項目へ分離.
  - `[#N/A.](https://github.com/kurorosu/pochitrain/pull/N/A.)` を `[#282](https://github.com/kurorosu/pochitrain/pull/282)` へ更新.
  - 既存の `#280` 項目は維持し, 今回分と混ざらないように再配置.

## Code Changes

無し.

## Test Plan

- [x] 無し（ドキュメント更新のみ）

## Checklist

- [x] `uv run pre-commit run --all-files`
