### PR TITLE
refactor: test_pochi_cli_infer.py の _ServiceStub 簡素化と設定ヘルパー重複の解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@
 - なし.
 
 ### Changed
-- なし.
+- `test_objective.py` の白箱テストを古典派テストへ移行した ([#293](https://github.com/kurorosu/pochitrain/pull/293)).
+  - `FakeTrainer` から `last_init_kwargs` / `last_setup_kwargs` による内部呼び出し検証を削除し, 観測可能な出力 (戻り値, trial.reported) を基準とするテストへ再構成した.
+- `test_pochi_cli_infer.py` の `_ServiceStub` を簡素化し, 設定ヘルパーの重複を解消した (N/A.).
+  - `_ServiceStub` から `captured` dict による内部引数検証を削除し, 観測可能な副作用 (ファイル作成, 集計実行有無) のみで検証するテストへ移行した.
+  - `_build_config_dict` / `_build_minimal_config` を `test_cli/conftest.py` の `build_cli_config()` に集約した.
 
 ### Fixed
 - なし.

--- a/tests/unit/test_cli/conftest.py
+++ b/tests/unit/test_cli/conftest.py
@@ -1,0 +1,33 @@
+"""test_cli 共通フィクスチャ."""
+
+from typing import Any
+
+import torchvision.transforms as transforms
+
+
+def build_cli_config(**overrides: Any) -> dict[str, Any]:
+    """CLI テスト用の最小設定辞書を生成する.
+
+    Args:
+        **overrides: 上書きするキーと値.
+
+    Returns:
+        設定辞書.
+    """
+    config: dict[str, Any] = {
+        "model_name": "resnet18",
+        "num_classes": 2,
+        "device": "cpu",
+        "epochs": 1,
+        "batch_size": 4,
+        "learning_rate": 0.001,
+        "optimizer": "Adam",
+        "train_data_root": "data/train",
+        "val_data_root": "data/val",
+        "num_workers": 0,
+        "train_transform": transforms.Compose([transforms.ToTensor()]),
+        "val_transform": transforms.Compose([transforms.ToTensor()]),
+        "enable_layer_wise_lr": False,
+    }
+    config.update(overrides)
+    return config

--- a/tests/unit/test_cli/test_pochi_cli_infer.py
+++ b/tests/unit/test_cli/test_pochi_cli_infer.py
@@ -5,10 +5,11 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-import torchvision.transforms as transforms
 
 from pochitrain.cli.pochi import infer_command, main
 from pochitrain.inference.types.orchestration_types import InferenceRunResult
+
+from .conftest import build_cli_config
 
 
 class TestMainDispatchInfer:
@@ -45,221 +46,199 @@ class TestMainDispatchInfer:
         assert getattr(called["args"], "config_path") == "config.py"
 
 
+class _Dataset:
+    """テスト用の最小データセットスタブ."""
+
+    labels = [0, 1]
+
+    @staticmethod
+    def get_file_paths() -> list[str]:
+        """ファイルパス一覧を返す."""
+        return ["a.jpg", "b.jpg"]
+
+    @staticmethod
+    def get_classes() -> list[str]:
+        """クラス一覧を返す."""
+        return ["cat", "dog"]
+
+
+class _Predictor:
+    """テスト用の最小推論器スタブ."""
+
+    @staticmethod
+    def get_model_info() -> dict[str, str]:
+        """モデル情報を返す."""
+        return {"model_name": "resnet18"}
+
+
+class _ServiceStub:
+    """PyTorchInferenceService の最小スタブ.
+
+    観測可能な副作用 (aggregate_called, create_dataloader_called) のみ記録し,
+    内部引数の検証は行わない.
+    """
+
+    def __init__(self, resolved_output_dir: Path) -> None:
+        self.resolved_output_dir = resolved_output_dir
+        self.aggregate_called = False
+        self.create_dataloader_called = False
+        self.raise_on_create_predictor = False
+        self.raise_on_run = False
+
+    def resolve_paths(self, request, config):
+        """パス解決をスタブする."""
+        del config
+        data_path = request.data_path if request.data_path is not None else Path("")
+        output_dir = (
+            request.output_dir
+            if request.output_dir is not None
+            else self.resolved_output_dir
+        )
+        output_dir.mkdir(parents=True, exist_ok=True)
+        return SimpleNamespace(
+            model_path=request.model_path,
+            data_path=data_path,
+            output_dir=output_dir,
+        )
+
+    def resolve_pipeline(self, requested, *, use_gpu):
+        """パイプライン解決をスタブする."""
+        del use_gpu
+        return requested
+
+    def resolve_runtime_options(self, *, config, pipeline, use_gpu):
+        """ランタイムオプション解決をスタブする."""
+        return SimpleNamespace(
+            pipeline=pipeline,
+            batch_size=1,
+            num_workers=0,
+            pin_memory=bool(config.get("infer_pin_memory", True)),
+            use_gpu=use_gpu,
+            use_gpu_pipeline=pipeline == "gpu",
+        )
+
+    def create_predictor(self, config, model_path):
+        """推論器作成をスタブする."""
+        del config, model_path
+        if self.raise_on_create_predictor:
+            raise RuntimeError("model error")
+        return _Predictor()
+
+    def create_dataloader(
+        self, config, data_path, val_transform, pipeline, runtime_options
+    ):
+        """データローダー作成をスタブする."""
+        del config, val_transform, runtime_options
+        self.create_dataloader_called = True
+        return (object(), _Dataset(), pipeline, None, None)
+
+    def detect_input_size(self, config, dataset):
+        """入力サイズ検出をスタブする."""
+        del config, dataset
+        return (3, 224, 224)
+
+    def create_runtime_adapter(self, predictor):
+        """ランタイムアダプター作成をスタブする."""
+        del predictor
+        return SimpleNamespace(use_cuda_timing=False)
+
+    def build_runtime_execution_request(self, **kwargs):
+        """実行リクエスト構築をスタブする."""
+        return SimpleNamespace(
+            execution_request=SimpleNamespace(
+                gpu_non_blocking=kwargs.get("gpu_non_blocking", True),
+            ),
+        )
+
+    def run(self, runtime_request):
+        """推論実行をスタブする."""
+        del runtime_request
+        if self.raise_on_run:
+            raise RuntimeError("inference error")
+        return InferenceRunResult(
+            predictions=[0, 1],
+            confidences=[0.9, 0.8],
+            true_labels=[0, 1],
+            num_samples=2,
+            correct=2,
+            avg_time_per_image=1.0,
+            total_samples=2,
+            warmup_samples=0,
+            avg_total_time_per_image=1.5,
+        )
+
+    def aggregate_and_export(self, **kwargs):
+        """集計・出力をスタブする."""
+        del kwargs
+        self.aggregate_called = True
+
+
+def _create_dummy_model_file(base_dir: Path) -> Path:
+    """ダミーモデルファイルを作成して返す."""
+    model_path = base_dir / "models" / "best.pth"
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    model_path.touch()
+    return model_path
+
+
+def _create_dummy_data_dir(base_dir: Path) -> Path:
+    """ダミー推論データディレクトリを作成して返す."""
+    data_path = base_dir / "data"
+    data_path.mkdir(parents=True, exist_ok=True)
+    return data_path
+
+
+def _make_args(tmp_path: Path) -> argparse.Namespace:
+    """テスト用の argparse.Namespace を生成する."""
+    model_path = _create_dummy_model_file(tmp_path)
+    data_path = _create_dummy_data_dir(tmp_path)
+    return argparse.Namespace(
+        debug=False,
+        model_path=str(model_path),
+        data=str(data_path),
+        config_path=str(tmp_path / "config.py"),
+        output=str(tmp_path / "output"),
+    )
+
+
+def _install_service_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    module: object,
+    service_stub: _ServiceStub,
+) -> None:
+    """ServiceStub を PyTorchInferenceService の代わりに注入する."""
+    monkeypatch.setattr(
+        module,
+        "PyTorchInferenceService",
+        lambda logger: service_stub,
+    )
+
+
 class TestInferCommandServiceDelegation:
     """infer_command が Service に委譲するテスト."""
 
-    class _Dataset:
-        labels = [0, 1]
-
-        @staticmethod
-        def get_file_paths() -> list[str]:
-            return ["a.jpg", "b.jpg"]
-
-        @staticmethod
-        def get_classes() -> list[str]:
-            return ["cat", "dog"]
-
-    class _Predictor:
-        @staticmethod
-        def get_model_info() -> dict[str, str]:
-            return {"model_name": "resnet18"}
-
-    class _ServiceStub:
-        def __init__(self, resolved_output_dir: Path) -> None:
-            self.resolved_output_dir = resolved_output_dir
-            self.aggregate_called = False
-            self.create_dataloader_called = False
-            self.raise_on_create_predictor = False
-            self.raise_on_run = False
-            self.captured: dict[str, object] = {}
-
-        def resolve_paths(self, request, config):
-            del config
-            data_path = request.data_path if request.data_path is not None else Path("")
-            output_dir = (
-                request.output_dir
-                if request.output_dir is not None
-                else self.resolved_output_dir
-            )
-            output_dir.mkdir(parents=True, exist_ok=True)
-            return SimpleNamespace(
-                model_path=request.model_path,
-                data_path=data_path,
-                output_dir=output_dir,
-            )
-
-        def resolve_pipeline(self, requested: str, *, use_gpu: bool) -> str:
-            del use_gpu
-            return requested
-
-        def resolve_runtime_options(self, *, config, pipeline: str, use_gpu: bool):
-            return SimpleNamespace(
-                pipeline=pipeline,
-                batch_size=1,
-                num_workers=0,
-                pin_memory=bool(config.get("infer_pin_memory", True)),
-                use_gpu=use_gpu,
-                use_gpu_pipeline=pipeline == "gpu",
-            )
-
-        def create_predictor(self, config, model_path):
-            del config
-            del model_path
-            if self.raise_on_create_predictor:
-                raise RuntimeError("model error")
-            return TestInferCommandServiceDelegation._Predictor()
-
-        def create_dataloader(
-            self,
-            config,
-            data_path,
-            val_transform,
-            pipeline,
-            runtime_options,
-        ):
-            del config
-            del val_transform
-            self.create_dataloader_called = True
-            self.captured["data_path"] = data_path
-            self.captured["pipeline"] = pipeline
-            self.captured["pin_memory"] = runtime_options.pin_memory
-            return (
-                object(),
-                TestInferCommandServiceDelegation._Dataset(),
-                pipeline,
-                None,
-                None,
-            )
-
-        def detect_input_size(self, config, dataset):
-            del config
-            del dataset
-            return (3, 224, 224)
-
-        def create_runtime_adapter(self, predictor):
-            del predictor
-            return SimpleNamespace(use_cuda_timing=False)
-
-        def build_runtime_execution_request(self, **kwargs):
-            self.captured["use_gpu_pipeline"] = kwargs["use_gpu_pipeline"]
-            self.captured["gpu_non_blocking"] = kwargs["gpu_non_blocking"]
-            return SimpleNamespace(
-                execution_request=SimpleNamespace(
-                    gpu_non_blocking=kwargs["gpu_non_blocking"]
-                )
-            )
-
-        def run(self, runtime_request):
-            del runtime_request
-            if self.raise_on_run:
-                raise RuntimeError("inference error")
-            return InferenceRunResult(
-                predictions=[0, 1],
-                confidences=[0.9, 0.8],
-                true_labels=[0, 1],
-                num_samples=2,
-                correct=2,
-                avg_time_per_image=1.0,
-                total_samples=2,
-                warmup_samples=0,
-                avg_total_time_per_image=1.5,
-            )
-
-        def aggregate_and_export(self, **kwargs):
-            self.aggregate_called = True
-            self.captured["workspace_dir"] = kwargs["workspace_dir"]
-
-    @staticmethod
-    def _create_dummy_model_file(base_dir: Path) -> Path:
-        """ダミーモデルファイルを作成して返す."""
-        model_path = base_dir / "models" / "best.pth"
-        model_path.parent.mkdir(parents=True, exist_ok=True)
-        model_path.touch()
-        return model_path
-
-    @staticmethod
-    def _create_dummy_data_dir(base_dir: Path) -> Path:
-        """ダミー推論データディレクトリを作成して返す."""
-        data_path = base_dir / "data"
-        data_path.mkdir(parents=True, exist_ok=True)
-        return data_path
-
-    def _make_args(self, tmp_path: Path) -> argparse.Namespace:
-        """テスト用の argparse.Namespace を生成する."""
-        model_path = self._create_dummy_model_file(tmp_path)
-        data_path = self._create_dummy_data_dir(tmp_path)
-
-        return argparse.Namespace(
-            debug=False,
-            model_path=str(model_path),
-            data=str(data_path),
-            config_path=str(tmp_path / "config.py"),
-            output=str(tmp_path / "output"),
-        )
-
-    @staticmethod
-    def _install_service_stub(
-        monkeypatch: pytest.MonkeyPatch,
-        module,
-        service_stub: "_ServiceStub",
-    ) -> None:
-        monkeypatch.setattr(
-            module,
-            "PyTorchInferenceService",
-            lambda logger: service_stub,
-        )
-
-    @staticmethod
-    def _build_config_dict(
-        data_root: Path, *, infer_pin_memory: bool = True
-    ) -> dict[str, object]:
-        """infer_command 用の最小設定辞書を生成する."""
-        return {
-            "model_name": "resnet18",
-            "num_classes": 2,
-            "device": "cpu",
-            "epochs": 1,
-            "batch_size": 4,
-            "learning_rate": 0.001,
-            "optimizer": "Adam",
-            "train_data_root": "data/train",
-            "val_data_root": str(data_root),
-            "num_workers": 0,
-            "infer_pin_memory": infer_pin_memory,
-            "train_transform": transforms.Compose(
-                [transforms.Resize(224), transforms.ToTensor()]
-            ),
-            "val_transform": transforms.Compose(
-                [transforms.Resize(224), transforms.ToTensor()]
-            ),
-            "enable_layer_wise_lr": False,
-        }
-
-    def test_delegates_to_service_with_explicit_output(
+    def test_successful_inference_creates_output_dir(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """--output 指定時に Service 解決結果を使って委譲することを検証する."""
+        """正常完了時に出力ディレクトリが作成され集計が実行されることを検証する."""
         import pochitrain.cli.pochi as pochi_module
 
-        args = self._make_args(tmp_path)
-        config = self._build_config_dict(Path(args.data), infer_pin_memory=False)
+        args = _make_args(tmp_path)
+        config = build_cli_config(val_data_root=args.data)
         monkeypatch.setattr(
             pochi_module.ConfigLoader,
             "load_config",
             lambda _path: config,
         )
-        service_stub = self._ServiceStub(resolved_output_dir=tmp_path / "unused")
-        self._install_service_stub(monkeypatch, pochi_module, service_stub)
+        service_stub = _ServiceStub(resolved_output_dir=tmp_path / "unused")
+        _install_service_stub(monkeypatch, pochi_module, service_stub)
 
         infer_command(args)
 
-        assert service_stub.captured["data_path"] == Path(args.data)
-        assert service_stub.captured["pipeline"] == "current"
-        assert service_stub.captured["pin_memory"] is False
-        assert service_stub.captured["workspace_dir"] == Path(args.output)
         assert Path(args.output).exists()
+        assert service_stub.aggregate_called is True
 
     def test_creates_workspace_when_output_not_specified(
         self,
@@ -270,8 +249,8 @@ class TestInferCommandServiceDelegation:
         import pochitrain.cli.pochi as pochi_module
 
         work_dir = tmp_path / "work_dirs" / "20260223_001"
-        model_path = self._create_dummy_model_file(work_dir)
-        data_path = self._create_dummy_data_dir(tmp_path)
+        model_path = _create_dummy_model_file(work_dir)
+        data_path = _create_dummy_data_dir(tmp_path)
 
         args = argparse.Namespace(
             debug=False,
@@ -280,66 +259,63 @@ class TestInferCommandServiceDelegation:
             config_path=str(tmp_path / "config.py"),
             output=None,
         )
-        config = self._build_config_dict(data_path)
+        config = build_cli_config(val_data_root=str(data_path))
         monkeypatch.setattr(
             pochi_module.ConfigLoader,
             "load_config",
             lambda _path: config,
         )
         expected_output = work_dir / "inference_results" / "20260223_001"
-        service_stub = self._ServiceStub(resolved_output_dir=expected_output)
-        self._install_service_stub(monkeypatch, pochi_module, service_stub)
+        service_stub = _ServiceStub(resolved_output_dir=expected_output)
+        _install_service_stub(monkeypatch, pochi_module, service_stub)
 
         infer_command(args)
 
-        workspace_dir_obj = service_stub.captured["workspace_dir"]
-        assert isinstance(workspace_dir_obj, Path)
-        workspace_dir = workspace_dir_obj
-        assert workspace_dir.parent == work_dir / "inference_results"
-        assert workspace_dir.exists()
+        assert expected_output.exists()
+        assert service_stub.aggregate_called is True
 
-    def test_predictor_error_returns_early(
+    def test_predictor_error_skips_dataloader_and_export(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """推論器作成エラー時に早期 return することを検証する."""
+        """推論器作成エラー時にデータローダー作成と集計がスキップされることを検証する."""
         import pochitrain.cli.pochi as pochi_module
 
-        args = self._make_args(tmp_path)
-        config = self._build_config_dict(Path(args.data))
+        args = _make_args(tmp_path)
+        config = build_cli_config(val_data_root=args.data)
         monkeypatch.setattr(
             pochi_module.ConfigLoader,
             "load_config",
             lambda _path: config,
         )
-        service_stub = self._ServiceStub(resolved_output_dir=tmp_path / "unused")
+        service_stub = _ServiceStub(resolved_output_dir=tmp_path / "unused")
         service_stub.raise_on_create_predictor = True
-        self._install_service_stub(monkeypatch, pochi_module, service_stub)
+        _install_service_stub(monkeypatch, pochi_module, service_stub)
 
         infer_command(args)
 
         assert service_stub.create_dataloader_called is False
         assert service_stub.aggregate_called is False
 
-    def test_inference_error_returns_early(
+    def test_inference_error_skips_export(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """推論実行エラー時に早期 return することを検証する."""
+        """推論実行エラー時に集計がスキップされることを検証する."""
         import pochitrain.cli.pochi as pochi_module
 
-        args = self._make_args(tmp_path)
-        config = self._build_config_dict(Path(args.data))
+        args = _make_args(tmp_path)
+        config = build_cli_config(val_data_root=args.data)
         monkeypatch.setattr(
             pochi_module.ConfigLoader,
             "load_config",
             lambda _path: config,
         )
-        service_stub = self._ServiceStub(resolved_output_dir=tmp_path / "unused")
+        service_stub = _ServiceStub(resolved_output_dir=tmp_path / "unused")
         service_stub.raise_on_run = True
-        self._install_service_stub(monkeypatch, pochi_module, service_stub)
+        _install_service_stub(monkeypatch, pochi_module, service_stub)
 
         infer_command(args)
 

--- a/tests/unit/test_cli/test_pochi_cli_train.py
+++ b/tests/unit/test_cli/test_pochi_cli_train.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import torchvision.transforms as transforms
 
 from pochitrain.cli.pochi import main, train_command
+
+from .conftest import build_cli_config
 
 
 class TestMainDispatchTrain:
@@ -32,26 +33,6 @@ class TestMainDispatchTrain:
 
 class TestTrainCommandValidationHandling:
     """train_command の ValidationError ハンドリングのテスト."""
-
-    @staticmethod
-    def _build_minimal_config(**overrides: object) -> dict[str, object]:
-        """train_command 用の最小設定辞書を返す."""
-        config: dict[str, object] = {
-            "model_name": "resnet18",
-            "num_classes": 2,
-            "device": "cpu",
-            "epochs": 1,
-            "batch_size": 4,
-            "learning_rate": 0.001,
-            "optimizer": "Adam",
-            "train_data_root": "data/train",
-            "val_data_root": "data/val",
-            "train_transform": transforms.Compose([transforms.ToTensor()]),
-            "val_transform": transforms.Compose([transforms.ToTensor()]),
-            "enable_layer_wise_lr": False,
-        }
-        config.update(overrides)
-        return config
 
     @staticmethod
     def _make_train_args(tmp_path: Path) -> argparse.Namespace:
@@ -84,7 +65,7 @@ class TestTrainCommandValidationHandling:
         import pochitrain.cli.pochi as pochi_module
 
         logger = MagicMock()
-        config = self._build_minimal_config(
+        config = build_cli_config(
             # ここだけ意図的に不正値を入れて ValidationError を発生させる.
             early_stopping={
                 "enabled": False,
@@ -115,7 +96,7 @@ class TestTrainCommandValidationHandling:
         missing_train = tmp_path / "missing_train"
         existing_val = tmp_path / "val"
         existing_val.mkdir()
-        config = self._build_minimal_config(
+        config = build_cli_config(
             # train_data_root を存在しないパスへ差し替える.
             train_data_root=str(missing_train),
             val_data_root=str(existing_val),
@@ -144,7 +125,7 @@ class TestTrainCommandValidationHandling:
         existing_train = tmp_path / "train"
         existing_train.mkdir()
         missing_val = tmp_path / "missing_val"
-        config = self._build_minimal_config(
+        config = build_cli_config(
             # val_data_root を存在しないパスへ差し替える.
             train_data_root=str(existing_train),
             val_data_root=str(missing_val),


### PR DESCRIPTION
## Summary

- `test_pochi_cli_infer.py` の `_ServiceStub` から `captured` dict による内部引数検証を削除し, 観測可能な副作用のみで検証する古典派テストへ移行した.
- `_build_config_dict` / `_build_minimal_config` を `test_cli/conftest.py` の `build_cli_config()` に集約し, 重複を解消した.

## Related Issue

Closes #288

## Changes

- `test_cli/conftest.py` を新規作成し, `build_cli_config()` 共通ヘルパーを定義した.
- `test_pochi_cli_infer.py`:
  - `_ServiceStub` から `captured` dict, 内部引数記録ロジックを削除
  - `_Dataset`, `_Predictor`, `_ServiceStub` をクラス外トップレベルに移動し, テストクラスのネストを解消
  - ヘルパー関数 (`_create_dummy_model_file`, `_make_args` 等) をクラス外に移動
  - テスト名を観測対象を明示する命名に変更
  - `_build_config_dict` を `build_cli_config()` に置き換え
- `test_pochi_cli_train.py`:
  - `_build_minimal_config` を削除し, `build_cli_config()` に置き換え
  - `torchvision.transforms` の import を削除

## Code Changes

```python
# tests/unit/test_cli/conftest.py (新規)
def build_cli_config(**overrides: Any) -> dict[str, Any]:
    """CLI テスト用の最小設定辞書を生成する."""
    config: dict[str, Any] = {
        "model_name": "resnet18",
        "num_classes": 2,
        ...
    }
    config.update(overrides)
    return config
```

```python
# tests/unit/test_cli/test_pochi_cli_infer.py (_ServiceStub 簡素化)
class _ServiceStub:
    """観測可能な副作用のみ記録し, 内部引数の検証は行わない."""

    def aggregate_and_export(self, **kwargs):
        del kwargs
        self.aggregate_called = True
```

## Test Plan

- [x] `uv run pytest tests/unit/test_cli/test_pochi_cli_infer.py tests/unit/test_cli/test_pochi_cli_train.py -v` — 全9件 PASSED

## Checklist

- [x] `uv run pre-commit run --all-files`