### PR TITLE
refactor: test_training_loop / test_training_configurator のプライベートメソッド…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@
 ### Changed
 - `test_objective.py` の白箱テストを古典派テストへ移行した ([#293](https://github.com/kurorosu/pochitrain/pull/293)).
   - `FakeTrainer` から `last_init_kwargs` / `last_setup_kwargs` による内部呼び出し検証を削除し, 観測可能な出力 (戻り値, trial.reported) を基準とするテストへ再構成した.
-- `test_pochi_cli_infer.py` の `_ServiceStub` を簡素化し, 設定ヘルパーの重複を解消した (N/A.).
+- `test_pochi_cli_infer.py` の `_ServiceStub` を簡素化し, 設定ヘルパーの重複を解消した ([#294](https://github.com/kurorosu/pochitrain/pull/294)).
   - `_ServiceStub` から `captured` dict による内部引数検証を削除し, 観測可能な副作用 (ファイル作成, 集計実行有無) のみで検証するテストへ移行した.
   - `_build_config_dict` / `_build_minimal_config` を `test_cli/conftest.py` の `build_cli_config()` に集約した.
+- `test_training_loop.py` / `test_training_configurator.py` のプライベートメソッド直接テストを公開 API 経由に移行した (N/A.).
+  - `_update_best_and_check_early_stop()` の直接テストを `run()` 経由の古典派テストに置き換えた.
+  - `_get_layer_group()` / `_build_layer_wise_param_groups()` の直接テストを `configure()` 経由の検証に移行した.
 
 ### Fixed
 - なし.

--- a/tests/unit/test_core/test_training_loop.py
+++ b/tests/unit/test_core/test_training_loop.py
@@ -59,11 +59,12 @@ def test_run_uses_initial_best_accuracy():
     checkpoint_store.save_last_model.assert_called_once()
 
 
-def test_update_best_and_check_early_stop_does_not_save_last_checkpoint():
-    """Early Stopping判定でlast checkpointを重複保存しないことをテスト."""
+def test_early_stopping_saves_last_checkpoint_only_once():
+    """Early Stopping発動時にlast checkpointが1回だけ保存されることをテスト."""
     checkpoint_store = Mock()
     early_stopping = Mock()
     early_stopping.monitor = "val_accuracy"
+    early_stopping.should_stop = False
     early_stopping.step.return_value = True
     training_loop = TrainingLoop(
         logger=Mock(),
@@ -71,19 +72,27 @@ def test_update_best_and_check_early_stop_does_not_save_last_checkpoint():
         early_stopping=early_stopping,
     )
     model = nn.Linear(2, 2)
+    train_loader = cast(DataLoader[Any], Mock())
+    val_loader = cast(DataLoader[Any], Mock())
 
-    _, should_stop = training_loop._update_best_and_check_early_stop(
-        epoch=1,
-        val_metrics={"val_loss": 1.0, "val_accuracy": 85.0},
+    _, best_accuracy = training_loop.run(
+        epochs=3,
+        train_epoch_fn=lambda _: {"loss": 1.0, "accuracy": 10.0},
+        validate_fn=lambda _: {"val_loss": 1.0, "val_accuracy": 85.0},
+        train_loader=train_loader,
+        val_loader=val_loader,
         model=model,
         optimizer=None,
         scheduler=None,
-        best_accuracy=80.0,
+        tracker=None,
+        get_learning_rate_fn=lambda: 0.001,
+        get_layer_wise_rates_fn=lambda: {},
+        is_layer_wise_lr_fn=lambda: False,
     )
 
-    assert should_stop is True
+    assert best_accuracy == 85.0
     checkpoint_store.save_best_model.assert_called_once()
-    checkpoint_store.save_last_model.assert_not_called()
+    assert checkpoint_store.save_last_model.call_count == 1
 
 
 def test_run_calls_set_epoch_fn_each_epoch():


### PR DESCRIPTION
## Summary

- `test_training_loop.py` の `_update_best_and_check_early_stop()` 直接テストを `run()` 経由の古典派テストに置き換えた.
- `test_training_configurator.py` の `_get_layer_group()` / `_build_layer_wise_param_groups()` 直接テストを `configure()` 経由の検証に移行した.

## Related Issue

Closes #289

## Changes

- `test_training_loop.py`:
  - `test_update_best_and_check_early_stop_does_not_save_last_checkpoint` を削除
  - `test_early_stopping_saves_last_checkpoint_only_once` を追加: `run()` 経由で Early Stopping 発動時の checkpoint 保存回数を検証
- `test_training_configurator.py`:
  - `TestTrainingConfiguratorLayerGroup` クラス (1テスト) を削除: `_get_layer_group()` のプライベートメソッド直接テスト
  - `TestTrainingConfiguratorBuildParamGroups` クラス (1テスト) を削除: `_build_layer_wise_param_groups()` のプライベートメソッド直接テスト
  - `TestTrainingConfiguratorLayerWiseLrDetails` クラス (2テスト) を追加: `configure()` の戻り値 `optimizer.param_groups` で層別学習率の反映を検証
- `test_pochi_trainer.py`:
  - 変更なし. `TrainingLoop.run` の patch は訓練実行を回避するためのもので, テスト自体は公開属性 (`best_accuracy`) を検証しているため現状維持

## Code Changes

```python
# tests/unit/test_core/test_training_loop.py (Before: プライベートメソッド直接呼び出し)
_, should_stop = training_loop._update_best_and_check_early_stop(...)
assert should_stop is True

# tests/unit/test_core/test_training_loop.py (After: run() 経由)
_, best_accuracy = training_loop.run(epochs=3, ...)
assert best_accuracy == 85.0
assert checkpoint_store.save_last_model.call_count == 1
```

```python
# tests/unit/test_core/test_training_configurator.py (Before: プライベートメソッド直接呼び出し)
assert configurator._get_layer_group("conv1.weight") == "conv1"

# tests/unit/test_core/test_training_configurator.py (After: configure() 経由)
components = configurator.configure(model=model, ..., enable_layer_wise_lr=True, ...)
group_lrs = {g["layer_name"]: g["lr"] for g in components.optimizer.param_groups}
assert group_lrs["conv1"] == pytest.approx(0.0001)
```

## Test Plan

- [x] `uv run pytest tests/unit/test_core/test_training_loop.py tests/unit/test_core/test_training_configurator.py tests/unit/test_core/test_pochi_trainer.py -v` — 全35件 PASSED

## Checklist

- [x] `uv run pre-commit run --all-files`