### PR TITLE
refactor: test_runtime_adapters.py の TRT/ONNX 重複テスト統合と inference 系テストのモック削減

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@
 - `test_pochi_cli_infer.py` の `_ServiceStub` を簡素化し, 設定ヘルパーの重複を解消した ([#294](https://github.com/kurorosu/pochitrain/pull/294)).
   - `_ServiceStub` から `captured` dict による内部引数検証を削除し, 観測可能な副作用 (ファイル作成, 集計実行有無) のみで検証するテストへ移行した.
   - `_build_config_dict` / `_build_minimal_config` を `test_cli/conftest.py` の `build_cli_config()` に集約した.
-- `test_training_loop.py` / `test_training_configurator.py` のプライベートメソッド直接テストを公開 API 経由に移行した (N/A.).
+- `test_training_loop.py` / `test_training_configurator.py` のプライベートメソッド直接テストを公開 API 経由に移行した ([#295](https://github.com/kurorosu/pochitrain/pull/295)).
   - `_update_best_and_check_early_stop()` の直接テストを `run()` 経由の古典派テストに置き換えた.
   - `_get_layer_group()` / `_build_layer_wise_param_groups()` の直接テストを `configure()` 経由の検証に移行した.
+- `test_runtime_adapters.py` の TRT/ONNX 重複テストを統合し, inference 系テストのモックを削減した (N/A.).
+  - TRT/ONNX `gpu_non_blocking` 重複テストを `@pytest.mark.parametrize` で統合した.
+  - `test_base_inference_service.py` の `MagicMock` を `_DummyAdapter` スタブと実 `DataLoader` に置換した.
+  - `test_pytorch_inference_service.py` の `create_dataset_and_params` 完全モックを実データテストに移行した.
 
 ### Fixed
 - なし.

--- a/tests/unit/test_inference/test_base_inference_service.py
+++ b/tests/unit/test_inference/test_base_inference_service.py
@@ -140,35 +140,27 @@ class TestIInferenceServiceResolveRuntimeOptions:
         assert options.use_gpu_pipeline == (pipeline == "gpu")
 
 
+class _DummyAdapter:
+    """build_runtime_execution_request 用の最小アダプタスタブ."""
+
+    device = "cpu"
+
+
 class TestIInferenceServiceBuildRequest:
     """build_runtime_execution_request のテスト."""
 
     def test_build_runtime_execution_request_basic(self, service):
-        from unittest.mock import MagicMock
-
-        import torch
-
-        adapter = MagicMock()
-        adapter.device = "cpu"
-
         request = service.build_runtime_execution_request(
-            data_loader=MagicMock(),
-            runtime_adapter=adapter,
+            data_loader=DataLoader([]),
+            runtime_adapter=_DummyAdapter(),
             use_gpu_pipeline=False,
         )
         assert request.execution_request.use_gpu_pipeline is False
 
     def test_build_runtime_execution_request_with_gpu_pipeline(self, service):
-        from unittest.mock import MagicMock
-
-        import torch
-
-        adapter = MagicMock()
-        adapter.device = "cpu"
-
         request = service.build_runtime_execution_request(
-            data_loader=MagicMock(),
-            runtime_adapter=adapter,
+            data_loader=DataLoader([]),
+            runtime_adapter=_DummyAdapter(),
             use_gpu_pipeline=True,
             norm_mean=[0.5, 0.5, 0.5],
             norm_std=[0.5, 0.5, 0.5],
@@ -177,12 +169,10 @@ class TestIInferenceServiceBuildRequest:
         assert request.execution_request.mean_255 is not None
 
     def test_build_runtime_execution_request_raises_if_missing_norm(self, service):
-        from unittest.mock import MagicMock
-
         with pytest.raises(ValueError, match="normalize パラメータが必要"):
             service.build_runtime_execution_request(
-                data_loader=MagicMock(),
-                runtime_adapter=MagicMock(),
+                data_loader=DataLoader([]),
+                runtime_adapter=_DummyAdapter(),
                 use_gpu_pipeline=True,
             )
 
@@ -213,8 +203,8 @@ class TestIInferenceServiceRun:
         )
 
         request = RuntimeExecutionRequest(
-            data_loader=MagicMock(),
-            runtime_adapter=MagicMock(),
+            data_loader=DataLoader([]),
+            runtime_adapter=_DummyAdapter(),
             execution_request=ExecutionRequest(use_gpu_pipeline=False),
         )
 


### PR DESCRIPTION
## Summary

- `test_runtime_adapters.py` の TRT/ONNX `gpu_non_blocking` 重複テストを `@pytest.mark.parametrize` で統合した.
- `test_base_inference_service.py` の `MagicMock` を `_DummyAdapter` スタブと実 `DataLoader` に置換した.
- `test_pytorch_inference_service.py` の `create_dataset_and_params` 完全モックを削除し, `create_dummy_dataset` フィクスチャによる実データテストに移行した.

## Related Issue

Closes #290

## Changes

### `test_runtime_adapters.py`
- `test_trt_adapter_passes_gpu_non_blocking_to_gpu_normalize` と `test_onnx_adapter_passes_gpu_non_blocking_to_gpu_normalize` を `@pytest.mark.parametrize` で `test_adapter_passes_gpu_non_blocking_to_gpu_normalize[trt/onnx]` に統合した.

```python
# tests/unit/test_inference/test_runtime_adapters.py
@pytest.mark.parametrize(
    "adapter_cls, stub_factory",
    [
        (TensorRTRuntimeAdapter, _StubTrtInference),
        (OnnxRuntimeAdapter, _StubOnnxInference),
    ],
    ids=["trt", "onnx"],
)
def test_adapter_passes_gpu_non_blocking_to_gpu_normalize(
    monkeypatch, adapter_cls, stub_factory
) -> None:
```

### `test_base_inference_service.py`
- `TestIInferenceServiceBuildRequest` と `TestIInferenceServiceRun` で `MagicMock()` を `_DummyAdapter()` と `DataLoader([])` に置換した.

```python
# tests/unit/test_inference/test_base_inference_service.py
class _DummyAdapter:
    """build_runtime_execution_request 用の最小アダプタスタブ."""

    device = "cpu"
```

### `test_pytorch_inference_service.py`
- `@patch("...create_dataset_and_params")` を削除し, `create_dummy_dataset` フィクスチャで実ディレクトリを構築して `create_dataloader` を実際に呼び出すテストに変更した.

## Test Plan

- [x] `uv run pytest tests/unit/test_inference/test_runtime_adapters.py tests/unit/test_inference/test_base_inference_service.py tests/unit/test_inference/test_pytorch_inference_service.py -v` (22 passed)

## Checklist

- [x] `uv run pre-commit run --all-files`