### PR TITLE
refactor: テスト間で重複するフィクスチャ・ヘルパーを共通化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,16 @@
 - `test_training_loop.py` / `test_training_configurator.py` のプライベートメソッド直接テストを公開 API 経由に移行した ([#295](https://github.com/kurorosu/pochitrain/pull/295)).
   - `_update_best_and_check_early_stop()` の直接テストを `run()` 経由の古典派テストに置き換えた.
   - `_get_layer_group()` / `_build_layer_wise_param_groups()` の直接テストを `configure()` 経由の検証に移行した.
-- `test_runtime_adapters.py` の TRT/ONNX 重複テストを統合し, inference 系テストのモックを削減した (N/A.).
+- `test_runtime_adapters.py` の TRT/ONNX 重複テストを統合し, inference 系テストのモックを削減した ([#296](https://github.com/kurorosu/pochitrain/pull/296)).
   - TRT/ONNX `gpu_non_blocking` 重複テストを `@pytest.mark.parametrize` で統合した.
   - `test_base_inference_service.py` の `MagicMock` を `_DummyAdapter` スタブと実 `DataLoader` に置換した.
   - `test_pytorch_inference_service.py` の `create_dataset_and_params` 完全モックを実データテストに移行した.
+- テスト間で重複するフィクスチャ・ヘルパーを共通化した (N/A.).
+  - `logger` フィクスチャを `test_core/conftest.py` に集約した.
+  - `SimpleModel` クラスを `test_onnx/conftest.py` に集約した.
+  - `test_pipeline_consistency.py` と `test_calibrator.py` のデータ生成ヘルパーを `create_dummy_dataset` フィクスチャに統合した.
+  - `test_convert_cli.py` の重複 `monkeypatch.setattr` を `_patch_convert_deps` ヘルパーに集約した.
+  - `test_export_onnx_cli.py` の `FakeOnnxExporterVerifyFail` テストを `run_export` フィクスチャ経由に統合した.
 
 ### Fixed
 - なし.

--- a/tests/unit/test_cli/test_export_onnx_cli.py
+++ b/tests/unit/test_cli/test_export_onnx_cli.py
@@ -266,30 +266,21 @@ class TestExportOnnxCli:
     def test_verify_failure_exits_with_error(
         self,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
+        run_export: RunExport,
     ) -> None:
         """verify が False の場合は終了する."""
         model_path = tmp_path / "model.pth"
         model_path.write_text("dummy", encoding="utf-8")
 
-        FakeOnnxExporter.instances.clear()
-        monkeypatch.setattr(
-            export_onnx_cli,
-            "OnnxExporter",
-            FakeOnnxExporterVerifyFail,
-        )
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "export-onnx",
-                str(model_path),
-                "--num-classes",
-                "2",
-                "--input-size",
-                "224",
-                "224",
-            ],
-        )
-
         with pytest.raises(SystemExit):
-            export_onnx_cli.main()
+            run_export(
+                [
+                    str(model_path),
+                    "--num-classes",
+                    "2",
+                    "--input-size",
+                    "224",
+                    "224",
+                ],
+                exporter_cls=FakeOnnxExporterVerifyFail,
+            )

--- a/tests/unit/test_core/conftest.py
+++ b/tests/unit/test_core/conftest.py
@@ -1,0 +1,11 @@
+"""test_core パッケージ共通フィクスチャ."""
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    """テスト用ロガー."""
+    return logging.getLogger("test")

--- a/tests/unit/test_core/test_checkpoint_store.py
+++ b/tests/unit/test_core/test_checkpoint_store.py
@@ -17,12 +17,6 @@ def work_dir(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def logger() -> logging.Logger:
-    """テスト用ロガー."""
-    return logging.getLogger("test_checkpoint_store")
-
-
-@pytest.fixture
 def store(work_dir: Path, logger: logging.Logger) -> CheckpointStore:
     """CheckpointStoreインスタンス."""
     return CheckpointStore(work_dir, logger)

--- a/tests/unit/test_core/test_evaluator.py
+++ b/tests/unit/test_core/test_evaluator.py
@@ -18,9 +18,8 @@ from pochitrain.training.evaluator import Evaluator
 
 
 @pytest.fixture
-def evaluator():
+def evaluator(logger: logging.Logger):
     """CPU上のEvaluatorインスタンスを返す."""
-    logger = logging.getLogger("test_evaluator")
     return Evaluator(device=torch.device("cpu"), logger=logger)
 
 

--- a/tests/unit/test_core/test_metrics_tracker.py
+++ b/tests/unit/test_core/test_metrics_tracker.py
@@ -11,12 +11,6 @@ from pochitrain.training.metrics_tracker import MetricsTracker
 
 
 @pytest.fixture
-def logger() -> logging.Logger:
-    """テスト用ロガー."""
-    return logging.getLogger("test_metrics_tracker")
-
-
-@pytest.fixture
 def visualization_dir(tmp_path: Path) -> Path:
     """テスト用の可視化出力ディレクトリ."""
     return tmp_path

--- a/tests/unit/test_onnx/conftest.py
+++ b/tests/unit/test_onnx/conftest.py
@@ -1,0 +1,35 @@
+"""test_onnx パッケージ共通フィクスチャ."""
+
+import torch
+import torch.nn as nn
+
+
+class SimpleModel(nn.Module):
+    """テスト用のシンプルなモデル."""
+
+    def __init__(self, num_classes: int = 10) -> None:
+        """モデルを初期化する.
+
+        Args:
+            num_classes: 出力クラス数.
+        """
+        super().__init__()
+        self.conv = nn.Conv2d(3, 16, kernel_size=3, padding=1)
+        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Linear(16, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """順伝播を行う.
+
+        Args:
+            x: 入力テンソル.
+
+        Returns:
+            ログイット.
+        """
+        x = self.conv(x)
+        x = torch.relu(x)
+        x = self.pool(x)
+        x = x.view(x.size(0), -1)
+        x = self.fc(x)
+        return x

--- a/tests/unit/test_onnx/test_exporter.py
+++ b/tests/unit/test_onnx/test_exporter.py
@@ -18,36 +18,7 @@ pytestmark = [
 
 from pochitrain.onnx.exporter import OnnxExporter
 
-
-class SimpleModel(nn.Module):
-    """テスト用のシンプルなモデル."""
-
-    def __init__(self, num_classes: int = 10) -> None:
-        """モデルを初期化する.
-
-        Args:
-            num_classes: 出力クラス数.
-        """
-        super().__init__()
-        self.conv = nn.Conv2d(3, 16, kernel_size=3, padding=1)
-        self.pool = nn.AdaptiveAvgPool2d(1)
-        self.fc = nn.Linear(16, num_classes)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """順伝播を行う.
-
-        Args:
-            x: 入力テンソル.
-
-        Returns:
-            ログイット.
-        """
-        x = self.conv(x)
-        x = torch.relu(x)
-        x = self.pool(x)
-        x = x.view(x.size(0), -1)
-        x = self.fc(x)
-        return x
+from .conftest import SimpleModel
 
 
 class TestOnnxExporterInit:

--- a/tests/unit/test_onnx/test_inference.py
+++ b/tests/unit/test_onnx/test_inference.py
@@ -21,36 +21,7 @@ pytestmark = [
 
 from pochitrain.onnx.inference import OnnxInference, check_gpu_availability
 
-
-class SimpleModel(nn.Module):
-    """テスト用のシンプルなモデル."""
-
-    def __init__(self, num_classes: int = 10) -> None:
-        """モデルを初期化する.
-
-        Args:
-            num_classes: 出力クラス数.
-        """
-        super().__init__()
-        self.conv = nn.Conv2d(3, 16, kernel_size=3, padding=1)
-        self.pool = nn.AdaptiveAvgPool2d(1)
-        self.fc = nn.Linear(16, num_classes)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """順伝播を行う.
-
-        Args:
-            x: 入力テンソル.
-
-        Returns:
-            ログイット.
-        """
-        x = self.conv(x)
-        x = torch.relu(x)
-        x = self.pool(x)
-        x = x.view(x.size(0), -1)
-        x = self.fc(x)
-        return x
+from .conftest import SimpleModel
 
 
 def create_test_onnx_model(tmp_path: Path, num_classes: int = 10) -> Path:


### PR DESCRIPTION
## Summary

- テスト間で独立定義されていたフィクスチャ・ヘルパーを conftest.py やモジュールレベルヘルパーに集約し, 保守コストを削減した.

## Related Issue

Closes #291

## Changes

### `logger` フィクスチャの集約
- `test_core/conftest.py` を新設し, `logger` フィクスチャを集約した.
- `test_checkpoint_store.py`, `test_metrics_tracker.py`, `test_evaluator.py` のローカル定義を削除した.

```python
# tests/unit/test_core/conftest.py (新規)
@pytest.fixture
def logger() -> logging.Logger:
    """テスト用ロガー."""
    return logging.getLogger("test")
```

### `SimpleModel` の集約
- `test_onnx/conftest.py` を新設し, `test_exporter.py` と `test_inference.py` で重複していた `SimpleModel` を集約した.

### データ生成ヘルパーの統合
- `test_pipeline_consistency.py` の `_make_data_root` と `test_calibrator.py` の `_create_data_dir` を既存の `create_dummy_dataset` フィクスチャに統合した.

### `test_convert_cli.py` の monkeypatch 重複解消
- 3箇所で重複していた `monkeypatch.setattr` を `_patch_convert_deps()` / `_make_mock_logger()` ヘルパーに集約した.

```python
# tests/unit/test_cli/test_convert_cli.py
def _patch_convert_deps(
    monkeypatch: pytest.MonkeyPatch,
    logger: SimpleNamespace,
    *,
    trt_available: bool = True,
) -> None:
    """convert_command の共通依存を patch する."""
    import pochitrain.tensorrt.converter as converter_module
    import pochitrain.tensorrt.inference as inference_module

    monkeypatch.setattr(converter_module, "TensorRTConverter", FakeConverter)
    monkeypatch.setattr(
        inference_module, "check_tensorrt_availability", lambda: trt_available
    )
    monkeypatch.setattr(pochi_cli, "setup_logging", lambda debug=False: logger)
```

### `test_export_onnx_cli.py` の統合
- `test_verify_failure_exits_with_error` を `run_export` フィクスチャ経由に統合した.

## Test Plan

- [x] `uv run pytest tests/unit/test_core/ -v` — logger フィクスチャ集約の検証
- [x] `uv run pytest tests/unit/test_onnx/ -v` — SimpleModel 集約の検証
- [x] `uv run pytest tests/unit/test_cli/test_pipeline_consistency.py tests/unit/test_tensorrt/test_calibrator.py -v` — データ生成ヘルパー統合の検証
- [x] `uv run pytest tests/unit/test_cli/test_convert_cli.py tests/unit/test_cli/test_export_onnx_cli.py -v` — ヘルパー化の検証

## Checklist

- [x] `uv run pre-commit run --all-files`