### PR TITLE
refactor: test_tensorrt/ のスタブ密結合と test_infer_onnx.py の内部メソッド patch を改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,15 @@
   - TRT/ONNX `gpu_non_blocking` 重複テストを `@pytest.mark.parametrize` で統合した.
   - `test_base_inference_service.py` の `MagicMock` を `_DummyAdapter` スタブと実 `DataLoader` に置換した.
   - `test_pytorch_inference_service.py` の `create_dataset_and_params` 完全モックを実データテストに移行した.
-- テスト間で重複するフィクスチャ・ヘルパーを共通化した (N/A.).
+- テスト間で重複するフィクスチャ・ヘルパーを共通化した ([#297](https://github.com/kurorosu/pochitrain/pull/297)).
   - `logger` フィクスチャを `test_core/conftest.py` に集約した.
   - `SimpleModel` クラスを `test_onnx/conftest.py` に集約した.
   - `test_pipeline_consistency.py` と `test_calibrator.py` のデータ生成ヘルパーを `create_dummy_dataset` フィクスチャに統合した.
   - `test_convert_cli.py` の重複 `monkeypatch.setattr` を `_patch_convert_deps` ヘルパーに集約した.
   - `test_export_onnx_cli.py` の `FakeOnnxExporterVerifyFail` テストを `run_export` フィクスチャ経由に統合した.
+- `test_tensorrt/` のスタブ密結合と `test_infer_onnx.py` の内部メソッド patch を改善した ([#298](https://github.com/kurorosu/pochitrain/pull/298)).
+  - `TestResolveIoBindings` の6テストと `TestResolveDynamicShape` の7テストを `@pytest.mark.parametrize` で集約した.
+  - `test_infer_onnx.py` の `set_input_gpu` 内部メソッド patch テストを削除した.
 
 ### Fixed
 - なし.

--- a/tests/unit/test_cli/test_infer_onnx.py
+++ b/tests/unit/test_cli/test_infer_onnx.py
@@ -175,40 +175,6 @@ class TestGpuFallbackReresolution:
         csv_files = list(output_dir.glob("*.csv"))
         assert len(csv_files) > 0
 
-    def test_main_fallback_uses_set_input_not_set_input_gpu(
-        self,
-        gpu_fallback_test_env,
-        tmp_path,
-    ):
-        """フォールバック後にset_input_gpu()が呼ばれないことを確認."""
-        from pochitrain.cli.infer_onnx import main
-
-        model_path, data_path = gpu_fallback_test_env
-        output_dir = tmp_path / "output"
-        output_dir.mkdir()
-
-        with (
-            _patch_fallback_runtime(
-                [
-                    "infer-onnx",
-                    str(model_path),
-                    "--data",
-                    str(data_path),
-                    "-o",
-                    str(output_dir),
-                    "--pipeline",
-                    "gpu",
-                ]
-            ),
-            patch(
-                "pochitrain.onnx.inference.OnnxInference.set_input_gpu",
-                side_effect=RuntimeError("set_input_gpuが呼ばれた"),
-            ) as mock_set_input_gpu,
-        ):
-            main()
-
-        mock_set_input_gpu.assert_not_called()
-
     def test_main_writes_benchmark_json_when_enabled(
         self,
         gpu_fallback_test_env,


### PR DESCRIPTION
## Summary

- `test_tensorrt/` の重複テストをパラメータ化で集約し, `test_infer_onnx.py` の内部メソッド patch テストを削除した.

## Related Issue

Closes #292

## Changes

### `test_inference.py`: `TestResolveIoBindings` のパラメータ化
- 正常系2テスト (`test_single_input_output`, `test_reversed_order`) を `test_resolves_single_io` に統合した.
- エラー系4テスト (`test_multiple_inputs_raises` 等) を `test_raises_on_invalid_io_count` に統合した.

```python
# tests/unit/test_tensorrt/test_inference.py
@pytest.mark.parametrize(
    "tensor_specs, expected",
    [
        pytest.param([...], {"input": "input", "output": "output"}, id="standard-order"),
        pytest.param([...], {"input": "input", "output": "output"}, id="reversed-order"),
    ],
)
def test_resolves_single_io(self, tensor_specs, expected) -> None:
```

### `test_converter.py`: `TestResolveDynamicShape` のパラメータ化
- 正常系6テストを `test_resolves_shape` に統合した.
- エラー系1テスト (`test_spatial_dynamic_without_input_shape_raises`) は単体で維持した.

### `test_infer_onnx.py`: 内部メソッド patch テストの削除
- `test_main_fallback_uses_set_input_not_set_input_gpu` を削除した.
- `test_main_does_not_crash_when_cuda_ep_unavailable` がフォールバック後の正常完走 (CSV 出力) を既に検証しているため, 内部メソッドの呼び出し有無を検証する必要はない.

## Test Plan

- [x] `uv run pytest tests/unit/test_tensorrt/test_inference.py tests/unit/test_tensorrt/test_converter.py tests/unit/test_cli/test_infer_onnx.py -v` (26 passed, 2 skipped)

## Checklist

- [x] `uv run pre-commit run --all-files`