### PR TITLE
refactor: pochi_dataset.py のTransform検証ロジックとDataset __getitem__ の重複を排除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   - `TestResolveIoBindings` の6テストと `TestResolveDynamicShape` の7テストを `@pytest.mark.parametrize` で集約した.
   - `test_infer_onnx.py` の `set_input_gpu` 内部メソッド patch テストを削除した.
 
+- `pochi_dataset.py` の Transform 検証ロジックと Dataset `__getitem__` の重複を排除した ([#299](https://github.com/kurorosu/pochitrain/pull/299)).
+  - `_PIL_ONLY_TRANSFORMS` をモジュールレベル定数に集約した.
+  - PIL専用 transform の検出ロジックを `_check_pil_transform` に抽出した.
+  - `GpuInferenceDataset.__getitem__` を削除し, `FastInferenceDataset.__getitem__` の実装を再利用するようにエラーハンドリング処理を統一した.
+
 ### Fixed
 - なし.
 


### PR DESCRIPTION
## Summary

`pochi_dataset.py` に存在していた2種類の重複パターン（TransformのPIL検証ロジックと `__getitem__` のエラーハンドリング）を集約し、保守性を向上させた.

## Related Issue

Closes #271

## Changes

- `_PIL_ONLY_TRANSFORMS` をファイルの先頭にモジュールレベル定数として一元化
- PIL 専用 transform の検出を行う共通フロー（判定・警告ログ出力・True/Falseの返却）を `_check_pil_transform` ヘルパー関数に抽出
- `GpuInferenceDataset.__getitem__` を削除し、親クラス `FastInferenceDataset.__getitem__` の実装内で `type(self).__name__` を利用することでエラーメッセージ出力を統一

## Test Plan

- [x] 既存の pytest が全てパスすることを確認
- [x] `uv run pre-commit run --all-files` 実行により静的解析エラーがないことを確認

## Checklist

- [x] `uv run pre-commit run --all-files`