### PR TITLE
release: v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,7 @@
 - なし.
 
 ### Changed
-- コード品質・設計パターンを改善した (N/A.).
-  - `Evaluator.calculate_accuracy` の戻り値型を `Dict[str, float]` から `Dict[str, Any]` に修正した.
-  - `TrainingLoop.run()` の引数16個を `TrainingContext` dataclass に集約した.
-  - `PochiImageDataset.get_class_counts` を `Counter` ベースに書き換え, 計算量を O(n*m) から O(n) に改善した.
-  - `TrainingConfigurator._build_optimizer` を if-elif チェーンから辞書マッピング + `functools.partial` 方式に変更し, `_build_scheduler` とスタイルを統一した.
-  - `pochitrain/` 配下の全ファイルで typing の `Dict`, `List`, `Tuple` を built-in 型 (`dict`, `list`, `tuple`) に統一した.
+- なし.
 
 ### Fixed
 - なし.
@@ -22,40 +17,25 @@
 ### Removed
 - なし.
 
-## v1.7.2 (2026-02-28)
+## v1.7.3 (2026-03-14)
 
 ### 概要
-- テストコードのリファクタリングと本番コードの重複排除を行ったパッチリリースです.
+- コード品質・設計パターンの改善と mypy エラーの全件解消を行ったパッチリリースです.
 
 ### Added
 - なし.
 
 ### Changed
-- `test_objective.py` の白箱テストを古典派テストへ移行した ([#293](https://github.com/kurorosu/pochitrain/pull/293)).
-  - `FakeTrainer` から `last_init_kwargs` / `last_setup_kwargs` による内部呼び出し検証を削除し, 観測可能な出力 (戻り値, trial.reported) を基準とするテストへ再構成した.
-- `test_pochi_cli_infer.py` の `_ServiceStub` を簡素化し, 設定ヘルパーの重複を解消した ([#294](https://github.com/kurorosu/pochitrain/pull/294)).
-  - `_ServiceStub` から `captured` dict による内部引数検証を削除し, 観測可能な副作用 (ファイル作成, 集計実行有無) のみで検証するテストへ移行した.
-  - `_build_config_dict` / `_build_minimal_config` を `test_cli/conftest.py` の `build_cli_config()` に集約した.
-- `test_training_loop.py` / `test_training_configurator.py` のプライベートメソッド直接テストを公開 API 経由に移行した ([#295](https://github.com/kurorosu/pochitrain/pull/295)).
-  - `_update_best_and_check_early_stop()` の直接テストを `run()` 経由の古典派テストに置き換えた.
-  - `_get_layer_group()` / `_build_layer_wise_param_groups()` の直接テストを `configure()` 経由の検証に移行した.
-- `test_runtime_adapters.py` の TRT/ONNX 重複テストを統合し, inference 系テストのモックを削減した ([#296](https://github.com/kurorosu/pochitrain/pull/296)).
-  - TRT/ONNX `gpu_non_blocking` 重複テストを `@pytest.mark.parametrize` で統合した.
-  - `test_base_inference_service.py` の `MagicMock` を `_DummyAdapter` スタブと実 `DataLoader` に置換した.
-  - `test_pytorch_inference_service.py` の `create_dataset_and_params` 完全モックを実データテストに移行した.
-- テスト間で重複するフィクスチャ・ヘルパーを共通化した ([#297](https://github.com/kurorosu/pochitrain/pull/297)).
-  - `logger` フィクスチャを `test_core/conftest.py` に集約した.
-  - `SimpleModel` クラスを `test_onnx/conftest.py` に集約した.
-  - `test_pipeline_consistency.py` と `test_calibrator.py` のデータ生成ヘルパーを `create_dummy_dataset` フィクスチャに統合した.
-  - `test_convert_cli.py` の重複 `monkeypatch.setattr` を `_patch_convert_deps` ヘルパーに集約した.
-  - `test_export_onnx_cli.py` の `FakeOnnxExporterVerifyFail` テストを `run_export` フィクスチャ経由に統合した.
-- `test_tensorrt/` のスタブ密結合と `test_infer_onnx.py` の内部メソッド patch を改善した ([#298](https://github.com/kurorosu/pochitrain/pull/298)).
-  - `TestResolveIoBindings` の6テストと `TestResolveDynamicShape` の7テストを `@pytest.mark.parametrize` で集約した.
-  - `test_infer_onnx.py` の `set_input_gpu` 内部メソッド patch テストを削除した.
-- `pochi_dataset.py` の Transform 検証ロジックと Dataset `__getitem__` の重複を排除した ([#299](https://github.com/kurorosu/pochitrain/pull/299)).
-  - `_PIL_ONLY_TRANSFORMS` をモジュールレベル定数に集約した.
-  - PIL専用 transform の検出ロジックを `_check_pil_transform` に抽出した.
-  - `GpuInferenceDataset.__getitem__` を削除し, `FastInferenceDataset.__getitem__` の実装を再利用するようにエラーハンドリング処理を統一した.
+- コード品質・設計パターンを改善した (N/A.).
+  - `Evaluator.calculate_accuracy` の戻り値型を `Dict[str, float]` から `Dict[str, Any]` に修正した.
+  - `TrainingLoop.run()` の引数16個を `TrainingContext` dataclass に集約した.
+  - `PochiImageDataset.get_class_counts` を `Counter` ベースに書き換え, 計算量を O(n*m) から O(n) に改善した.
+  - `TrainingConfigurator._build_optimizer` を if-elif チェーンから辞書マッピング + `functools.partial` 方式に変更し, `_build_scheduler` とスタイルを統一した.
+  - `pochitrain/` 配下の全ファイルで typing の `Dict`, `List`, `Tuple` を built-in 型 (`dict`, `list`, `tuple`) に統一した.
+- mypy エラーを全件解消した (N/A.).
+  - `pyproject.toml` の mypy 設定に `benchmark_runs/` と `work_dirs/` の除外を追加した.
+  - `DefaultParamSuggestor` / `LayerWiseLRSuggestor` の `suggest()` 引数型を `optuna.Trial` から `optuna.trial.BaseTrial` に変更した.
+  - `create_calibration_dataset` の戻り値型を `Dataset[Any]` から `PochiImageDataset | Subset[Any]` に変更した.
 
 ### Fixed
 - なし.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pochitrain
 
-[![Version](https://img.shields.io/badge/version-1.7.2-blue.svg)](https://github.com/kurorosu/pochitrain)
+[![Version](https://img.shields.io/badge/version-1.7.3-blue.svg)](https://github.com/kurorosu/pochitrain)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.13+-yellow.svg)](https://www.python.org/)
 [![Jetson](https://img.shields.io/badge/Jetson-JetPack%206.2.1%20%28Python%203.10%29-76B900.svg)](https://developer.nvidia.com/embedded/jetpack)

--- a/changelogs/1.7.x.md
+++ b/changelogs/1.7.x.md
@@ -1,5 +1,46 @@
 # Changelog 1.7.x
 
+## v1.7.2 (2026-02-28)
+
+### 概要
+- テストコードのリファクタリングと本番コードの重複排除を行ったパッチリリースです.
+
+### Added
+- なし.
+
+### Changed
+- `test_objective.py` の白箱テストを古典派テストへ移行した ([#293](https://github.com/kurorosu/pochitrain/pull/293)).
+  - `FakeTrainer` から `last_init_kwargs` / `last_setup_kwargs` による内部呼び出し検証を削除し, 観測可能な出力 (戻り値, trial.reported) を基準とするテストへ再構成した.
+- `test_pochi_cli_infer.py` の `_ServiceStub` を簡素化し, 設定ヘルパーの重複を解消した ([#294](https://github.com/kurorosu/pochitrain/pull/294)).
+  - `_ServiceStub` から `captured` dict による内部引数検証を削除し, 観測可能な副作用 (ファイル作成, 集計実行有無) のみで検証するテストへ移行した.
+  - `_build_config_dict` / `_build_minimal_config` を `test_cli/conftest.py` の `build_cli_config()` に集約した.
+- `test_training_loop.py` / `test_training_configurator.py` のプライベートメソッド直接テストを公開 API 経由に移行した ([#295](https://github.com/kurorosu/pochitrain/pull/295)).
+  - `_update_best_and_check_early_stop()` の直接テストを `run()` 経由の古典派テストに置き換えた.
+  - `_get_layer_group()` / `_build_layer_wise_param_groups()` の直接テストを `configure()` 経由の検証に移行した.
+- `test_runtime_adapters.py` の TRT/ONNX 重複テストを統合し, inference 系テストのモックを削減した ([#296](https://github.com/kurorosu/pochitrain/pull/296)).
+  - TRT/ONNX `gpu_non_blocking` 重複テストを `@pytest.mark.parametrize` で統合した.
+  - `test_base_inference_service.py` の `MagicMock` を `_DummyAdapter` スタブと実 `DataLoader` に置換した.
+  - `test_pytorch_inference_service.py` の `create_dataset_and_params` 完全モックを実データテストに移行した.
+- テスト間で重複するフィクスチャ・ヘルパーを共通化した ([#297](https://github.com/kurorosu/pochitrain/pull/297)).
+  - `logger` フィクスチャを `test_core/conftest.py` に集約した.
+  - `SimpleModel` クラスを `test_onnx/conftest.py` に集約した.
+  - `test_pipeline_consistency.py` と `test_calibrator.py` のデータ生成ヘルパーを `create_dummy_dataset` フィクスチャに統合した.
+  - `test_convert_cli.py` の重複 `monkeypatch.setattr` を `_patch_convert_deps` ヘルパーに集約した.
+  - `test_export_onnx_cli.py` の `FakeOnnxExporterVerifyFail` テストを `run_export` フィクスチャ経由に統合した.
+- `test_tensorrt/` のスタブ密結合と `test_infer_onnx.py` の内部メソッド patch を改善した ([#298](https://github.com/kurorosu/pochitrain/pull/298)).
+  - `TestResolveIoBindings` の6テストと `TestResolveDynamicShape` の7テストを `@pytest.mark.parametrize` で集約した.
+  - `test_infer_onnx.py` の `set_input_gpu` 内部メソッド patch テストを削除した.
+- `pochi_dataset.py` の Transform 検証ロジックと Dataset `__getitem__` の重複を排除した ([#299](https://github.com/kurorosu/pochitrain/pull/299)).
+  - `_PIL_ONLY_TRANSFORMS` をモジュールレベル定数に集約した.
+  - PIL専用 transform の検出ロジックを `_check_pil_transform` に抽出した.
+  - `GpuInferenceDataset.__getitem__` を削除し, `FastInferenceDataset.__getitem__` の実装を再利用するようにエラーハンドリング処理を統一した.
+
+### Fixed
+- なし.
+
+### Removed
+- なし.
+
 ## v1.7.1 (2026-02-28)
 
 ### 概要

--- a/pochitrain/__init__.py
+++ b/pochitrain/__init__.py
@@ -22,7 +22,7 @@ from .pochi_predictor import PochiPredictor
 from .pochi_trainer import PochiTrainer
 from .utils.directory_manager import InferenceWorkspaceManager, PochiWorkspaceManager
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 __author__ = "Pochi Team"
 __email__ = "pochi@example.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochitrain"
-version = "1.7.2"
+version = "1.7.3"
 description = "Simple CNN training framework for image classification"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1769,7 +1769,7 @@ wheels = [
 
 [[package]]
 name = "pochitrain"
-version = "1.7.2"
+version = "1.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
## Summary

- バージョンを `1.7.2` → `1.7.3` に更新した.
- CHANGELOG の `[Unreleased]` を `v1.7.3` に確定し, `v1.7.2` の履歴をアーカイブした.

## Related Issue

無し.

## Changes

- `pyproject.toml`, `pochitrain/__init__.py`, `README.md` のバージョンを `1.7.3` に更新.
- `uv.lock` を更新.
- `CHANGELOG.md` の `[Unreleased]` の内容を `v1.7.3 (2026-03-14)` に移動.
- `v1.7.2` の履歴を `changelogs/1.7.x.md` に移動.

## Test Plan

- `uv run pytest` で全テスト (528 passed, 2 skipped) がパスすることを確認済み.
- `uv run mypy .` でエラー 0 件を確認済み.

## Checklist

- [x] `uv run pre-commit run --all-files`