### PR TITLE
fix: CHANGELOG v1.7.3 の PR 参照修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,13 @@
 - なし.
 
 ### Changed
-- コード品質・設計パターンを改善した (N/A.).
+- コード品質・設計パターンを改善した ([#305](https://github.com/kurorosu/pochitrain/pull/305)).
   - `Evaluator.calculate_accuracy` の戻り値型を `Dict[str, float]` から `Dict[str, Any]` に修正した.
   - `TrainingLoop.run()` の引数16個を `TrainingContext` dataclass に集約した.
   - `PochiImageDataset.get_class_counts` を `Counter` ベースに書き換え, 計算量を O(n*m) から O(n) に改善した.
   - `TrainingConfigurator._build_optimizer` を if-elif チェーンから辞書マッピング + `functools.partial` 方式に変更し, `_build_scheduler` とスタイルを統一した.
   - `pochitrain/` 配下の全ファイルで typing の `Dict`, `List`, `Tuple` を built-in 型 (`dict`, `list`, `tuple`) に統一した.
-- mypy エラーを全件解消した (N/A.).
+- mypy エラーを全件解消した ([#305](https://github.com/kurorosu/pochitrain/pull/305)).
   - `pyproject.toml` の mypy 設定に `benchmark_runs/` と `work_dirs/` の除外を追加した.
   - `DefaultParamSuggestor` / `LayerWiseLRSuggestor` の `suggest()` 引数型を `optuna.Trial` から `optuna.trial.BaseTrial` に変更した.
   - `create_calibration_dataset` の戻り値型を `Dataset[Any]` から `PochiImageDataset | Subset[Any]` に変更した.


### PR DESCRIPTION
## Summary

- CHANGELOG.md の v1.7.3 セクションで `N/A.` のまま残っていた PR 参照2箇所を `#305` に修正した.

## Related Issue

無し.

## Changes

- `CHANGELOG.md` の v1.7.3 Changed セクション内の `(N/A.)` を `([#305](https://github.com/kurorosu/pochitrain/pull/305))` に置換した.

## Test Plan

- CHANGELOG.md の記述修正のみのため, テスト不要.

## Checklist

- [x] `uv run pre-commit run --all-files`