### PR TITLE
chore: v1.7.4 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
 ## [Unreleased]
 
 ### Added
+- なし.
+
+### Changed
+- なし.
+
+### Fixed
+- なし.
+
+### Removed
+- なし.
+
+## v1.7.4 (2026-03-14)
+
+### 概要
+- テスト品質, セキュリティ・依存関係, ドキュメント・API設計に関する問題点を改善したパッチリリースです.
+
+### Added
 - テスト品質に関する改善を行った ([#308](https://github.com/kurorosu/pochitrain/pull/308)).
   - `model_loading.py` の専用ユニットテストを追加した.
   - `json_utils.py` の専用ユニットテストを追加した.
@@ -32,32 +49,6 @@
   - `configuration.md` の `device` パラメータ説明を実装に合わせて修正した.
   - Python バージョンバッジを `pyproject.toml` の `>=3.10` に合わせて修正した.
   - `__init__.py` の `__all__` から内部クラスを除外した.
-
-### Fixed
-- なし.
-
-### Removed
-- なし.
-
-## v1.7.3 (2026-03-14)
-
-### 概要
-- コード品質・設計パターンの改善と mypy エラーの全件解消を行ったパッチリリースです.
-
-### Added
-- なし.
-
-### Changed
-- コード品質・設計パターンを改善した ([#305](https://github.com/kurorosu/pochitrain/pull/305)).
-  - `Evaluator.calculate_accuracy` の戻り値型を `Dict[str, float]` から `Dict[str, Any]` に修正した.
-  - `TrainingLoop.run()` の引数16個を `TrainingContext` dataclass に集約した.
-  - `PochiImageDataset.get_class_counts` を `Counter` ベースに書き換え, 計算量を O(n*m) から O(n) に改善した.
-  - `TrainingConfigurator._build_optimizer` を if-elif チェーンから辞書マッピング + `functools.partial` 方式に変更し, `_build_scheduler` とスタイルを統一した.
-  - `pochitrain/` 配下の全ファイルで typing の `Dict`, `List`, `Tuple` を built-in 型 (`dict`, `list`, `tuple`) に統一した.
-- mypy エラーを全件解消した ([#305](https://github.com/kurorosu/pochitrain/pull/305)).
-  - `pyproject.toml` の mypy 設定に `benchmark_runs/` と `work_dirs/` の除外を追加した.
-  - `DefaultParamSuggestor` / `LayerWiseLRSuggestor` の `suggest()` 引数型を `optuna.Trial` から `optuna.trial.BaseTrial` に変更した.
-  - `create_calibration_dataset` の戻り値型を `Dataset[Any]` から `PochiImageDataset | Subset[Any]` に変更した.
 
 ### Fixed
 - なし.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pochitrain
 
-[![Version](https://img.shields.io/badge/version-1.7.3-blue.svg)](https://github.com/kurorosu/pochitrain)
+[![Version](https://img.shields.io/badge/version-1.7.4-blue.svg)](https://github.com/kurorosu/pochitrain)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-yellow.svg)](https://www.python.org/)
 [![Jetson](https://img.shields.io/badge/Jetson-JetPack%206.2.1%20%28Python%203.10%29-76B900.svg)](https://developer.nvidia.com/embedded/jetpack)

--- a/changelogs/1.7.x.md
+++ b/changelogs/1.7.x.md
@@ -1,5 +1,31 @@
 # Changelog 1.7.x
 
+## v1.7.3 (2026-03-14)
+
+### 概要
+- コード品質・設計パターンの改善と mypy エラーの全件解消を行ったパッチリリースです.
+
+### Added
+- なし.
+
+### Changed
+- コード品質・設計パターンを改善した ([#305](https://github.com/kurorosu/pochitrain/pull/305)).
+  - `Evaluator.calculate_accuracy` の戻り値型を `Dict[str, float]` から `Dict[str, Any]` に修正した.
+  - `TrainingLoop.run()` の引数16個を `TrainingContext` dataclass に集約した.
+  - `PochiImageDataset.get_class_counts` を `Counter` ベースに書き換え, 計算量を O(n*m) から O(n) に改善した.
+  - `TrainingConfigurator._build_optimizer` を if-elif チェーンから辞書マッピング + `functools.partial` 方式に変更し, `_build_scheduler` とスタイルを統一した.
+  - `pochitrain/` 配下の全ファイルで typing の `Dict`, `List`, `Tuple` を built-in 型 (`dict`, `list`, `tuple`) に統一した.
+- mypy エラーを全件解消した ([#305](https://github.com/kurorosu/pochitrain/pull/305)).
+  - `pyproject.toml` の mypy 設定に `benchmark_runs/` と `work_dirs/` の除外を追加した.
+  - `DefaultParamSuggestor` / `LayerWiseLRSuggestor` の `suggest()` 引数型を `optuna.Trial` から `optuna.trial.BaseTrial` に変更した.
+  - `create_calibration_dataset` の戻り値型を `Dataset[Any]` から `PochiImageDataset | Subset[Any]` に変更した.
+
+### Fixed
+- なし.
+
+### Removed
+- なし.
+
 ## v1.7.2 (2026-02-28)
 
 ### 概要

--- a/pochitrain/__init__.py
+++ b/pochitrain/__init__.py
@@ -20,7 +20,7 @@ from .pochi_dataset import (
 from .pochi_predictor import PochiPredictor
 from .pochi_trainer import PochiTrainer
 
-__version__ = "1.7.3"
+__version__ = "1.7.4"
 __author__ = "Pochi Team"
 __email__ = "pochi@example.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochitrain"
-version = "1.7.3"
+version = "1.7.4"
 description = "Simple CNN training framework for image classification"
 readme = "README.md"
 # Jetson (JetPack 6.2.1 / Python 3.10) で pip install -e . するため >=3.10 を維持.

--- a/uv.lock
+++ b/uv.lock
@@ -1769,7 +1769,7 @@ wheels = [
 
 [[package]]
 name = "pochitrain"
-version = "1.7.3"
+version = "1.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
## Summary

- テスト品質, セキュリティ・依存関係, ドキュメント・API設計に関する問題点を改善したパッチリリース.
- バージョン番号を `1.7.3` → `1.7.4` に更新し, v1.7.3 の changelog をアーカイブした.

## Related Issue

無し

## Changes

### バージョン番号更新
- `pyproject.toml`, `pochitrain/__init__.py`, `README.md` のバージョンを `1.7.4` に更新した.
- `uv lock` で lockfile を更新した.

### Changelog 整理
- `CHANGELOG.md` の `[Unreleased]` を `v1.7.4 (2026-03-14)` としてリリースした.
- `v1.7.3` のエントリを `changelogs/1.7.x.md` にアーカイブした.

### v1.7.4 に含まれる変更 (マージ済み)
- テスト品質に関する改善 ([#308](https://github.com/kurorosu/pochitrain/pull/308))
- セキュリティ・依存関係に関する改善 ([#309](https://github.com/kurorosu/pochitrain/pull/309))
- ドキュメント・API設計に関する改善 ([#310](https://github.com/kurorosu/pochitrain/pull/310))

## Test Plan

- [x] `uv run pytest` で全テストが通ること
- [x] `uv run pre-commit run --all-files`
- [x] `uv lock` が成功すること

## Checklist

- [x] `uv run pre-commit run --all-files`