### PR TITLE
refactor: sys.exit(1) を例外 raise に置き換え, 例外チェーンを保持するよう改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
   - `tensorboard>=2.14.0` を依存関係に追加した.
 
 ### Changed
-- なし.
+- 例外処理を改善した (N/A.).
+  - `pochi_predictor.py` の例外チェーンを `from e` 付きに修正し, デバッグ時のスタックトレースを保持するようにした.
+  - `inference_utils.py` の `sys.exit(1)` を `FileNotFoundError` / `RuntimeError` に置き換え, Jupyter 等での利用を可能にした.
+  - CLI 側で例外をキャッチしてエラーログ出力後に安全に終了するようにした.
 
 ### Fixed
 - なし.

--- a/pochitrain/cli/infer_onnx.py
+++ b/pochitrain/cli/infer_onnx.py
@@ -94,9 +94,17 @@ def main() -> None:
     manager.set_logger_level(__name__, level)
 
     model_path = Path(args.model_path)
-    validate_model_path(model_path)
+    try:
+        validate_model_path(model_path)
+    except FileNotFoundError as e:
+        logger.error(str(e))
+        sys.exit(1)
 
-    config = load_config_auto(model_path)
+    try:
+        config = load_config_auto(model_path)
+    except (FileNotFoundError, RuntimeError) as e:
+        logger.error(str(e))
+        sys.exit(1)
 
     cli_request = InferenceCliRequest(
         model_path=model_path,

--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -98,7 +98,11 @@ def main() -> None:
     manager.set_logger_level(__name__, level)
 
     engine_path = Path(args.engine_path)
-    validate_model_path(engine_path)
+    try:
+        validate_model_path(engine_path)
+    except FileNotFoundError as e:
+        logger.error(str(e))
+        sys.exit(1)
 
     try:
         inference = orchestration_service.create_trt_inference(engine_path)
@@ -109,7 +113,11 @@ def main() -> None:
         )
         sys.exit(1)
 
-    config = load_config_auto(engine_path)
+    try:
+        config = load_config_auto(engine_path)
+    except (FileNotFoundError, RuntimeError) as e:
+        logger.error(str(e))
+        sys.exit(1)
 
     cli_request = InferenceCliRequest(
         model_path=engine_path,

--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -334,7 +334,11 @@ def infer_command(args: argparse.Namespace) -> None:
     logger.debug("=== pochitrain 推論モード ===")
 
     model_path = Path(args.model_path)
-    validate_model_path(model_path)
+    try:
+        validate_model_path(model_path)
+    except FileNotFoundError as e:
+        logger.error(str(e))
+        return
     logger.debug(f"使用するモデル: {model_path}")
 
     if args.config_path:
@@ -346,7 +350,11 @@ def infer_command(args: argparse.Namespace) -> None:
             logger.error(f"設定ファイル読み込みエラー: {e}")
             return
     else:
-        config = load_config_auto(model_path)
+        try:
+            config = load_config_auto(model_path)
+        except (FileNotFoundError, RuntimeError) as e:
+            logger.error(str(e))
+            return
 
     try:
         pochi_config = PochiConfig.from_dict(config)
@@ -728,7 +736,11 @@ def convert_command(args: argparse.Namespace) -> None:
                 logger.error(f"設定ファイル読み込みエラー: {e}")
                 return
         else:
-            config = load_config_auto(onnx_path)
+            try:
+                config = load_config_auto(onnx_path)
+            except (FileNotFoundError, RuntimeError) as e:
+                logger.error(str(e))
+                return
 
         if args.calib_data:
             calib_data_root = args.calib_data

--- a/pochitrain/pochi_predictor.py
+++ b/pochitrain/pochi_predictor.py
@@ -96,7 +96,7 @@ class PochiPredictor:
             self.logger.debug(f"学習済みモデルを読み込み: {self.model_path}")
 
         except Exception as e:
-            raise RuntimeError(f"モデルの読み込みに失敗しました: {e}")
+            raise RuntimeError(f"モデルの読み込みに失敗しました: {e}") from e
 
     def predict(
         self,

--- a/pochitrain/utils/inference_utils.py
+++ b/pochitrain/utils/inference_utils.py
@@ -6,7 +6,6 @@ PyTorch, ONNX, TensorRT推論CLIで共通して使用する処理を提供.
 import csv
 import importlib
 import logging
-import sys
 from pathlib import Path
 from typing import Any, Optional
 
@@ -217,11 +216,10 @@ def validate_model_path(model_path: Path) -> None:
         model_path: モデルファイルパス
 
     Raises:
-        SystemExit: モデルファイルが存在しない場合
+        FileNotFoundError: モデルファイルが存在しない場合
     """
     if not model_path.exists():
-        logger.error(f"モデルファイルが見つかりません: {model_path}")
-        sys.exit(1)
+        raise FileNotFoundError(f"モデルファイルが見つかりません: {model_path}")
 
 
 def validate_data_path(data_path: Path) -> None:
@@ -231,11 +229,10 @@ def validate_data_path(data_path: Path) -> None:
         data_path: データディレクトリパス
 
     Raises:
-        SystemExit: データディレクトリが存在しない場合
+        FileNotFoundError: データディレクトリが存在しない場合
     """
     if not data_path.exists():
-        logger.error(f"データディレクトリが見つかりません: {data_path}")
-        sys.exit(1)
+        raise FileNotFoundError(f"データディレクトリが見つかりません: {data_path}")
 
 
 def load_config_auto(model_path: Path) -> dict[str, Any]:
@@ -248,13 +245,15 @@ def load_config_auto(model_path: Path) -> dict[str, Any]:
         読み込んだconfig辞書
 
     Raises:
-        SystemExit: configファイルが見つからない、または読み込めない場合
+        FileNotFoundError: configファイルが見つからない場合
+        RuntimeError: configファイルの読み込みに失敗した場合
     """
     config_path = auto_detect_config_path(model_path)
     if not config_path.exists():
-        logger.error(f"設定ファイルが見つかりません: {config_path}")
-        logger.error("モデルパスと同じwork_dir内にconfig.pyが必要です")
-        sys.exit(1)
+        raise FileNotFoundError(
+            f"設定ファイルが見つかりません: {config_path}\n"
+            "モデルパスと同じwork_dir内にconfig.pyが必要です"
+        )
 
     try:
         from pochitrain.utils.config_loader import ConfigLoader
@@ -263,8 +262,7 @@ def load_config_auto(model_path: Path) -> dict[str, Any]:
         logger.debug(f"設定ファイルを読み込み: {config_path}")
         return config
     except Exception as e:
-        logger.error(f"設定ファイル読み込みエラー: {e}")
-        sys.exit(1)
+        raise RuntimeError(f"設定ファイル読み込みエラー: {e}") from e
 
 
 def write_inference_csv(

--- a/tests/unit/test_utils/test_inference_utils.py
+++ b/tests/unit/test_utils/test_inference_utils.py
@@ -86,7 +86,7 @@ class TestValidateModelPath:
             assert result is None
             return
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FileNotFoundError):
             validate_model_path(model_file)
 
 
@@ -107,7 +107,7 @@ class TestValidateDataPath:
             assert result is None
             return
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(FileNotFoundError):
             validate_data_path(data_dir)
 
 


### PR DESCRIPTION
## Summary

- `inference_utils.py` の `sys.exit(1)` を適切な例外 raise に置き換え, Jupyter 等での利用を可能にした.
- `pochi_predictor.py` の例外チェーンを `from e` 付きに修正し, デバッグ時のスタックトレースを保持するようにした.

## Related Issue

Closes #312

## Changes

- `pochitrain/pochi_predictor.py`: `raise RuntimeError(...)` → `raise RuntimeError(...) from e` に修正.
- `pochitrain/utils/inference_utils.py`: `validate_model_path`, `validate_data_path`, `load_config_auto` の `sys.exit(1)` を `FileNotFoundError` / `RuntimeError` に置き換え. 不要な `import sys` を削除.
- `pochitrain/cli/pochi.py`: `validate_model_path` / `load_config_auto` の呼び出しを `try-except` でラップ.
- `pochitrain/cli/infer_onnx.py`: 同上.
- `pochitrain/cli/infer_trt.py`: 同上.
- `tests/unit/test_utils/test_inference_utils.py`: `pytest.raises(SystemExit)` → `pytest.raises(FileNotFoundError)` に更新.

## Code Changes

```python
# pochitrain/utils/inference_utils.py (変更前)
def validate_model_path(model_path: Path) -> None:
    if not model_path.exists():
        logger.error(f"モデルファイルが見つかりません: {model_path}")
        sys.exit(1)

# pochitrain/utils/inference_utils.py (変更後)
def validate_model_path(model_path: Path) -> None:
    if not model_path.exists():
        raise FileNotFoundError(f"モデルファイルが見つかりません: {model_path}")
```

## Test Plan

- [x] `uv run pytest` で全テストが通ること
- [x] `uv run pre-commit run --all-files`

## Checklist

- [x] `uv run pre-commit run --all-files`