### PR TITLE
refactor: FastInferenceDataset._transform_error_logged をインスタンス変数に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
   - CLI 側で例外をキャッチしてエラーログ出力後に安全に終了するようにした.
 - `PochiPredictor.predict()` の複雑度を削減した ([#327](https://github.com/kurorosu/pochitrain/pull/327)).
   - ウォームアップ, 初回バッチ実行, タイミング計測をヘルパーメソッドに分離した.
-- `pochi_dataset.py` の transform フィルタリングロジックの重複を解消した (N/A.).
+- `pochi_dataset.py` の transform フィルタリングロジックの重複を解消した ([#328](https://github.com/kurorosu/pochitrain/pull/328)).
   - 共通の `_filter_transforms()` 関数を抽出し, `build_gpu_preprocess_transform` と `convert_transform_for_fast_inference` から呼び出すようにした.
+- `FastInferenceDataset._transform_error_logged` をクラス変数からインスタンス変数に変更した ([#329](https://github.com/kurorosu/pochitrain/pull/329)).
 
 ### Fixed
 - なし.

--- a/pochitrain/pochi_dataset.py
+++ b/pochitrain/pochi_dataset.py
@@ -164,7 +164,15 @@ class FastInferenceDataset(PochiImageDataset):
         extensions: 許可する拡張子
     """
 
-    _transform_error_logged: bool = False
+    def __init__(
+        self,
+        root: str,
+        transform: Optional[Callable[..., Any]] = None,
+        extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png", ".bmp"),
+    ) -> None:
+        """FastInferenceDatasetを初期化."""
+        super().__init__(root=root, transform=transform, extensions=extensions)
+        self._transform_error_logged: bool = False
 
     def __getitem__(self, index: int) -> tuple[Tensor, int]:
         """指定されたインデックスのデータを返す."""
@@ -177,15 +185,14 @@ class FastInferenceDataset(PochiImageDataset):
             try:
                 image = self.transform(image)
             except Exception as e:
-                cls = type(self)
-                if not cls._transform_error_logged:
-                    dataset_name = cls.__name__
+                if not self._transform_error_logged:
+                    dataset_name = type(self).__name__
                     logger.error(
                         f"{dataset_name} で transform 実行に失敗しました: {e}. "
                         "PIL前提の transform が含まれている可能性があります. "
                         "PochiImageDataset への切替を検討してください."
                     )
-                    cls._transform_error_logged = True
+                    self._transform_error_logged = True
                 raise
 
         return image, label


### PR DESCRIPTION
## Summary

- `_transform_error_logged` をクラス変数からインスタンス変数に変更し, マルチスレッド環境での競合状態を解消した.

## Related Issue

Closes #316

## Changes

- `pochitrain/pochi_dataset.py`:
  - `FastInferenceDataset` に `__init__` を追加し, `_transform_error_logged` をインスタンス変数として初期化.
  - `__getitem__` 内の参照を `cls._transform_error_logged` から `self._transform_error_logged` に変更.

## Code Changes

```python
# pochitrain/pochi_dataset.py (変更前)
class FastInferenceDataset(PochiImageDataset):
    _transform_error_logged: bool = False  # クラス変数

    def __getitem__(self, index):
        # ...
        cls = type(self)
        if not cls._transform_error_logged:
            cls._transform_error_logged = True

# pochitrain/pochi_dataset.py (変更後)
class FastInferenceDataset(PochiImageDataset):
    def __init__(self, root, transform=None, extensions=...):
        super().__init__(root=root, transform=transform, extensions=extensions)
        self._transform_error_logged: bool = False  # インスタンス変数

    def __getitem__(self, index):
        # ...
        if not self._transform_error_logged:
            self._transform_error_logged = True
```

## Test Plan

- [x] `uv run pytest` で全テストが通ること
- [x] `uv run pre-commit run --all-files`

## Checklist

- [x] `uv run pre-commit run --all-files`