### PR TITLE
docs: ドキュメント不整合の修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
   - 単一バッチ/複数バッチの損失計算, 空 DataLoader の防御的ガード, クラス重み付き損失, 勾配更新のテストを追加した.
 - `visualize_gradient.py` のテストを追加した ([#332](https://github.com/kurorosu/pochitrain/pull/332)).
   - CSV 読み込み (正常系, 不正CSV), PNG 出力生成 (timeline, heatmap, statistics, snapshots), CLI ユーティリティ関数のテストを追加した.
-- エッジケーステストを追加した (`N/A.`).
+- エッジケーステストを追加した ([#333](https://github.com/kurorosu/pochitrain/pull/333)).
   - `early_stopping`: min_delta 境界値 (極小0.0001/極大10.0) のテストを追加した.
   - `pochi_dataset`: 画像1枚データセット, 破損画像ファイルのテストを追加した.
   - `training_configurator`: 学習率0.0, 負の学習率, 極端な層別学習率のテストを追加した.
@@ -42,7 +42,10 @@
   - `evaluator`: 空 DataLoader, 単一サンプルの精度計算/混同行列のテストを追加した.
 
 ### Fixed
-- なし.
+- ドキュメント不整合を修正した (`N/A.`).
+  - CLAUDE.md: `pochi infer` コマンドの引数を位置引数に修正した.
+  - README.md: `--opset` を `--opset-version` に修正した.
+  - README.md: `create_data_loaders` の使用例に `train_transform`/`val_transform` パラメータを追加した.
 
 ### Removed
 - なし.

--- a/README.md
+++ b/README.md
@@ -169,12 +169,25 @@ uv run tensorboard --logdir work_dirs/YYYYMMDD_XXX/visualization/tensorboard
 
 ```python
 from pochitrain import PochiTrainer, create_data_loaders
+from torchvision import transforms
+
+# transformの定義
+train_transform = transforms.Compose([
+    transforms.Resize(224),
+    transforms.ToTensor(),
+])
+val_transform = transforms.Compose([
+    transforms.Resize(224),
+    transforms.ToTensor(),
+])
 
 # データローダーの作成
 train_loader, val_loader, classes = create_data_loaders(
     train_root='data/train',
     val_root='data/val',
-    batch_size=32
+    batch_size=32,
+    train_transform=train_transform,
+    val_transform=val_transform,
 )
 
 # トレーナーの作成
@@ -451,7 +464,7 @@ uv run export-onnx work_dirs/20251018_001/models/best_epoch40.pth --input-size 2
 ```bash
 uv run export-onnx work_dirs/20251018_001/models/best_epoch40.pth \
   --output model.onnx \
-  --opset 17
+  --opset-version 17
 ```
 
 ### ONNX推論の実行


### PR DESCRIPTION
## Summary

- CLAUDE.md, README.md と実装の間にある不整合を3箇所修正した.

## Related Issue

Closes #321

## Changes

- CLAUDE.md: `pochi infer --model-path <path>` を `pochi infer <model_path>` に修正した (位置引数).
- README.md: `--opset` を `--opset-version` に修正し, `export_onnx.py` の実装と一致させた.
- README.md: `create_data_loaders` の使用例に `train_transform`/`val_transform` パラメータと定義例を追加した.

## Code Changes

無し

## Test Plan

- ドキュメントのみの変更のため, コードテストへの影響はない.
- `uv run pytest` で既存テスト全662テストがパスすることを確認した.

## Checklist

- [x] `uv run pre-commit run --all-files`