### PR TITLE
refactor: TrainingConfigurator から層別学習率ロジックを分離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
 - なし.
 
 ### Changed
-- なし.
+- `TrainingConfigurator` から層別学習率ロジックを分離した (`N/A.`).
+  - `training/layer_wise_lr/` パッケージを新設した (`ILayerGrouper`, `ResNetLayerGrouper`, `ParamGroupBuilder`).
+  - Strategy パターンにより, 将来の非 ResNet モデル対応が拡張のみで可能になった.
+  - `ResNetLayerGrouper`, `ParamGroupBuilder` のユニットテストを追加した.
 
 ### Fixed
 - なし.

--- a/pochitrain/pochi_trainer.py
+++ b/pochitrain/pochi_trainer.py
@@ -20,6 +20,7 @@ from .training.checkpoint_store import CheckpointStore
 from .training.early_stopping import EarlyStopping
 from .training.epoch_runner import EpochRunner
 from .training.evaluator import Evaluator
+from .training.layer_wise_lr import ParamGroupBuilder, ResNetLayerGrouper
 from .training.training_configurator import TrainingConfigurator
 from .training.training_loop import TrainingContext, TrainingLoop
 from .utils.directory_manager import PochiWorkspaceManager
@@ -82,7 +83,11 @@ class PochiTrainer:
 
         self.evaluator = Evaluator(self.device, self.logger)
 
-        self.training_configurator = TrainingConfigurator(self.device, self.logger)
+        self.training_configurator = TrainingConfigurator(
+            self.device,
+            self.logger,
+            param_group_builder=ParamGroupBuilder(ResNetLayerGrouper(), self.logger),
+        )
         self.epoch_runner = EpochRunner(device=self.device, logger=self.logger)
 
         self.model = create_model(model_name, num_classes, pretrained)

--- a/pochitrain/training/__init__.py
+++ b/pochitrain/training/__init__.py
@@ -4,6 +4,7 @@ from .checkpoint_store import CheckpointStore
 from .early_stopping import EarlyStopping
 from .epoch_runner import EpochRunner
 from .evaluator import Evaluator
+from .layer_wise_lr import ILayerGrouper, ParamGroupBuilder, ResNetLayerGrouper
 from .metrics_tracker import MetricsTracker
 from .training_configurator import TrainingComponents, TrainingConfigurator
 from .training_loop import TrainingContext, TrainingLoop
@@ -13,7 +14,10 @@ __all__ = [
     "EarlyStopping",
     "EpochRunner",
     "Evaluator",
+    "ILayerGrouper",
     "MetricsTracker",
+    "ParamGroupBuilder",
+    "ResNetLayerGrouper",
     "TrainingComponents",
     "TrainingConfigurator",
     "TrainingContext",

--- a/pochitrain/training/layer_wise_lr/__init__.py
+++ b/pochitrain/training/layer_wise_lr/__init__.py
@@ -1,0 +1,11 @@
+"""pochitrain.training.layer_wise_lr: 層別学習率の構築."""
+
+from .interfaces import ILayerGrouper
+from .param_group_builder import ParamGroupBuilder
+from .resnet_layer_grouper import ResNetLayerGrouper
+
+__all__ = [
+    "ILayerGrouper",
+    "ParamGroupBuilder",
+    "ResNetLayerGrouper",
+]

--- a/pochitrain/training/layer_wise_lr/interfaces.py
+++ b/pochitrain/training/layer_wise_lr/interfaces.py
@@ -1,0 +1,18 @@
+"""pochitrain.training.layer_wise_lr.interfaces: 層別学習率のインターフェース."""
+
+from abc import ABC, abstractmethod
+
+
+class ILayerGrouper(ABC):
+    """パラメータ名から層グループ名を取得するインターフェース."""
+
+    @abstractmethod
+    def get_group(self, param_name: str) -> str:
+        """パラメータ名から層グループ名を取得.
+
+        Args:
+            param_name: パラメータ名.
+
+        Returns:
+            str: 層グループ名.
+        """

--- a/pochitrain/training/layer_wise_lr/param_group_builder.py
+++ b/pochitrain/training/layer_wise_lr/param_group_builder.py
@@ -1,0 +1,79 @@
+"""pochitrain.training.layer_wise_lr.param_group_builder: パラメータグループの構築."""
+
+import logging
+from typing import Any
+
+import torch.nn as nn
+
+from .interfaces import ILayerGrouper
+
+
+class ParamGroupBuilder:
+    """層別学習率のパラメータグループを構築する.
+
+    ILayerGrouper を使用してパラメータを層グループに分類し,
+    各グループに適切な学習率を割り当てる.
+    """
+
+    def __init__(self, layer_grouper: ILayerGrouper, logger: logging.Logger):
+        """初期化.
+
+        Args:
+            layer_grouper: 層グルーパー.
+            logger: ロガー.
+        """
+        self._layer_grouper = layer_grouper
+        self._logger = logger
+
+    def build(
+        self,
+        model: nn.Module,
+        base_lr: float,
+        layer_wise_lr_config: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """層別学習率のパラメータグループを構築.
+
+        Args:
+            model: 訓練対象のモデル.
+            base_lr: 基本学習率.
+            layer_wise_lr_config: 層別学習率の設定.
+
+        Returns:
+            list[dict[str, Any]]: パラメータグループのリスト.
+        """
+        layer_rates = layer_wise_lr_config.get("layer_rates", {})
+
+        layer_params: dict[str, list] = {}
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                layer_group = self._layer_grouper.get_group(name)
+                if layer_group not in layer_params:
+                    layer_params[layer_group] = []
+                layer_params[layer_group].append(param)
+
+        param_groups = []
+        for layer_name, params in layer_params.items():
+            lr = layer_rates.get(layer_name, base_lr)
+            param_groups.append(
+                {
+                    "params": params,
+                    "lr": lr,
+                    "layer_name": layer_name,
+                }
+            )
+
+        return param_groups
+
+    def log_param_groups(self, param_groups: list[dict[str, Any]]) -> None:
+        """層別学習率の設定をログ出力.
+
+        Args:
+            param_groups: パラメータグループのリスト.
+        """
+        self._logger.debug("=== 層別学習率設定 ===")
+        for group in param_groups:
+            layer_name = group.get("layer_name", "unknown")
+            lr = group["lr"]
+            param_count = sum(p.numel() for p in group["params"])
+            self._logger.debug(f"  {layer_name}: lr={lr:.6f}, params={param_count:,}")
+        self._logger.debug("=====================")

--- a/pochitrain/training/layer_wise_lr/resnet_layer_grouper.py
+++ b/pochitrain/training/layer_wise_lr/resnet_layer_grouper.py
@@ -1,0 +1,35 @@
+"""pochitrain.training.layer_wise_lr.resnet_layer_grouper: ResNet 用の層グルーパー."""
+
+from .interfaces import ILayerGrouper
+
+
+class ResNetLayerGrouper(ILayerGrouper):
+    """ResNet アーキテクチャに基づく層グルーパー.
+
+    パラメータ名を ResNet の構造 (conv1, bn1, layer1-4, fc) に基づいて
+    グループ名にマッピングする.
+    """
+
+    _GROUP_KEYWORDS: tuple[str, ...] = (
+        "layer1",
+        "layer2",
+        "layer3",
+        "layer4",
+        "conv1",
+        "bn1",
+        "fc",
+    )
+
+    def get_group(self, param_name: str) -> str:
+        """パラメータ名から ResNet 層グループ名を取得.
+
+        Args:
+            param_name: パラメータ名.
+
+        Returns:
+            str: 層グループ名. 該当しない場合は "other".
+        """
+        for keyword in self._GROUP_KEYWORDS:
+            if keyword in param_name:
+                return keyword
+        return "other"

--- a/pochitrain/training/training_configurator.py
+++ b/pochitrain/training/training_configurator.py
@@ -9,6 +9,8 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
+from .layer_wise_lr import ParamGroupBuilder
+
 
 @dataclass
 class TrainingComponents:
@@ -26,15 +28,22 @@ class TrainingComponents:
 class TrainingConfigurator:
     """optimizer, scheduler, criterion の構築を担当."""
 
-    def __init__(self, device: torch.device, logger: logging.Logger):
+    def __init__(
+        self,
+        device: torch.device,
+        logger: logging.Logger,
+        param_group_builder: Optional[ParamGroupBuilder] = None,
+    ):
         """訓練コンフィギュレータを初期化.
 
         Args:
             device: 訓練に使用するデバイス.
             logger: ロガー.
+            param_group_builder: 層別学習率のパラメータグループビルダー.
         """
         self.device = device
         self.logger = logger
+        self._param_group_builder = param_group_builder
 
     def configure(
         self,
@@ -69,10 +78,14 @@ class TrainingConfigurator:
         criterion = self._build_criterion(class_weights, num_classes)
 
         if enable_layer_wise_lr:
-            param_groups = self._build_layer_wise_param_groups(
+            if self._param_group_builder is None:
+                raise RuntimeError(
+                    "層別学習率を使用するには param_group_builder の注入が必要です"
+                )
+            param_groups = self._param_group_builder.build(
                 model, learning_rate, lr_config
             )
-            self._log_layer_wise_lr(param_groups)
+            self._param_group_builder.log_param_groups(param_groups)
         else:
             param_groups = [{"params": model.parameters(), "lr": learning_rate}]
 
@@ -187,83 +200,3 @@ class TrainingConfigurator:
             optimizer, **scheduler_params
         )
         return scheduler
-
-    def _build_layer_wise_param_groups(
-        self,
-        model: nn.Module,
-        base_lr: float,
-        layer_wise_lr_config: dict[str, Any],
-    ) -> list[dict[str, Any]]:
-        """層別学習率のパラメータグループを構築.
-
-        Args:
-            model: 訓練対象のモデル.
-            base_lr: 基本学習率.
-            layer_wise_lr_config: 層別学習率の設定.
-
-        Returns:
-            list[dict[str, Any]]: パラメータグループのリスト.
-        """
-        layer_rates = layer_wise_lr_config.get("layer_rates", {})
-
-        layer_params: dict[str, list] = {}
-        for name, param in model.named_parameters():
-            if param.requires_grad:
-                layer_group = self._get_layer_group(name)
-                if layer_group not in layer_params:
-                    layer_params[layer_group] = []
-                layer_params[layer_group].append(param)
-
-        param_groups = []
-        for layer_name, params in layer_params.items():
-            lr = layer_rates.get(layer_name, base_lr)
-            param_groups.append(
-                {
-                    "params": params,
-                    "lr": lr,
-                    "layer_name": layer_name,
-                }
-            )
-
-        return param_groups
-
-    def _get_layer_group(self, param_name: str) -> str:
-        """パラメータ名から層グループ名を取得.
-
-        Args:
-            param_name: パラメータ名.
-
-        Returns:
-            str: 層グループ名.
-        """
-        # ResNet構造に基づいて, より具体的な層から優先判定する.
-        if "layer1" in param_name:
-            return "layer1"
-        elif "layer2" in param_name:
-            return "layer2"
-        elif "layer3" in param_name:
-            return "layer3"
-        elif "layer4" in param_name:
-            return "layer4"
-        elif "conv1" in param_name:
-            return "conv1"
-        elif "bn1" in param_name:
-            return "bn1"
-        elif "fc" in param_name:
-            return "fc"
-        else:
-            return "other"
-
-    def _log_layer_wise_lr(self, param_groups: list[dict[str, Any]]) -> None:
-        """層別学習率の設定をログ出力.
-
-        Args:
-            param_groups: パラメータグループのリスト.
-        """
-        self.logger.debug("=== 層別学習率設定 ===")
-        for group in param_groups:
-            layer_name = group.get("layer_name", "unknown")
-            lr = group["lr"]
-            param_count = sum(p.numel() for p in group["params"])
-            self.logger.debug(f"  {layer_name}: lr={lr:.6f}, params={param_count:,}")
-        self.logger.debug("=====================")

--- a/tests/unit/test_core/test_edge_cases.py
+++ b/tests/unit/test_core/test_edge_cases.py
@@ -18,6 +18,7 @@ from pochitrain.pochi_dataset import PochiImageDataset
 from pochitrain.training.checkpoint_store import CheckpointStore
 from pochitrain.training.early_stopping import EarlyStopping
 from pochitrain.training.evaluator import Evaluator
+from pochitrain.training.layer_wise_lr import ParamGroupBuilder, ResNetLayerGrouper
 from pochitrain.training.training_configurator import TrainingConfigurator
 
 # --- EarlyStopping エッジケース ---
@@ -147,7 +148,11 @@ class TestTrainingConfiguratorEdgeCases:
     def configurator(self):
         """テスト用コンフィギュレータ."""
         logger = logging.getLogger("test_edge")
-        return TrainingConfigurator(device=torch.device("cpu"), logger=logger)
+        return TrainingConfigurator(
+            device=torch.device("cpu"),
+            logger=logger,
+            param_group_builder=ParamGroupBuilder(ResNetLayerGrouper(), logger),
+        )
 
     @pytest.fixture
     def model(self):

--- a/tests/unit/test_core/test_layer_wise_lr_modules.py
+++ b/tests/unit/test_core/test_layer_wise_lr_modules.py
@@ -1,0 +1,168 @@
+"""layer_wise_lr パッケージのテスト.
+
+ResNetLayerGrouper, ParamGroupBuilder を実際の PyTorch モデルで検証する古典派テスト.
+"""
+
+import logging
+
+import pytest
+import torch
+import torch.nn as nn
+
+from pochitrain.models.pochi_models import create_model
+from pochitrain.training.layer_wise_lr import (
+    ILayerGrouper,
+    ParamGroupBuilder,
+    ResNetLayerGrouper,
+)
+
+# --- ResNetLayerGrouper ---
+
+
+class TestResNetLayerGrouper:
+    """ResNetLayerGrouper のテスト."""
+
+    @pytest.fixture
+    def grouper(self) -> ResNetLayerGrouper:
+        """テスト用の ResNetLayerGrouper インスタンス."""
+        return ResNetLayerGrouper()
+
+    def test_layer1_params(self, grouper: ResNetLayerGrouper):
+        """layer1 を含むパラメータ名は 'layer1' を返す."""
+        assert grouper.get_group("layer1.0.conv1.weight") == "layer1"
+
+    def test_layer2_params(self, grouper: ResNetLayerGrouper):
+        """layer2 を含むパラメータ名は 'layer2' を返す."""
+        assert grouper.get_group("layer2.1.bn2.weight") == "layer2"
+
+    def test_layer3_params(self, grouper: ResNetLayerGrouper):
+        """layer3 を含むパラメータ名は 'layer3' を返す."""
+        assert grouper.get_group("layer3.0.conv2.weight") == "layer3"
+
+    def test_layer4_params(self, grouper: ResNetLayerGrouper):
+        """layer4 を含むパラメータ名は 'layer4' を返す."""
+        assert grouper.get_group("layer4.0.conv1.weight") == "layer4"
+
+    def test_conv1_params(self, grouper: ResNetLayerGrouper):
+        """conv1 を含むパラメータ名は 'conv1' を返す."""
+        assert grouper.get_group("conv1.weight") == "conv1"
+
+    def test_bn1_params(self, grouper: ResNetLayerGrouper):
+        """bn1 を含むパラメータ名は 'bn1' を返す."""
+        assert grouper.get_group("bn1.weight") == "bn1"
+
+    def test_fc_params(self, grouper: ResNetLayerGrouper):
+        """fc を含むパラメータ名は 'fc' を返す."""
+        assert grouper.get_group("fc.weight") == "fc"
+
+    def test_unknown_param_returns_other(self, grouper: ResNetLayerGrouper):
+        """該当しないパラメータ名は 'other' を返す."""
+        assert grouper.get_group("some_unknown_module.weight") == "other"
+
+    def test_implements_interface(self):
+        """ResNetLayerGrouper は ILayerGrouper を実装している."""
+        assert issubclass(ResNetLayerGrouper, ILayerGrouper)
+
+    def test_all_resnet18_params_are_grouped(self, grouper: ResNetLayerGrouper):
+        """ResNet18 の全パラメータが 'other' 以外にグルーピングされる."""
+        model = create_model("resnet18", num_classes=4, pretrained=False)
+        for name, _ in model.named_parameters():
+            group = grouper.get_group(name)
+            assert group != "other", f"パラメータ '{name}' が 'other' に分類された"
+
+
+# --- ParamGroupBuilder ---
+
+
+class TestParamGroupBuilder:
+    """ParamGroupBuilder のテスト."""
+
+    @pytest.fixture
+    def builder(self, logger: logging.Logger) -> ParamGroupBuilder:
+        """テスト用の ParamGroupBuilder インスタンス."""
+        return ParamGroupBuilder(ResNetLayerGrouper(), logger)
+
+    @pytest.fixture
+    def model(self) -> nn.Module:
+        """テスト用の ResNet18 モデル."""
+        return create_model("resnet18", num_classes=4, pretrained=False)
+
+    def test_build_creates_multiple_groups(
+        self, builder: ParamGroupBuilder, model: nn.Module
+    ):
+        """build() は複数のパラメータグループを作成する."""
+        groups = builder.build(model, base_lr=0.001, layer_wise_lr_config={})
+
+        assert len(groups) > 1
+
+    def test_build_assigns_specified_rates(
+        self, builder: ParamGroupBuilder, model: nn.Module
+    ):
+        """指定した層には指定学習率が適用される."""
+        config = {"layer_rates": {"conv1": 0.0001, "fc": 0.01}}
+        groups = builder.build(model, base_lr=0.001, layer_wise_lr_config=config)
+
+        group_lrs = {g["layer_name"]: g["lr"] for g in groups}
+        assert group_lrs["conv1"] == pytest.approx(0.0001)
+        assert group_lrs["fc"] == pytest.approx(0.01)
+
+    def test_build_uses_base_lr_for_unspecified(
+        self, builder: ParamGroupBuilder, model: nn.Module
+    ):
+        """未指定の層にはベース学習率が適用される."""
+        config = {"layer_rates": {"fc": 0.01}}
+        groups = builder.build(model, base_lr=0.005, layer_wise_lr_config=config)
+
+        for group in groups:
+            if group["layer_name"] != "fc":
+                assert group["lr"] == pytest.approx(0.005)
+
+    def test_build_skips_frozen_params(
+        self, builder: ParamGroupBuilder, model: nn.Module
+    ):
+        """requires_grad=False のパラメータはグループに含まれない."""
+        # conv1 のパラメータを凍結
+        for name, param in model.named_parameters():
+            if "conv1" in name:
+                param.requires_grad = False
+
+        groups = builder.build(model, base_lr=0.001, layer_wise_lr_config={})
+
+        group_names = {g["layer_name"] for g in groups}
+        assert "conv1" not in group_names
+
+    def test_build_all_params_included(
+        self, builder: ParamGroupBuilder, model: nn.Module
+    ):
+        """全 trainable パラメータがいずれかのグループに含まれる."""
+        groups = builder.build(model, base_lr=0.001, layer_wise_lr_config={})
+
+        total_in_groups = sum(sum(p.numel() for p in g["params"]) for g in groups)
+        total_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        assert total_in_groups == total_trainable
+
+    def test_build_with_empty_config(
+        self, builder: ParamGroupBuilder, model: nn.Module
+    ):
+        """空の config でも正常に動作する."""
+        groups = builder.build(model, base_lr=0.001, layer_wise_lr_config={})
+
+        for group in groups:
+            assert group["lr"] == pytest.approx(0.001)
+
+    def test_each_group_has_layer_name(
+        self, builder: ParamGroupBuilder, model: nn.Module
+    ):
+        """各グループに layer_name キーが含まれる."""
+        groups = builder.build(model, base_lr=0.001, layer_wise_lr_config={})
+
+        for group in groups:
+            assert "layer_name" in group
+            assert isinstance(group["layer_name"], str)
+
+    def test_log_param_groups(self, builder: ParamGroupBuilder, model: nn.Module):
+        """log_param_groups() がエラーなく実行される."""
+        groups = builder.build(model, base_lr=0.001, layer_wise_lr_config={})
+
+        # エラーなく実行できることを確認
+        builder.log_param_groups(groups)

--- a/tests/unit/test_core/test_training_configurator.py
+++ b/tests/unit/test_core/test_training_configurator.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from pochitrain.models.pochi_models import create_model
+from pochitrain.training.layer_wise_lr import ParamGroupBuilder, ResNetLayerGrouper
 from pochitrain.training.training_configurator import (
     TrainingComponents,
     TrainingConfigurator,
@@ -15,7 +16,11 @@ from pochitrain.training.training_configurator import (
 @pytest.fixture
 def configurator(logger):
     """テスト用の TrainingConfigurator インスタンスを作成."""
-    return TrainingConfigurator(device=torch.device("cpu"), logger=logger)
+    return TrainingConfigurator(
+        device=torch.device("cpu"),
+        logger=logger,
+        param_group_builder=ParamGroupBuilder(ResNetLayerGrouper(), logger),
+    )
 
 
 @pytest.fixture
@@ -188,6 +193,48 @@ class TestTrainingConfiguratorConfigure:
                 optimizer_name="Adam",
                 scheduler_name="StepLR",
                 scheduler_params=None,
+            )
+
+
+class TestTrainingConfiguratorWithoutBuilder:
+    """param_group_builder=None の場合のテスト."""
+
+    @pytest.fixture
+    def configurator_without_builder(self, logger):
+        """builder なしの TrainingConfigurator."""
+        return TrainingConfigurator(
+            device=torch.device("cpu"),
+            logger=logger,
+            param_group_builder=None,
+        )
+
+    def test_configure_without_layer_wise_lr(self, configurator_without_builder):
+        """層別学習率を無効にすれば builder なしでも正常に動作."""
+        model = create_model("resnet18", num_classes=4, pretrained=False)
+
+        components = configurator_without_builder.configure(
+            model=model,
+            learning_rate=0.001,
+            optimizer_name="Adam",
+            enable_layer_wise_lr=False,
+        )
+
+        assert components.enable_layer_wise_lr is False
+        assert len(components.optimizer.param_groups) == 1
+
+    def test_enable_layer_wise_lr_without_builder_raises(
+        self, configurator_without_builder
+    ):
+        """builder なしで層別学習率を有効化すると RuntimeError."""
+        model = create_model("resnet18", num_classes=4, pretrained=False)
+
+        with pytest.raises(RuntimeError, match="param_group_builder の注入が必要"):
+            configurator_without_builder.configure(
+                model=model,
+                learning_rate=0.001,
+                optimizer_name="SGD",
+                enable_layer_wise_lr=True,
+                layer_wise_lr_config={"layer_rates": {"fc": 0.01}},
             )
 
 


### PR DESCRIPTION
## Summary

- `TrainingConfigurator` の SRP 違反を解消し, 層別学習率ロジックを専用パッケージに分離した.
- Strategy パターンにより, 将来の非 ResNet モデル対応が拡張のみで可能になった.
- 19テスト追加, 既存テスト含め全680テストがパスすることを確認した.

## Related Issue

Closes #315

## Changes

- `pochitrain/training/layer_wise_lr/` パッケージを新設した.
  - `interfaces.py`: `ILayerGrouper` インターフェースを定義した.
  - `resnet_layer_grouper.py`: ResNet 用の `ResNetLayerGrouper` を実装した.
  - `param_group_builder.py`: パラメータグループの構築とログ出力を担う `ParamGroupBuilder` を実装した.
- `training_configurator.py` を変更した.
  - `_build_layer_wise_param_groups()`, `_get_layer_group()`, `_log_layer_wise_lr()` を削除した.
  - `ParamGroupBuilder` を外部から注入する DI 構成にした (具象クラスへの依存を排除).
- `pochi_trainer.py` で `ParamGroupBuilder(ResNetLayerGrouper(), logger)` を組み立てて注入するようにした.
- `training/__init__.py` に新クラスのエクスポートを追加した.
- `tests/unit/test_core/test_layer_wise_lr_modules.py` を作成した.
  - `ResNetLayerGrouper`: 全7ブランチ + ResNet18 全パラメータの網羅テスト.
  - `ParamGroupBuilder`: 指定率適用, ベースLR適用, 凍結パラメータ除外, 空 config 等のテスト.

## Code Changes

```python
# pochitrain/training/layer_wise_lr/interfaces.py
class ILayerGrouper(ABC):
    @abstractmethod
    def get_group(self, param_name: str) -> str: ...

# pochitrain/training/layer_wise_lr/resnet_layer_grouper.py
class ResNetLayerGrouper(ILayerGrouper):
    _GROUP_KEYWORDS: tuple[str, ...] = (
        "layer1", "layer2", "layer3", "layer4", "conv1", "bn1", "fc",
    )

    def get_group(self, param_name: str) -> str:
        for keyword in self._GROUP_KEYWORDS:
            if keyword in param_name:
                return keyword
        return "other"

# pochitrain/training/training_configurator.py (DI で受け取る)
class TrainingConfigurator:
    def __init__(self, device, logger, param_group_builder=None):
        ...
        self._param_group_builder = param_group_builder

# pochitrain/pochi_trainer.py (組み立てて注入)
self.training_configurator = TrainingConfigurator(
    self.device,
    self.logger,
    param_group_builder=ParamGroupBuilder(ResNetLayerGrouper(), self.logger),
)
```

## Test Plan

- `uv run pytest tests/unit/test_core/test_layer_wise_lr_modules.py -v` で新規19テスト全パスを確認.
- `uv run pytest tests/unit/test_core/test_layer_wise_lr.py tests/unit/test_core/test_training_configurator.py -v` で既存テストの後方互換性を確認.
- `uv run pytest` で全680テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`