### PR TITLE
refactor: デッドコード削除と未使用公開メソッドの private 化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,21 @@
 - なし.
 
 ### Changed
-- `TrainingConfigurator` から層別学習率ロジックを分離した (`N/A.`).
+- `TrainingConfigurator` から層別学習率ロジックを分離した ([#337](https://github.com/kurorosu/pochitrain/pull/337)).
   - `training/layer_wise_lr/` パッケージを新設した (`ILayerGrouper`, `ResNetLayerGrouper`, `ParamGroupBuilder`).
   - Strategy パターンにより, 将来の非 ResNet モデル対応が拡張のみで可能になった.
   - `ResNetLayerGrouper`, `ParamGroupBuilder` のユニットテストを追加した.
+- デッドコード・未使用公開メソッドを整理した (`N/A.`).
+  - `CheckpointStore.save_checkpoint()` 等 7メソッドを private 化した.
+  - テストを public API 経由に書き換えた.
 
 ### Fixed
 - なし.
 
 ### Removed
-- なし.
+- `PochiTrainer.setup_training_from_config()` を削除した (呼び出し元なし) (`N/A.`).
+- `find_best_model()` を削除した (呼び出し元なし) (`N/A.`).
+- `EarlyStopping.get_status()` を削除した (呼び出し元なし) (`N/A.`).
 
 ## v1.8.0 (2026-03-16)
 

--- a/pochitrain/cli/pochi.py
+++ b/pochitrain/cli/pochi.py
@@ -7,7 +7,6 @@ pochitrain 統一CLI エントリーポイント.
 
 import argparse
 import logging
-import re
 import signal
 import sys
 from pathlib import Path
@@ -83,41 +82,6 @@ def setup_logging(
     for existing_name in logger_manager.get_available_loggers():
         logger_manager.set_logger_level(existing_name, level)
     return logger_manager.get_logger(logger_name, level=level)
-
-
-def find_best_model(work_dir: str) -> Path:
-    """
-    work_dir内でベストモデルを自動検出.
-
-    Args:
-        work_dir (str): 作業ディレクトリパス
-
-    Returns:
-        Path: ベストモデルのパス
-
-    Raises:
-        FileNotFoundError: モデルが見つからない場合
-    """
-    work_path = Path(work_dir)
-    models_dir = work_path / "models"
-
-    if not models_dir.exists():
-        raise FileNotFoundError(f"モデルディレクトリが見つかりません: {models_dir}")
-
-    model_files = list(models_dir.glob("best_epoch*.pth"))
-
-    if not model_files:
-        raise FileNotFoundError(
-            f"ベストモデルが見つかりません: {models_dir}/best_epoch*.pth"
-        )
-
-    best_model = max(
-        model_files,
-        key=lambda x: (
-            int(m.group(1)) if (m := re.search(r"best_epoch(\d+)", x.name)) else 0
-        ),
-    )
-    return best_model
 
 
 def train_command(args: argparse.Namespace) -> None:

--- a/pochitrain/pochi_trainer.py
+++ b/pochitrain/pochi_trainer.py
@@ -132,26 +132,6 @@ class PochiTrainer:
             cudnn_benchmark=config.cudnn_benchmark,
         )
 
-    def setup_training_from_config(self, config: PochiConfig, num_classes: int) -> None:
-        """PochiConfigから訓練設定を適用."""
-        layer_wise_lr_config = config.layer_wise_lr_config.model_dump()
-        early_stopping_config = (
-            config.early_stopping.model_dump()
-            if config.early_stopping is not None
-            else None
-        )
-        self.setup_training(
-            learning_rate=config.learning_rate,
-            optimizer_name=config.optimizer,
-            scheduler_name=config.scheduler,
-            scheduler_params=config.scheduler_params,
-            class_weights=config.class_weights,
-            num_classes=num_classes,
-            enable_layer_wise_lr=config.enable_layer_wise_lr,
-            layer_wise_lr_config=layer_wise_lr_config,
-            early_stopping_config=early_stopping_config,
-        )
-
     def _setup_logger(self) -> logging.Logger:
         """ロガーの設定."""
         logger_manager = LoggerManager()

--- a/pochitrain/training/checkpoint_store.py
+++ b/pochitrain/training/checkpoint_store.py
@@ -23,7 +23,7 @@ class CheckpointStore:
         self.work_dir = work_dir
         self.logger = logger
 
-    def save_checkpoint(
+    def _save_checkpoint(
         self,
         filename: str,
         epoch: int,
@@ -85,7 +85,7 @@ class CheckpointStore:
             self.logger.info(f"既存のベストモデルを削除: {existing_file}")
 
         best_filename = f"best_epoch{epoch}.pth"
-        checkpoint_path = self.save_checkpoint(
+        checkpoint_path = self._save_checkpoint(
             best_filename, epoch, model, optimizer, scheduler, best_accuracy
         )
         self.logger.info(f"ベストモデルを保存: {checkpoint_path}")
@@ -107,6 +107,6 @@ class CheckpointStore:
             scheduler: スケジューラ
             best_accuracy: ベスト精度
         """
-        self.save_checkpoint(
+        self._save_checkpoint(
             "last_model.pth", epoch, model, optimizer, scheduler, best_accuracy
         )

--- a/pochitrain/training/early_stopping.py
+++ b/pochitrain/training/early_stopping.py
@@ -96,20 +96,3 @@ class EarlyStopping:
                 return True
 
         return False
-
-    def get_status(self) -> dict:
-        """
-        現在のEarlyStopping状態を取得.
-
-        Returns:
-            dict: 状態情報
-        """
-        return {
-            "patience": self.patience,
-            "min_delta": self.min_delta,
-            "monitor": self.monitor,
-            "counter": self.counter,
-            "best_value": self.best_value,
-            "best_epoch": self.best_epoch,
-            "should_stop": self.should_stop,
-        }

--- a/pochitrain/training/evaluator.py
+++ b/pochitrain/training/evaluator.py
@@ -81,15 +81,15 @@ class Evaluator:
             all_predicted_tensor = torch.cat(all_predicted, dim=0)
             all_targets_tensor = torch.cat(all_targets, dim=0)
 
-            cm = self.compute_confusion_matrix(
+            cm = self._compute_confusion_matrix(
                 all_predicted_tensor, all_targets_tensor, num_classes_for_cm
             )
 
-            self.log_confusion_matrix(cm, epoch, workspace_path)
+            self._log_confusion_matrix(cm, epoch, workspace_path)
 
         return {"val_loss": avg_loss, "val_accuracy": accuracy}
 
-    def compute_confusion_matrix(
+    def _compute_confusion_matrix(
         self, predicted: torch.Tensor, targets: torch.Tensor, num_classes: int
     ) -> torch.Tensor:
         """純粋なPyTorchテンソル操作による混同行列計算.
@@ -121,7 +121,7 @@ class Evaluator:
 
         return confusion_matrix
 
-    def log_confusion_matrix(
+    def _log_confusion_matrix(
         self,
         confusion_matrix: torch.Tensor,
         epoch: int,

--- a/pochitrain/visualization/metrics_exporter.py
+++ b/pochitrain/visualization/metrics_exporter.py
@@ -57,7 +57,7 @@ class TrainingMetricsExporter(BaseCSVExporter):
         ]
         self.extended_headers: list[str] = []  # Issue 9用の拡張ヘッダー
 
-    def add_extended_headers(self, headers: list[str]) -> None:
+    def _add_extended_headers(self, headers: list[str]) -> None:
         """
         拡張ヘッダーを追加（Issue 9でのパラメータ追跡用）.
 
@@ -108,7 +108,7 @@ class TrainingMetricsExporter(BaseCSVExporter):
         if layer_wise_lr_enabled:
             for key in kwargs:
                 if key.startswith("lr_") and key not in self.extended_headers:
-                    self.add_extended_headers([key])
+                    self._add_extended_headers([key])
 
         self.metrics_history.append(metrics)
 
@@ -122,7 +122,7 @@ class TrainingMetricsExporter(BaseCSVExporter):
             f"LR={lr_display}, Loss={train_loss:.4f}, Acc={train_accuracy:.2f}%"
         )
 
-    def export_to_csv(self, filename: Optional[str] = None) -> Optional[Path]:
+    def _export_to_csv(self, filename: Optional[str] = None) -> Optional[Path]:
         """
         メトリクスをCSVファイルに出力.
 
@@ -152,7 +152,7 @@ class TrainingMetricsExporter(BaseCSVExporter):
         self.logger.info(f"訓練メトリクスをCSVに出力: {output_path}")
         return output_path
 
-    def generate_graphs(
+    def _generate_graphs(
         self, base_filename: Optional[str] = None
     ) -> Optional[list[Path]]:
         """
@@ -377,12 +377,12 @@ class TrainingMetricsExporter(BaseCSVExporter):
         Returns:
             tuple[Optional[Path], Optional[List[Path]]]: (CSVファイルパス, グラフファイルパスリスト)
         """
-        csv_path = self.export_to_csv(csv_filename)
-        graph_paths = self.generate_graphs(graph_base_filename)
+        csv_path = self._export_to_csv(csv_filename)
+        graph_paths = self._generate_graphs(graph_base_filename)
 
         return csv_path, graph_paths
 
-    def get_best_epoch(self, metric: str = "val_accuracy") -> Optional[dict[str, Any]]:
+    def _get_best_epoch(self, metric: str = "val_accuracy") -> Optional[dict[str, Any]]:
         """
         指定されたメトリクスで最良のエポックを取得.
 
@@ -427,7 +427,7 @@ class TrainingMetricsExporter(BaseCSVExporter):
             summary["final_val_loss"] = self.metrics_history[-1]["val_loss"]
             summary["final_val_accuracy"] = self.metrics_history[-1]["val_accuracy"]
 
-            best_val = self.get_best_epoch("val_accuracy")
+            best_val = self._get_best_epoch("val_accuracy")
             if best_val:
                 summary["best_val_accuracy"] = best_val["val_accuracy"]
                 summary["best_val_accuracy_epoch"] = best_val["epoch"]

--- a/tests/unit/test_cli/test_pochi_cli.py
+++ b/tests/unit/test_cli/test_pochi_cli.py
@@ -6,7 +6,6 @@ import pytest
 
 from pochitrain.cli.pochi import (
     create_signal_handler,
-    find_best_model,
     get_indexed_output_dir,
     main,
     setup_logging,
@@ -44,51 +43,6 @@ class TestSignalHandler:
         assert pochi_module.training_interrupted is True
 
         pochi_module.training_interrupted = False
-
-
-class TestFindBestModel:
-    """find_best_model関数のテスト."""
-
-    def test_find_best_model_success(self, tmp_path):
-        """ベストモデルを正しく検出することを確認."""
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        (models_dir / "best_epoch10.pth").touch()
-        (models_dir / "best_epoch20.pth").touch()
-        (models_dir / "best_epoch30.pth").touch()
-
-        result = find_best_model(str(tmp_path))
-
-        assert result.name == "best_epoch30.pth"
-
-    def test_find_best_model_cross_digit_boundary(self, tmp_path):
-        """桁が変わるエポック番号でも正しく数値比較されることを確認."""
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        (models_dir / "best_epoch9.pth").touch()
-        (models_dir / "best_epoch10.pth").touch()
-
-        result = find_best_model(str(tmp_path))
-
-        # 文字列比較では 9 が 10 より大きく見えるため, 数値比較を検証する.
-        assert result.name == "best_epoch10.pth"
-
-    def test_find_best_model_no_models_dir(self, tmp_path):
-        """モデルディレクトリがない場合にエラーを発生させることを確認."""
-        with pytest.raises(
-            FileNotFoundError, match="モデルディレクトリが見つかりません"
-        ):
-            find_best_model(str(tmp_path))
-
-    def test_find_best_model_no_model_files(self, tmp_path):
-        """モデルファイルがない場合にエラーを発生させることを確認."""
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        with pytest.raises(FileNotFoundError, match="ベストモデルが見つかりません"):
-            find_best_model(str(tmp_path))
 
 
 class TestGetIndexedOutputDir:

--- a/tests/unit/test_core/test_checkpoint_store.py
+++ b/tests/unit/test_core/test_checkpoint_store.py
@@ -34,79 +34,6 @@ def optimizer(model: nn.Module) -> optim.Optimizer:
     return optim.SGD(model.parameters(), lr=0.01)
 
 
-class TestSaveCheckpoint:
-    """save_checkpointメソッドのテスト."""
-
-    def test_save_checkpoint(
-        self,
-        store: CheckpointStore,
-        model: nn.Module,
-        optimizer: optim.Optimizer,
-        work_dir: Path,
-    ) -> None:
-        """チェックポイントファイルが正しく保存される."""
-        path = store.save_checkpoint(
-            filename="checkpoint.pth",
-            epoch=5,
-            model=model,
-            optimizer=optimizer,
-            scheduler=None,
-            best_accuracy=85.0,
-        )
-
-        assert path == work_dir / "checkpoint.pth"
-        assert path.exists()
-
-        checkpoint = torch.load(path, map_location="cpu", weights_only=True)
-        assert checkpoint["epoch"] == 5
-        assert checkpoint["best_accuracy"] == 85.0
-        assert checkpoint["model_state_dict"] is not None
-        assert checkpoint["optimizer_state_dict"] is not None
-
-    def test_save_checkpoint_with_scheduler(
-        self,
-        store: CheckpointStore,
-        model: nn.Module,
-        optimizer: optim.Optimizer,
-        work_dir: Path,
-    ) -> None:
-        """スケジューラー状態も保存される."""
-        scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=5)
-
-        path = store.save_checkpoint(
-            filename="checkpoint.pth",
-            epoch=3,
-            model=model,
-            optimizer=optimizer,
-            scheduler=scheduler,
-            best_accuracy=90.0,
-        )
-
-        checkpoint = torch.load(path, map_location="cpu", weights_only=True)
-        assert "scheduler_state_dict" in checkpoint
-        assert checkpoint["scheduler_state_dict"] is not None
-
-    def test_save_checkpoint_without_scheduler(
-        self,
-        store: CheckpointStore,
-        model: nn.Module,
-        optimizer: optim.Optimizer,
-        work_dir: Path,
-    ) -> None:
-        """スケジューラーなしの場合, scheduler_state_dictが含まれない."""
-        path = store.save_checkpoint(
-            filename="checkpoint.pth",
-            epoch=1,
-            model=model,
-            optimizer=optimizer,
-            scheduler=None,
-            best_accuracy=50.0,
-        )
-
-        checkpoint = torch.load(path, map_location="cpu", weights_only=True)
-        assert "scheduler_state_dict" not in checkpoint
-
-
 class TestSaveBestModel:
     """save_best_modelメソッドのテスト."""
 
@@ -117,7 +44,7 @@ class TestSaveBestModel:
         optimizer: optim.Optimizer,
         work_dir: Path,
     ) -> None:
-        """ベストモデルが保存される."""
+        """ベストモデルが保存され, チェックポイント内容が正しい."""
         store.save_best_model(
             epoch=10,
             model=model,
@@ -128,6 +55,36 @@ class TestSaveBestModel:
 
         best_file = work_dir / "best_epoch10.pth"
         assert best_file.exists()
+
+        checkpoint = torch.load(best_file, map_location="cpu", weights_only=True)
+        assert checkpoint["epoch"] == 10
+        assert checkpoint["best_accuracy"] == 95.0
+        assert checkpoint["model_state_dict"] is not None
+        assert checkpoint["optimizer_state_dict"] is not None
+        assert "scheduler_state_dict" not in checkpoint
+
+    def test_save_best_model_with_scheduler(
+        self,
+        store: CheckpointStore,
+        model: nn.Module,
+        optimizer: optim.Optimizer,
+        work_dir: Path,
+    ) -> None:
+        """スケジューラー状態もベストモデルに保存される."""
+        scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=5)
+
+        store.save_best_model(
+            epoch=3,
+            model=model,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            best_accuracy=90.0,
+        )
+
+        best_file = work_dir / "best_epoch3.pth"
+        checkpoint = torch.load(best_file, map_location="cpu", weights_only=True)
+        assert "scheduler_state_dict" in checkpoint
+        assert checkpoint["scheduler_state_dict"] is not None
 
     def test_save_best_model_deletes_existing(
         self,

--- a/tests/unit/test_core/test_early_stopping.py
+++ b/tests/unit/test_core/test_early_stopping.py
@@ -115,34 +115,6 @@ class TestEarlyStoppingValLoss:
         )  # -0.08 < min_delta(0.1) -> 改善なし (2/2) -> 停止
 
 
-class TestEarlyStoppingGetStatus:
-    """get_statusメソッドのテスト."""
-
-    def test_initial_status(self):
-        """初期状態のステータス確認."""
-        es = EarlyStopping(patience=5, min_delta=0.01, monitor="val_accuracy")
-        status = es.get_status()
-        assert status["patience"] == 5
-        assert status["min_delta"] == 0.01
-        assert status["monitor"] == "val_accuracy"
-        assert status["counter"] == 0
-        assert status["best_value"] is None
-        assert status["best_epoch"] == 0
-        assert status["should_stop"] is False
-
-    def test_status_after_steps(self):
-        """数ステップ後のステータス確認."""
-        es = EarlyStopping(patience=3, monitor="val_accuracy")
-        es.step(90.0, 1)
-        es.step(89.0, 2)  # 改善なし
-
-        status = es.get_status()
-        assert status["counter"] == 1
-        assert status["best_value"] == 90.0
-        assert status["best_epoch"] == 1
-        assert status["should_stop"] is False
-
-
 class TestEarlyStoppingWithLogger:
     """ロガー付きEarlyStoppingのテスト."""
 

--- a/tests/unit/test_core/test_edge_cases.py
+++ b/tests/unit/test_core/test_edge_cases.py
@@ -253,8 +253,7 @@ class TestCheckpointStoreEdgeCases:
         optimizer = optim.SGD(model.parameters(), lr=0.01)
 
         with pytest.raises(Exception):
-            store.save_checkpoint(
-                filename="test.pth",
+            store.save_best_model(
                 epoch=1,
                 model=model,
                 optimizer=optimizer,
@@ -262,14 +261,13 @@ class TestCheckpointStoreEdgeCases:
                 best_accuracy=50.0,
             )
 
-    def test_save_checkpoint_without_optimizer(self, tmp_path: Path):
-        """optimizer=None でもチェックポイント保存可能."""
+    def test_save_last_model_without_optimizer(self, tmp_path: Path):
+        """optimizer=None でもラストモデル保存可能."""
         logger = logging.getLogger("test_cp")
         store = CheckpointStore(tmp_path, logger)
         model = nn.Linear(10, 2)
 
-        path = store.save_checkpoint(
-            filename="no_opt.pth",
+        store.save_last_model(
             epoch=1,
             model=model,
             optimizer=None,
@@ -277,6 +275,7 @@ class TestCheckpointStoreEdgeCases:
             best_accuracy=0.0,
         )
 
+        path = tmp_path / "last_model.pth"
         checkpoint = torch.load(path, map_location="cpu", weights_only=True)
         assert checkpoint["optimizer_state_dict"] is None
 
@@ -327,7 +326,7 @@ class TestEvaluatorNanInfHandling:
         predicted = torch.tensor([1])
         targets = torch.tensor([1])
 
-        cm = evaluator.compute_confusion_matrix(predicted, targets, 3)
+        cm = evaluator._compute_confusion_matrix(predicted, targets, 3)
 
         assert cm[1, 1].item() == 1
         assert cm.sum().item() == 1

--- a/tests/unit/test_core/test_evaluator.py
+++ b/tests/unit/test_core/test_evaluator.py
@@ -30,7 +30,7 @@ class TestComputeConfusionMatrix:
         predicted = torch.tensor([0, 1, 2, 3, 0, 1])
         targets = torch.tensor([0, 1, 2, 3, 0, 2])
 
-        cm = evaluator.compute_confusion_matrix(predicted, targets, 4)
+        cm = evaluator._compute_confusion_matrix(predicted, targets, 4)
 
         expected = torch.tensor(
             [
@@ -47,7 +47,7 @@ class TestComputeConfusionMatrix:
         predicted = torch.tensor([0, 1, 2, 3])
         targets = torch.tensor([0, 1, 2, 3])
 
-        cm = evaluator.compute_confusion_matrix(predicted, targets, 4)
+        cm = evaluator._compute_confusion_matrix(predicted, targets, 4)
 
         expected = torch.tensor(
             [
@@ -64,7 +64,7 @@ class TestComputeConfusionMatrix:
         predicted = torch.tensor([1, 2, 3, 0])
         targets = torch.tensor([0, 1, 2, 3])
 
-        cm = evaluator.compute_confusion_matrix(predicted, targets, 4)
+        cm = evaluator._compute_confusion_matrix(predicted, targets, 4)
 
         expected = torch.tensor(
             [
@@ -81,7 +81,7 @@ class TestComputeConfusionMatrix:
         predicted = torch.tensor([])
         targets = torch.tensor([])
 
-        cm = evaluator.compute_confusion_matrix(predicted, targets, 4)
+        cm = evaluator._compute_confusion_matrix(predicted, targets, 4)
 
         expected = torch.zeros(4, 4, dtype=torch.int64)
         assert torch.equal(cm, expected)
@@ -91,7 +91,7 @@ class TestComputeConfusionMatrix:
         predicted = torch.tensor([2, 2, 2])
         targets = torch.tensor([2, 2, 2])
 
-        cm = evaluator.compute_confusion_matrix(predicted, targets, 4)
+        cm = evaluator._compute_confusion_matrix(predicted, targets, 4)
 
         expected = torch.tensor(
             [
@@ -108,7 +108,7 @@ class TestComputeConfusionMatrix:
         predicted = torch.tensor([0, 1, 2, 1])
         targets = torch.tensor([0, 1, 1, 2])
 
-        cm = evaluator.compute_confusion_matrix(predicted, targets, 3)
+        cm = evaluator._compute_confusion_matrix(predicted, targets, 3)
 
         assert cm.device.type == "cpu"
 
@@ -232,7 +232,7 @@ class TestLogConfusionMatrix:
         """混同行列ログファイルが作成される."""
         cm = torch.tensor([[2, 1], [0, 3]], dtype=torch.int64)
 
-        evaluator.log_confusion_matrix(cm, epoch=1, workspace_path=tmp_path)
+        evaluator._log_confusion_matrix(cm, epoch=1, workspace_path=tmp_path)
         log_file = tmp_path / "confusion_matrix.log"
         assert log_file.exists()
         content = log_file.read_text(encoding="utf-8")
@@ -242,5 +242,5 @@ class TestLogConfusionMatrix:
         """workspace_path=None のときスキップする."""
         cm = torch.tensor([[1, 0], [0, 1]], dtype=torch.int64)
         with patch("builtins.open") as mock_open:
-            evaluator.log_confusion_matrix(cm, epoch=1, workspace_path=None)
+            evaluator._log_confusion_matrix(cm, epoch=1, workspace_path=None)
         mock_open.assert_not_called()

--- a/tests/unit/test_visualization/test_metrics_exporter.py
+++ b/tests/unit/test_visualization/test_metrics_exporter.py
@@ -66,9 +66,11 @@ class TestTrainingMetricsExporter:
         assert exporter.metrics_history[4]["epoch"] == 5
         assert exporter.metrics_history[4]["train_accuracy"] == 85.0
 
-    def test_export_to_csv(self, tmp_path):
-        """CSV出力のテスト."""
-        exporter = TrainingMetricsExporter(output_dir=tmp_path)
+    def test_export_all_csv(self, tmp_path):
+        """export_all 経由の CSV 出力テスト."""
+        exporter = TrainingMetricsExporter(
+            output_dir=tmp_path, enable_visualization=False
+        )
 
         for epoch in range(1, 4):
             exporter.record_epoch(
@@ -80,27 +82,28 @@ class TestTrainingMetricsExporter:
                 val_accuracy=83.0,
             )
 
-        csv_path = exporter.export_to_csv("test_metrics.csv")
+        csv_path, graph_paths = exporter.export_all("test_metrics.csv")
 
         assert csv_path is not None
         assert csv_path.exists()
         assert csv_path.name == "test_metrics.csv"
+        assert graph_paths is None
 
         with open(csv_path, "r", encoding="utf-8") as f:
             lines = f.readlines()
             assert len(lines) == 4  # ヘッダー + 3エポック
             assert "epoch,learning_rate" in lines[0]
 
-    def test_export_to_csv_empty(self, tmp_path):
-        """空の履歴でのCSV出力テスト."""
+    def test_export_all_empty(self, tmp_path):
+        """空の履歴での export_all テスト."""
         exporter = TrainingMetricsExporter(output_dir=tmp_path)
 
-        csv_path = exporter.export_to_csv()
+        csv_path, graph_paths = exporter.export_all()
 
         assert csv_path is None
 
-    def test_generate_graphs(self, tmp_path):
-        """グラフ生成のテスト."""
+    def test_export_all_with_graphs(self, tmp_path):
+        """export_all 経由のグラフ生成テスト."""
         exporter = TrainingMetricsExporter(
             output_dir=tmp_path, enable_visualization=True
         )
@@ -115,16 +118,17 @@ class TestTrainingMetricsExporter:
                 val_accuracy=78.0 + epoch,
             )
 
-        graph_paths = exporter.generate_graphs("test_graph")
+        csv_path, graph_paths = exporter.export_all()
 
+        assert csv_path is not None
         assert graph_paths is not None
         assert len(graph_paths) == 2  # 損失、精度（学習率統合）の2つ
         assert all(p.exists() for p in graph_paths)
         assert any("loss" in str(p) for p in graph_paths)
         assert any("accuracy" in str(p) for p in graph_paths)
 
-    def test_generate_graphs_disabled(self, tmp_path):
-        """グラフ生成が無効化された場合のテスト."""
+    def test_export_all_graphs_disabled(self, tmp_path):
+        """グラフ生成が無効化された場合の export_all テスト."""
         exporter = TrainingMetricsExporter(
             output_dir=tmp_path, enable_visualization=False
         )
@@ -133,11 +137,12 @@ class TestTrainingMetricsExporter:
             epoch=1, learning_rate=0.001, train_loss=0.5, train_accuracy=85.0
         )
 
-        graph_paths = exporter.generate_graphs()
+        csv_path, graph_paths = exporter.export_all()
 
+        assert csv_path is not None
         assert graph_paths is None
 
-    def test_generate_graphs_with_layer_wise_lr(self, tmp_path, monkeypatch):
+    def test_export_all_with_layer_wise_lr(self, tmp_path, monkeypatch):
         """層別学習率有効時に専用グラフが追加生成されることを確認."""
 
         def _fast_savefig(path, *args, **kwargs):
@@ -160,18 +165,16 @@ class TestTrainingMetricsExporter:
                 lr_head=0.001 * epoch,
             )
 
-        # 通常経路の実描画は test_generate_graphs で担保し、
-        # ここでは層別学習率分岐の検証に集中する。
         monkeypatch.setattr(metrics_exporter.plt, "savefig", _fast_savefig)
-        graph_paths = exporter.generate_graphs("test_layer_wise")
+        csv_path, graph_paths = exporter.export_all()
 
         assert graph_paths is not None
         assert len(graph_paths) == 3  # 損失、精度、層別学習率の3つ
         assert all(p.exists() for p in graph_paths)
         assert any("layer_wise_lr" in str(p) for p in graph_paths)
 
-    def test_get_best_epoch(self, tmp_path):
-        """最良エポック取得のテスト."""
+    def test_get_summary_includes_best_epoch(self, tmp_path):
+        """get_summary が最良エポック情報を含むことを検証."""
         exporter = TrainingMetricsExporter(output_dir=tmp_path)
 
         exporter.record_epoch(
@@ -179,6 +182,7 @@ class TestTrainingMetricsExporter:
             learning_rate=0.001,
             train_loss=0.5,
             train_accuracy=85.0,
+            val_loss=0.6,
             val_accuracy=80.0,
         )
         exporter.record_epoch(
@@ -186,6 +190,7 @@ class TestTrainingMetricsExporter:
             learning_rate=0.001,
             train_loss=0.4,
             train_accuracy=87.0,
+            val_loss=0.5,
             val_accuracy=85.0,
         )
         exporter.record_epoch(
@@ -193,6 +198,7 @@ class TestTrainingMetricsExporter:
             learning_rate=0.001,
             train_loss=0.3,
             train_accuracy=90.0,
+            val_loss=0.4,
             val_accuracy=88.0,
         )
         exporter.record_epoch(
@@ -200,14 +206,14 @@ class TestTrainingMetricsExporter:
             learning_rate=0.001,
             train_loss=0.35,
             train_accuracy=89.0,
+            val_loss=0.45,
             val_accuracy=86.0,
         )
 
-        best = exporter.get_best_epoch("val_accuracy")
+        summary = exporter.get_summary()
 
-        assert best is not None
-        assert best["epoch"] == 3
-        assert best["val_accuracy"] == 88.0
+        assert summary["best_val_accuracy"] == 88.0
+        assert summary["best_val_accuracy_epoch"] == 3
 
     def test_get_summary(self, tmp_path):
         """サマリー取得のテスト."""
@@ -233,29 +239,27 @@ class TestTrainingMetricsExporter:
         assert summary["best_val_accuracy"] == 83.0
         assert summary["best_val_accuracy_epoch"] == 5
 
-    def test_add_extended_headers(self, tmp_path):
-        """拡張ヘッダー追加のテスト（Issue 9用）."""
+    def test_record_with_layer_wise_lr_adds_headers(self, tmp_path):
+        """層別学習率記録時に拡張ヘッダーが自動追加される."""
         exporter = TrainingMetricsExporter(output_dir=tmp_path)
-
-        exporter.add_extended_headers(["param_1", "param_2"])
-
-        assert "param_1" in exporter.extended_headers
-        assert "param_2" in exporter.extended_headers
 
         exporter.record_epoch(
             epoch=1,
             learning_rate=0.001,
             train_loss=0.5,
             train_accuracy=85.0,
-            param_1=0.123,
-            param_2=0.456,
+            layer_wise_lr_enabled=True,
+            lr_backbone=0.0001,
+            lr_head=0.001,
         )
 
-        assert exporter.metrics_history[0]["param_1"] == 0.123
-        assert exporter.metrics_history[0]["param_2"] == 0.456
+        assert "lr_backbone" in exporter.extended_headers
+        assert "lr_head" in exporter.extended_headers
+        assert exporter.metrics_history[0]["lr_backbone"] == 0.0001
+        assert exporter.metrics_history[0]["lr_head"] == 0.001
 
     def test_record_without_validation_data(self, tmp_path):
-        """検証データなしでの記録テスト."""
+        """検証データなしでの記録・エクスポートテスト."""
         exporter = TrainingMetricsExporter(output_dir=tmp_path)
 
         exporter.record_epoch(
@@ -265,6 +269,6 @@ class TestTrainingMetricsExporter:
         assert exporter.metrics_history[0]["val_loss"] == ""
         assert exporter.metrics_history[0]["val_accuracy"] == ""
 
-        csv_path = exporter.export_to_csv()
+        csv_path, _ = exporter.export_all()
         assert csv_path is not None
         assert csv_path.exists()


### PR DESCRIPTION
## Summary

- 呼び出し元のないデッドコード3件を削除した.
- 外部から呼ばれていない公開メソッド7件を private 化した.
- テストを public API 経由に書き換えた.

## Related Issue

Closes #338

## Changes

### 削除 (3件)
- `PochiTrainer.setup_training_from_config()` を削除した (`pochi_trainer.py`).
- `find_best_model()` を削除した (`cli/pochi.py`). 未使用の `import re` も除去.
- `EarlyStopping.get_status()` を削除した (`early_stopping.py`).
- 対応するテスト (`TestFindBestModel`, `TestEarlyStoppingGetStatus`) も削除した.

### private 化 (7件)
- `CheckpointStore.save_checkpoint()` → `_save_checkpoint()`
- `Evaluator.compute_confusion_matrix()` → `_compute_confusion_matrix()`
- `Evaluator.log_confusion_matrix()` → `_log_confusion_matrix()`
- `TrainingMetricsExporter.add_extended_headers()` → `_add_extended_headers()`
- `TrainingMetricsExporter.export_to_csv()` → `_export_to_csv()`
- `TrainingMetricsExporter.generate_graphs()` → `_generate_graphs()`
- `TrainingMetricsExporter.get_best_epoch()` → `_get_best_epoch()`

### テスト修正
- `TestSaveCheckpoint` を削除し, `save_best_model`/`save_last_model` 経由のテストに統合した.
- `TestTrainingMetricsExporter` を `export_all`/`get_summary`/`record_epoch` 経由のテストに書き換えた.

## Code Changes

```python
# pochitrain/training/checkpoint_store.py (private 化)
def _save_checkpoint(self, filename, epoch, model, optimizer, scheduler, best_accuracy):
    ...

# pochitrain/training/evaluator.py (private 化)
def _compute_confusion_matrix(self, predicted, targets, num_classes):
    ...
def _log_confusion_matrix(self, confusion_matrix, epoch, workspace_path):
    ...

# pochitrain/visualization/metrics_exporter.py (private 化, export_all 経由で呼び出し)
def _export_to_csv(self, filename=None):
    ...
def _generate_graphs(self, base_filename=None):
    ...
```

## Test Plan

- `uv run pytest` で全674テストがパスすることを確認.

## Checklist

- [ ] `uv run pre-commit run --all-files`