### PR TITLE
refactor: convert_command のビジネスロジック分離とベンチマーク JSON 共通化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,14 @@
 - デッドコード・未使用公開メソッドを整理した ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
   - `CheckpointStore.save_checkpoint()` 等 7メソッドを private 化した.
   - テストを public API 経由に書き換えた.
-- `pochi.py` をサブコマンドごとに分割した (`N/A.`).
+- `pochi.py` をサブコマンドごとに分割した ([#341](https://github.com/kurorosu/pochitrain/pull/341)).
   - `cli/commands/` に `train.py`, `infer.py`, `optimize.py`, `convert.py` を分離した.
   - `cli/cli_commons.py` に共有ユーティリティ (`setup_logging`, `create_signal_handler`) を抽出した.
-  - `pochi.py` を 956行から 191行に削減した.
+  - `pochi.py` を 956行から 181行に削減した.
+- `convert_command` のビジネスロジックをサービス層に分離した (`N/A.`).
+  - `tensorrt/input_shape_resolver.py`: ONNX 動的シェイプ検出を CLI から分離した.
+  - `tensorrt/int8_config.py`: INT8 キャリブレーション設定の組み立てを CLI から分離した.
+  - ベンチマーク JSON 出力の重複を `export_benchmark_json()` に共通化した.
 
 ### Fixed
 - なし.

--- a/pochitrain/cli/commands/convert.py
+++ b/pochitrain/cli/commands/convert.py
@@ -4,10 +4,6 @@ import argparse
 from pathlib import Path
 
 from pochitrain.cli.cli_commons import setup_logging
-from pochitrain.utils import (
-    ConfigLoader,
-    load_config_auto,
-)
 
 
 def convert_command(args: argparse.Namespace) -> None:
@@ -55,117 +51,51 @@ def convert_command(args: argparse.Namespace) -> None:
     logger.info(f"精度: {precision.upper()}")
     logger.info(f"出力: {output_path}")
 
-    # 動的シェイプONNXの変換時は全精度で入力サイズ指定が必要.
-    input_shape = None
-    if args.input_size:
-        # チャンネル数は RGB (C=3) 固定. pochitrain は RGB 画像のみ対応.
-        input_shape = (3, args.input_size[0], args.input_size[1])
-        logger.debug(f"CLI指定の入力形状: {input_shape}")
-    else:
-        try:
-            import onnx
+    from pochitrain.tensorrt.input_shape_resolver import InputShapeResolver
 
-            onnx_model = onnx.load(str(onnx_path))
-            input_tensor = onnx_model.graph.input[0]
-            input_dims = input_tensor.type.tensor_type.shape.dim
-
-            dynamic_dims = [
-                d.dim_param for d in input_dims[1:] if d.dim_value == 0 and d.dim_param
-            ]
-            if any(d.dim_value == 0 for d in input_dims[1:]):
-                dynamic_info = (
-                    f" (動的次元: {', '.join(dynamic_dims)})" if dynamic_dims else ""
-                )
-                logger.error(
-                    f"ONNXモデルに動的シェイプが含まれています{dynamic_info}. "
-                    "--input-size で入力サイズを明示的に指定してください. "
-                    "例: --input-size 224 224"
-                )
-                return
-        except ImportError:
-            logger.debug(
-                "onnxパッケージが未インストールのため動的シェイプ検出をスキップ"
-            )
-        except Exception as e:
-            logger.debug(f"ONNX動的シェイプ検出中にエラー: {e}")
+    shape_resolver = InputShapeResolver()
+    try:
+        input_shape = shape_resolver.resolve(args.input_size, onnx_path)
+    except ValueError as e:
+        logger.error(str(e))
+        return
+    if input_shape is not None:
+        logger.debug(f"入力形状: {input_shape}")
 
     calibrator = None
     if precision == "int8":
         from pochitrain.tensorrt.calibrator import create_int8_calibrator
+        from pochitrain.tensorrt.int8_config import INT8CalibrationConfigurer
 
-        config = None
-        if args.config_path:
-            config_path = Path(args.config_path)
-            try:
-                config = ConfigLoader.load_config(str(config_path))
-                logger.debug(f"設定ファイルを読み込み: {config_path}")
-            except Exception as e:
-                logger.error(f"設定ファイル読み込みエラー: {e}")
-                return
-        else:
-            try:
-                config = load_config_auto(onnx_path)
-            except (FileNotFoundError, RuntimeError) as e:
-                logger.error(str(e))
-                return
-
-        if args.calib_data:
-            calib_data_root = args.calib_data
-        elif config.get("val_data_root"):
-            calib_data_root = config["val_data_root"]
-            logger.debug(f"キャリブレーションデータをconfigから取得: {calib_data_root}")
-        else:
-            logger.error(
-                "--calib-data を指定するか, " "configにval_data_rootを設定してください"
+        configurer = INT8CalibrationConfigurer(logger)
+        try:
+            calib_config = configurer.configure(
+                config_path=args.config_path,
+                calib_data=args.calib_data,
+                input_shape=input_shape,
+                onnx_path=onnx_path,
+                output_path=output_path,
+                calib_samples=args.calib_samples,
+                calib_batch_size=args.calib_batch_size,
             )
+        except (ValueError, FileNotFoundError, RuntimeError) as e:
+            logger.error(str(e))
             return
-
-        calib_data_path = Path(calib_data_root)
-        if not calib_data_path.exists():
-            logger.error(f"キャリブレーションデータが見つかりません: {calib_data_path}")
-            return
-
-        if "val_transform" not in config:
-            logger.error(
-                "configにval_transformが設定されていません. "
-                "INT8キャリブレーションにはval_transformが必要です."
-            )
-            return
-        transform = config["val_transform"]
-
-        if input_shape is not None:
-            calib_input_shape = input_shape
-        else:
-            try:
-                import onnx
-
-                onnx_model = onnx.load(str(onnx_path))
-                input_tensor = onnx_model.graph.input[0]
-                input_dims = input_tensor.type.tensor_type.shape.dim
-                calib_input_shape = tuple(d.dim_value for d in input_dims[1:])
-                logger.debug(f"ONNX入力形状: {calib_input_shape}")
-            except Exception as e:
-                logger.error(f"ONNXモデルから入力形状を取得できません: {e}")
-                return
-
-        cache_file = str(output_path.with_suffix(".cache"))
-
-        max_calib_samples = args.calib_samples
 
         logger.info(
             f"キャリブレーション設定: "
-            f"データ={calib_data_root}, "
-            f"最大サンプル数={max_calib_samples}"
+            f"データ={calib_config.calib_data_root}, "
+            f"最大サンプル数={calib_config.max_samples}"
         )
 
         try:
             calibrator = create_int8_calibrator(
-                data_root=calib_data_root,
-                transform=transform,
-                input_shape=calib_input_shape,
-                batch_size=args.calib_batch_size,
-                max_samples=max_calib_samples,
-                cache_file=cache_file,
+                data_root=calib_config.calib_data_root,
+                transform=calib_config.transform,
+                input_shape=calib_config.input_shape,
+                batch_size=calib_config.batch_size,
+                max_samples=calib_config.max_samples,
+                cache_file=calib_config.cache_file,
             )
         except Exception as e:
             logger.error(f"キャリブレータ作成エラー: {e}")

--- a/pochitrain/cli/commands/infer.py
+++ b/pochitrain/cli/commands/infer.py
@@ -10,8 +10,8 @@ from pochitrain import PochiConfig
 from pochitrain.cli.cli_commons import setup_logging
 from pochitrain.inference.benchmark import (
     build_pytorch_benchmark_result,
+    export_benchmark_json,
     resolve_env_name,
-    write_benchmark_result_json,
 )
 from pochitrain.inference.services import PyTorchInferenceService
 from pochitrain.inference.types.orchestration_types import (
@@ -183,18 +183,7 @@ def infer_command(args: argparse.Namespace) -> None:
                 accuracy=run_result.accuracy_percent,
                 env_name=env_name,
             )
-            try:
-                benchmark_json_path = write_benchmark_result_json(
-                    output_dir=workspace_dir,
-                    benchmark_result=benchmark_result,
-                )
-                logger.info(
-                    f"ベンチマークJSONを出力しました: {benchmark_json_path.name}"
-                )
-            except Exception as exc:  # pragma: no cover
-                logger.warning(
-                    f"ベンチマークJSONの保存に失敗しました, error: {exc}",
-                )
+            export_benchmark_json(workspace_dir, benchmark_result, logger)
 
         logger.info("推論完了")
         logger.info(

--- a/pochitrain/cli/infer_onnx.py
+++ b/pochitrain/cli/infer_onnx.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 from pochitrain.inference.benchmark import (
     build_onnx_benchmark_result,
+    export_benchmark_json,
     resolve_env_name,
-    write_benchmark_result_json,
 )
 from pochitrain.inference.services.onnx_inference_service import OnnxInferenceService
 from pochitrain.inference.types.orchestration_types import InferenceCliRequest
@@ -216,16 +216,7 @@ def main() -> None:
             accuracy=run_result.accuracy_percent,
             env_name=env_name,
         )
-        try:
-            benchmark_json_path = write_benchmark_result_json(
-                output_dir=output_dir,
-                benchmark_result=benchmark_result,
-            )
-            logger.info(f"ベンチマークJSONを出力しました: {benchmark_json_path.name}")
-        except Exception as exc:  # pragma: no cover
-            logger.warning(
-                f"ベンチマークJSONの保存に失敗しました, error: {exc}",
-            )
+        export_benchmark_json(output_dir, benchmark_result, logger)
 
     logger.info(f"ワークスペース: {output_dir.name}にサマリーファイルを出力しました")
 

--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 from pochitrain.inference.benchmark import (
     build_trt_benchmark_result,
+    export_benchmark_json,
     resolve_env_name,
-    write_benchmark_result_json,
 )
 from pochitrain.inference.services.trt_inference_service import TensorRTInferenceService
 from pochitrain.inference.types.orchestration_types import InferenceCliRequest
@@ -216,16 +216,7 @@ def main() -> None:
             accuracy=run_result.accuracy_percent,
             env_name=env_name,
         )
-        try:
-            benchmark_json_path = write_benchmark_result_json(
-                output_dir=output_dir,
-                benchmark_result=benchmark_result,
-            )
-            logger.info(f"ベンチマークJSONを出力しました: {benchmark_json_path.name}")
-        except Exception as exc:  # pragma: no cover
-            logger.warning(
-                f"ベンチマークJSONの保存に失敗しました, error: {exc}",
-            )
+        export_benchmark_json(output_dir, benchmark_result, logger)
 
     logger.info(f"ワークスペース: {output_dir.name}にサマリーファイルを出力しました")
 

--- a/pochitrain/inference/benchmark/__init__.py
+++ b/pochitrain/inference/benchmark/__init__.py
@@ -6,7 +6,7 @@ from .result_builder import (
     build_pytorch_benchmark_result,
     build_trt_benchmark_result,
 )
-from .result_exporter import write_benchmark_result_json
+from .result_exporter import export_benchmark_json, write_benchmark_result_json
 
 __all__ = [
     "resolve_env_name",
@@ -14,4 +14,5 @@ __all__ = [
     "build_pytorch_benchmark_result",
     "build_trt_benchmark_result",
     "write_benchmark_result_json",
+    "export_benchmark_json",
 ]

--- a/pochitrain/inference/benchmark/result_exporter.py
+++ b/pochitrain/inference/benchmark/result_exporter.py
@@ -1,5 +1,6 @@
 """ベンチマーク結果の出力処理."""
 
+import logging
 from pathlib import Path
 
 from pochitrain.inference.types.benchmark_types import (
@@ -26,3 +27,25 @@ def write_benchmark_result_json(
     """
     output_path = output_dir / filename
     return write_json_file(output_path, benchmark_result.to_dict())
+
+
+def export_benchmark_json(
+    output_dir: Path,
+    benchmark_result: BenchmarkResult,
+    logger: logging.Logger,
+) -> None:
+    """ベンチマーク結果 JSON の書き出しとログ出力を行う.
+
+    Args:
+        output_dir: 出力ディレクトリ.
+        benchmark_result: 保存するベンチ結果.
+        logger: ロガー.
+    """
+    try:
+        json_path = write_benchmark_result_json(
+            output_dir=output_dir,
+            benchmark_result=benchmark_result,
+        )
+        logger.info(f"ベンチマークJSONを出力しました: {json_path.name}")
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"ベンチマークJSONの保存に失敗しました, error: {exc}")

--- a/pochitrain/tensorrt/input_shape_resolver.py
+++ b/pochitrain/tensorrt/input_shape_resolver.py
@@ -1,0 +1,83 @@
+"""ONNX モデルの入力形状解析と動的シェイプ検出."""
+
+from pathlib import Path
+from typing import Optional
+
+
+class InputShapeResolver:
+    """ONNX モデルの入力形状を解析し, 動的シェイプを検出する."""
+
+    def resolve(
+        self,
+        cli_input_size: Optional[list[int]],
+        onnx_path: Path,
+    ) -> Optional[tuple[int, ...]]:
+        """CLI 引数または ONNX モデルから入力形状を解決する.
+
+        Args:
+            cli_input_size: CLI で指定された [H, W]. None なら ONNX から検出.
+            onnx_path: ONNX モデルファイルパス.
+
+        Returns:
+            (C, H, W) 形式の入力形状. 静的シェイプで指定不要な場合は None.
+
+        Raises:
+            ValueError: 動的シェイプが検出され, cli_input_size が未指定の場合.
+        """
+        if cli_input_size is not None:
+            # チャンネル数は RGB (C=3) 固定. pochitrain は RGB 画像のみ対応.
+            return (3, cli_input_size[0], cli_input_size[1])
+
+        return self._detect_from_onnx(onnx_path)
+
+    def _detect_from_onnx(self, onnx_path: Path) -> Optional[tuple[int, ...]]:
+        """ONNX モデルから入力形状を検出する."""
+        try:
+            import onnx
+
+            onnx_model = onnx.load(str(onnx_path))
+            input_tensor = onnx_model.graph.input[0]
+            input_dims = input_tensor.type.tensor_type.shape.dim
+
+            dynamic_dims = [
+                d.dim_param for d in input_dims[1:] if d.dim_value == 0 and d.dim_param
+            ]
+            if any(d.dim_value == 0 for d in input_dims[1:]):
+                dynamic_info = (
+                    f" (動的次元: {', '.join(dynamic_dims)})" if dynamic_dims else ""
+                )
+                raise ValueError(
+                    f"ONNXモデルに動的シェイプが含まれています{dynamic_info}. "
+                    "--input-size で入力サイズを明示的に指定してください. "
+                    "例: --input-size 224 224"
+                )
+        except ImportError:
+            pass
+        except ValueError:
+            raise
+        except Exception:
+            pass
+
+        return None
+
+    def extract_static_shape(self, onnx_path: Path) -> tuple[int, ...]:
+        """ONNX モデルから静的入力形状 (C, H, W) を取得する.
+
+        Args:
+            onnx_path: ONNX モデルファイルパス.
+
+        Returns:
+            (C, H, W) 形式の入力形状.
+
+        Raises:
+            RuntimeError: 入力形状を取得できない場合.
+        """
+        try:
+            import onnx
+
+            onnx_model = onnx.load(str(onnx_path))
+            input_tensor = onnx_model.graph.input[0]
+            input_dims = input_tensor.type.tensor_type.shape.dim
+            return tuple(d.dim_value for d in input_dims[1:])
+        except Exception as e:
+            raise RuntimeError(f"ONNXモデルから入力形状を取得できません: {e}") from e

--- a/pochitrain/tensorrt/int8_config.py
+++ b/pochitrain/tensorrt/int8_config.py
@@ -1,0 +1,133 @@
+"""INT8 キャリブレーション設定の組み立て."""
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from pochitrain.tensorrt.input_shape_resolver import InputShapeResolver
+from pochitrain.utils import ConfigLoader, load_config_auto
+
+
+@dataclass
+class INT8CalibrationConfig:
+    """INT8 キャリブレーションに必要な設定."""
+
+    calib_data_root: str
+    transform: Any
+    input_shape: tuple[int, ...]
+    batch_size: int
+    max_samples: int
+    cache_file: str
+
+
+class INT8CalibrationConfigurer:
+    """INT8 キャリブレーション設定を CLI 引数と config から組み立てる."""
+
+    def __init__(self, logger: logging.Logger) -> None:
+        """INT8CalibrationConfigurer を初期化.
+
+        Args:
+            logger: ロガー.
+        """
+        self._logger = logger
+        self._shape_resolver = InputShapeResolver()
+
+    def configure(
+        self,
+        *,
+        config_path: Optional[str],
+        calib_data: Optional[str],
+        input_shape: Optional[tuple[int, ...]],
+        onnx_path: Path,
+        output_path: Path,
+        calib_samples: int,
+        calib_batch_size: int,
+    ) -> INT8CalibrationConfig:
+        """INT8 キャリブレーション設定を組み立てる.
+
+        Args:
+            config_path: CLI で指定された設定ファイルパス.
+            calib_data: CLI で指定されたキャリブレーションデータパス.
+            input_shape: 解決済みの入力形状 (C, H, W). None なら ONNX から取得.
+            onnx_path: ONNX モデルファイルパス.
+            output_path: 出力エンジンファイルパス (キャッシュファイル名生成用).
+            calib_samples: キャリブレーションサンプル数.
+            calib_batch_size: キャリブレーションバッチサイズ.
+
+        Returns:
+            INT8CalibrationConfig.
+
+        Raises:
+            ValueError: 設定が不足している場合.
+            FileNotFoundError: データパスが存在しない場合.
+            RuntimeError: 設定ファイルの読み込みに失敗した場合.
+        """
+        config = self._load_config(config_path, onnx_path)
+        calib_data_root = self._resolve_calib_data(calib_data, config)
+        transform = self._resolve_transform(config)
+        calib_input_shape = self._resolve_input_shape(input_shape, onnx_path)
+
+        return INT8CalibrationConfig(
+            calib_data_root=calib_data_root,
+            transform=transform,
+            input_shape=calib_input_shape,
+            batch_size=calib_batch_size,
+            max_samples=calib_samples,
+            cache_file=str(output_path.with_suffix(".cache")),
+        )
+
+    def _load_config(
+        self, config_path: Optional[str], onnx_path: Path
+    ) -> dict[str, Any]:
+        """設定ファイルを読み込む."""
+        if config_path:
+            try:
+                config = ConfigLoader.load_config(config_path)
+                self._logger.debug(f"設定ファイルを読み込み: {config_path}")
+                return config
+            except Exception as e:
+                raise RuntimeError(f"設定ファイル読み込みエラー: {e}") from e
+        else:
+            return load_config_auto(onnx_path)
+
+    def _resolve_calib_data(
+        self, calib_data: Optional[str], config: dict[str, Any]
+    ) -> str:
+        """キャリブレーションデータパスを解決する."""
+        if calib_data:
+            calib_data_root = calib_data
+        elif config.get("val_data_root"):
+            calib_data_root = config["val_data_root"]
+            self._logger.debug(
+                f"キャリブレーションデータをconfigから取得: {calib_data_root}"
+            )
+        else:
+            raise ValueError(
+                "--calib-data を指定するか, configにval_data_rootを設定してください"
+            )
+
+        if not Path(calib_data_root).exists():
+            raise FileNotFoundError(
+                f"キャリブレーションデータが見つかりません: {calib_data_root}"
+            )
+        return calib_data_root
+
+    def _resolve_transform(self, config: dict[str, Any]) -> Any:
+        """キャリブレーション用 transform を取得する."""
+        if "val_transform" not in config:
+            raise ValueError(
+                "configにval_transformが設定されていません. "
+                "INT8キャリブレーションにはval_transformが必要です."
+            )
+        return config["val_transform"]
+
+    def _resolve_input_shape(
+        self,
+        input_shape: Optional[tuple[int, ...]],
+        onnx_path: Path,
+    ) -> tuple[int, ...]:
+        """キャリブレーション用入力形状を解決する."""
+        if input_shape is not None:
+            return input_shape
+        return self._shape_resolver.extract_static_shape(onnx_path)

--- a/tests/unit/test_cli/test_convert_cli.py
+++ b/tests/unit/test_cli/test_convert_cli.py
@@ -14,6 +14,7 @@ import pytest
 
 import pochitrain.cli.commands.convert as convert_cli
 import pochitrain.cli.pochi as pochi_cli
+import pochitrain.tensorrt.int8_config as int8_config_module
 from pochitrain.cli.arg_types import positive_int
 
 ConvertArgsRunner = Callable[[list[str]], argparse.Namespace]
@@ -295,7 +296,7 @@ class TestConvertCommand:
             calibrator_module, "create_int8_calibrator", _fake_create_int8_calibrator
         )
         monkeypatch.setattr(
-            convert_cli.ConfigLoader,
+            int8_config_module.ConfigLoader,
             "load_config",
             lambda _path: {"val_transform": "dummy_transform"},
         )
@@ -359,7 +360,7 @@ class TestConvertCommand:
             calibrator_module, "create_int8_calibrator", _fake_create_int8_calibrator
         )
         monkeypatch.setattr(
-            convert_cli,
+            int8_config_module,
             "load_config_auto",
             lambda _path: {
                 "val_data_root": str(calib_dir),


### PR DESCRIPTION
## Summary

- `convert_command` の ONNX 動的シェイプ検出と INT8 キャリブレーション設定を専門クラスに分離した.
- ベンチマーク JSON 出力の重複 (3箇所) を `export_benchmark_json()` に共通化した.

## Related Issue

Closes #340

## Changes

### 新規ファイル

| ファイル | 内容 | 行数 |
|---------|------|------|
| `tensorrt/input_shape_resolver.py` | `InputShapeResolver`: CLI 引数または ONNX モデルから入力形状を解決. 動的シェイプ検出 | 89 |
| `tensorrt/int8_config.py` | `INT8CalibrationConfigurer`: config 読み込み, データパス解決, transform 取得, 入力形状取得を一括処理 | 133 |

### convert_command のスリム化

- 192行 → 122行 (37%削減)
- ONNX 動的シェイプ検出 (~27行) → `InputShapeResolver.resolve()` 呼び出し (3行)
- INT8 キャリブレーション設定 (~81行) → `INT8CalibrationConfigurer.configure()` 呼び出し (10行)

### ベンチマーク JSON 共通化

- `inference/benchmark/result_exporter.py` に `export_benchmark_json()` を追加
- 3箇所の重複パターン (build → write → ログ) を1関数呼び出しに置換:
  - `cli/commands/infer.py` (pytorch)
  - `cli/infer_onnx.py` (onnx)
  - `cli/infer_trt.py` (tensorrt)

### テスト修正

- monkeypatch 先を `convert_cli.ConfigLoader` → `int8_config_module.ConfigLoader` に変更
- テストロジック自体は変更なし

## Code Changes

```python
# tensorrt/input_shape_resolver.py
class InputShapeResolver:
    def resolve(self, cli_input_size, onnx_path) -> tuple[int,...] | None: ...
    def extract_static_shape(self, onnx_path) -> tuple[int,...]: ...

# tensorrt/int8_config.py
class INT8CalibrationConfigurer:
    def configure(self, *, config_path, calib_data, ...) -> INT8CalibrationConfig: ...

# inference/benchmark/result_exporter.py (追加)
def export_benchmark_json(output_dir, benchmark_result, logger) -> None: ...
```

## Test Plan

- `uv run pytest` で全674テストがパスすることを確認.
- `uv run pochi convert --help` の出力が変更前と同一であることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`