### PR TITLE
fix: metrics_exporter の colormap を層数に応じて自動選択

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,18 +20,19 @@
   - `cli/commands/` に `train.py`, `infer.py`, `optimize.py`, `convert.py` を分離した.
   - `cli/cli_commons.py` に共有ユーティリティ (`setup_logging`, `create_signal_handler`) を抽出した.
   - `pochi.py` を 956行から 181行に削減した.
-- `convert_command` のビジネスロジックをサービス層に分離した (`N/A.`).
+- `convert_command` のビジネスロジックをサービス層に分離した ([#342](https://github.com/kurorosu/pochitrain/pull/342)).
   - `tensorrt/input_shape_resolver.py`: ONNX 動的シェイプ検出を CLI から分離した.
   - `tensorrt/int8_config.py`: INT8 キャリブレーション設定の組み立てを CLI から分離した.
   - ベンチマーク JSON 出力の重複を `export_benchmark_json()` に共通化した.
 
 ### Fixed
-- なし.
+- `metrics_exporter.py` の colormap を層数に応じて自動選択するよう修正した (`N/A.`).
+  - 10層以下は `tab10`, 11層以上は `tab20` を使用する.
 
 ### Removed
-- `PochiTrainer.setup_training_from_config()` を削除した (呼び出し元なし) (`N/A.`).
-- `find_best_model()` を削除した (呼び出し元なし) (`N/A.`).
-- `EarlyStopping.get_status()` を削除した (呼び出し元なし) (`N/A.`).
+- `PochiTrainer.setup_training_from_config()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
+- `find_best_model()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
+- `EarlyStopping.get_status()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
 
 ## v1.8.0 (2026-03-16)
 

--- a/pochitrain/visualization/metrics_exporter.py
+++ b/pochitrain/visualization/metrics_exporter.py
@@ -331,7 +331,9 @@ class TrainingMetricsExporter(BaseCSVExporter):
 
         fig, ax = plt.subplots(figsize=(12, 8))
 
-        colors = plt.get_cmap("tab10")(range(len(lr_columns)))
+        n_colors = len(lr_columns)
+        cmap_name = "tab10" if n_colors <= 10 else "tab20"
+        colors = plt.get_cmap(cmap_name)(range(n_colors))
         for i, lr_col in enumerate(lr_columns):
             layer_name = lr_col.replace("lr_", "")
             learning_rates = [m.get(lr_col, 0) for m in self.metrics_history]


### PR DESCRIPTION
## Summary

- 層別学習率グラフの colormap を層数に応じて自動選択するよう修正した.
- 10層以下は `tab10`, 11層以上は `tab20` を使用する.

## Related Issue

Closes #347

## Changes

- `pochitrain/visualization/metrics_exporter.py` を修正した.
  - `_generate_layer_wise_lr_graph()` の colormap 選択を層数に応じて分岐するよう変更した.

## Code Changes

```python
# pochitrain/visualization/metrics_exporter.py (Before)
colors = plt.get_cmap("tab10")(range(len(lr_columns)))

# pochitrain/visualization/metrics_exporter.py (After)
n_colors = len(lr_columns)
cmap_name = "tab10" if n_colors <= 10 else "tab20"
colors = plt.get_cmap(cmap_name)(range(n_colors))
```

## Test Plan

- `uv run pytest tests/unit/test_visualization/test_metrics_exporter.py -v` で既存32テスト全パスを確認.
- `uv run pytest` で全674テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`