### PR TITLE
chore: v1.8.1 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@
 - なし.
 
 ### Changed
+- なし.
+
+### Fixed
+- なし.
+
+### Removed
+- なし.
+
+## v1.8.1 (2026-03-20)
+
+### 概要
+- CLI 構造のリファクタリング, 設計改善, バグ修正を含むパッチリリースです.
+
+### Added
+- なし.
+
+### Changed
 - `TrainingConfigurator` から層別学習率ロジックを分離した ([#337](https://github.com/kurorosu/pochitrain/pull/337)).
   - `training/layer_wise_lr/` パッケージを新設した (`ILayerGrouper`, `ResNetLayerGrouper`, `ParamGroupBuilder`).
   - Strategy パターンにより, 将来の非 ResNet モデル対応が拡張のみで可能になった.
@@ -34,61 +51,9 @@
 - `find_best_model()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
 - `EarlyStopping.get_status()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
 
-## v1.8.0 (2026-03-16)
-
-### 概要
-- TensorBoard 統合, リファクタリング, テスト拡充, ドキュメント修正を含むマイナーリリースです.
-
-### Added
-- TensorBoard 統合を実装した ([#325](https://github.com/kurorosu/pochitrain/pull/325)).
-  - `pochitrain/visualization/tensorboard/` パッケージを追加した.
-  - `PochiConfig` に `enable_tensorboard` オプションを追加した.
-  - `MetricsTracker` に `TensorBoardWriter` を統合し, loss, accuracy, 学習率を記録するようにした.
-  - `tensorboard>=2.14.0` を依存関係に追加した.
-
-### Changed
-- 例外処理を改善した ([#326](https://github.com/kurorosu/pochitrain/pull/326)).
-  - `pochi_predictor.py` の例外チェーンを `from e` 付きに修正し, デバッグ時のスタックトレースを保持するようにした.
-  - `inference_utils.py` の `sys.exit(1)` を `FileNotFoundError` / `RuntimeError` に置き換え, Jupyter 等での利用を可能にした.
-  - CLI 側で例外をキャッチしてエラーログ出力後に安全に終了するようにした.
-- `PochiPredictor.predict()` の複雑度を削減した ([#327](https://github.com/kurorosu/pochitrain/pull/327)).
-  - ウォームアップ, 初回バッチ実行, タイミング計測をヘルパーメソッドに分離した.
-- `pochi_dataset.py` の transform フィルタリングロジックの重複を解消した ([#328](https://github.com/kurorosu/pochitrain/pull/328)).
-  - 共通の `_filter_transforms()` 関数を抽出し, `build_gpu_preprocess_transform` と `convert_transform_for_fast_inference` から呼び出すようにした.
-- `FastInferenceDataset._transform_error_logged` をクラス変数からインスタンス変数に変更した ([#329](https://github.com/kurorosu/pochitrain/pull/329)).
-
-### Tests
-- `benchmark/` モジュールのテストを追加した ([#330](https://github.com/kurorosu/pochitrain/pull/330)).
-  - `models.py`: CaseConfig/SuiteConfig のフィールド保持, frozen 制約のテストを追加した.
-  - `utils.py`: configure_logger, タイムスタンプ形式, write_json, to_float のテストを追加した.
-  - `loader.py`: バリデーション関数と load_suite_config の正常系/エラー系テストを追加した.
-  - `aggregator.py`: パス収集, ケース名抽出, 集計ロジック (平均, 標準偏差, グループ分離, 不正JSON) のテストを追加した.
-  - `runner.py`: config パス解決, config コピー, コマンド構築のテストを追加した.
-- `epoch_runner.py` のテストを追加した ([#331](https://github.com/kurorosu/pochitrain/pull/331)).
-  - 単一バッチ/複数バッチの損失計算, 空 DataLoader の防御的ガード, クラス重み付き損失, 勾配更新のテストを追加した.
-- `visualize_gradient.py` のテストを追加した ([#332](https://github.com/kurorosu/pochitrain/pull/332)).
-  - CSV 読み込み (正常系, 不正CSV), PNG 出力生成 (timeline, heatmap, statistics, snapshots), CLI ユーティリティ関数のテストを追加した.
-- エッジケーステストを追加した ([#333](https://github.com/kurorosu/pochitrain/pull/333)).
-  - `early_stopping`: min_delta 境界値 (極小0.0001/極大10.0) のテストを追加した.
-  - `pochi_dataset`: 画像1枚データセット, 破損画像ファイルのテストを追加した.
-  - `training_configurator`: 学習率0.0, 負の学習率, 極端な層別学習率のテストを追加した.
-  - `checkpoint_store`: 存在しないディレクトリへの保存, optimizer=None のテストを追加した.
-  - `evaluator`: 空 DataLoader, 単一サンプルの精度計算/混同行列のテストを追加した.
-
-### Fixed
-- ドキュメント不整合を修正した ([#334](https://github.com/kurorosu/pochitrain/pull/334)).
-  - CLAUDE.md: `pochi infer` コマンドの引数を位置引数に修正した.
-  - README.md: `--opset` を `--opset-version` に修正した.
-  - README.md: `create_data_loaders` の使用例に `train_transform`/`val_transform` パラメータを追加した.
-- CLI の使用例を実装と整合させた ([#335](https://github.com/kurorosu/pochitrain/pull/335)).
-  - `pochi.py`: `pochi infer` の epilog を位置引数形式に修正した.
-  - `infer_trt.py`: `--pipeline gpu` のデフォルト表記を削除した (実際のデフォルトは `auto`).
-
-### Removed
-- なし.
-
 ## Archived Changelogs
 
+- [`changelogs/1.8.x.md`](./changelogs/1.8.x.md)
 - [`changelogs/1.7.x.md`](./changelogs/1.7.x.md)
 
 - [`changelogs/1.6.x.md`](./changelogs/1.6.x.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pochitrain
 
-[![Version](https://img.shields.io/badge/version-1.8.0-blue.svg)](https://github.com/kurorosu/pochitrain)
+[![Version](https://img.shields.io/badge/version-1.8.1-blue.svg)](https://github.com/kurorosu/pochitrain)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-yellow.svg)](https://www.python.org/)
 [![Jetson](https://img.shields.io/badge/Jetson-JetPack%206.2.1%20%28Python%203.10%29-76B900.svg)](https://developer.nvidia.com/embedded/jetpack)

--- a/changelogs/1.8.x.md
+++ b/changelogs/1.8.x.md
@@ -1,0 +1,54 @@
+# Changelog 1.8.x
+
+## v1.8.0 (2026-03-16)
+
+### 概要
+- TensorBoard 統合, リファクタリング, テスト拡充, ドキュメント修正を含むマイナーリリースです.
+
+### Added
+- TensorBoard 統合を実装した ([#325](https://github.com/kurorosu/pochitrain/pull/325)).
+  - `pochitrain/visualization/tensorboard/` パッケージを追加した.
+  - `PochiConfig` に `enable_tensorboard` オプションを追加した.
+  - `MetricsTracker` に `TensorBoardWriter` を統合し, loss, accuracy, 学習率を記録するようにした.
+  - `tensorboard>=2.14.0` を依存関係に追加した.
+
+### Changed
+- 例外処理を改善した ([#326](https://github.com/kurorosu/pochitrain/pull/326)).
+  - `pochi_predictor.py` の例外チェーンを `from e` 付きに修正し, デバッグ時のスタックトレースを保持するようにした.
+  - `inference_utils.py` の `sys.exit(1)` を `FileNotFoundError` / `RuntimeError` に置き換え, Jupyter 等での利用を可能にした.
+  - CLI 側で例外をキャッチしてエラーログ出力後に安全に終了するようにした.
+- `PochiPredictor.predict()` の複雑度を削減した ([#327](https://github.com/kurorosu/pochitrain/pull/327)).
+  - ウォームアップ, 初回バッチ実行, タイミング計測をヘルパーメソッドに分離した.
+- `pochi_dataset.py` の transform フィルタリングロジックの重複を解消した ([#328](https://github.com/kurorosu/pochitrain/pull/328)).
+  - 共通の `_filter_transforms()` 関数を抽出し, `build_gpu_preprocess_transform` と `convert_transform_for_fast_inference` から呼び出すようにした.
+- `FastInferenceDataset._transform_error_logged` をクラス変数からインスタンス変数に変更した ([#329](https://github.com/kurorosu/pochitrain/pull/329)).
+
+### Tests
+- `benchmark/` モジュールのテストを追加した ([#330](https://github.com/kurorosu/pochitrain/pull/330)).
+  - `models.py`: CaseConfig/SuiteConfig のフィールド保持, frozen 制約のテストを追加した.
+  - `utils.py`: configure_logger, タイムスタンプ形式, write_json, to_float のテストを追加した.
+  - `loader.py`: バリデーション関数と load_suite_config の正常系/エラー系テストを追加した.
+  - `aggregator.py`: パス収集, ケース名抽出, 集計ロジック (平均, 標準偏差, グループ分離, 不正JSON) のテストを追加した.
+  - `runner.py`: config パス解決, config コピー, コマンド構築のテストを追加した.
+- `epoch_runner.py` のテストを追加した ([#331](https://github.com/kurorosu/pochitrain/pull/331)).
+  - 単一バッチ/複数バッチの損失計算, 空 DataLoader の防御的ガード, クラス重み付き損失, 勾配更新のテストを追加した.
+- `visualize_gradient.py` のテストを追加した ([#332](https://github.com/kurorosu/pochitrain/pull/332)).
+  - CSV 読み込み (正常系, 不正CSV), PNG 出力生成 (timeline, heatmap, statistics, snapshots), CLI ユーティリティ関数のテストを追加した.
+- エッジケーステストを追加した ([#333](https://github.com/kurorosu/pochitrain/pull/333)).
+  - `early_stopping`: min_delta 境界値 (極小0.0001/極大10.0) のテストを追加した.
+  - `pochi_dataset`: 画像1枚データセット, 破損画像ファイルのテストを追加した.
+  - `training_configurator`: 学習率0.0, 負の学習率, 極端な層別学習率のテストを追加した.
+  - `checkpoint_store`: 存在しないディレクトリへの保存, optimizer=None のテストを追加した.
+  - `evaluator`: 空 DataLoader, 単一サンプルの精度計算/混同行列のテストを追加した.
+
+### Fixed
+- ドキュメント不整合を修正した ([#334](https://github.com/kurorosu/pochitrain/pull/334)).
+  - CLAUDE.md: `pochi infer` コマンドの引数を位置引数に修正した.
+  - README.md: `--opset` を `--opset-version` に修正した.
+  - README.md: `create_data_loaders` の使用例に `train_transform`/`val_transform` パラメータを追加した.
+- CLI の使用例を実装と整合させた ([#335](https://github.com/kurorosu/pochitrain/pull/335)).
+  - `pochi.py`: `pochi infer` の epilog を位置引数形式に修正した.
+  - `infer_trt.py`: `--pipeline gpu` のデフォルト表記を削除した (実際のデフォルトは `auto`).
+
+### Removed
+- なし.

--- a/pochitrain/__init__.py
+++ b/pochitrain/__init__.py
@@ -20,7 +20,7 @@ from .pochi_dataset import (
 from .pochi_predictor import PochiPredictor
 from .pochi_trainer import PochiTrainer
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 __author__ = "Pochi Team"
 __email__ = "pochi@example.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochitrain"
-version = "1.8.0"
+version = "1.8.1"
 description = "Simple CNN training framework for image classification"
 readme = "README.md"
 # Jetson (JetPack 6.2.1 / Python 3.10) で pip install -e . するため >=3.10 を維持.

--- a/uv.lock
+++ b/uv.lock
@@ -1848,7 +1848,7 @@ wheels = [
 
 [[package]]
 name = "pochitrain"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },
@@ -2788,13 +2788,13 @@ dependencies = [
     { name = "torch", marker = "python_full_version < '3.15' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:bfd03db06f624a7e921f9cc5bb03d4b6afa13b5f9e225610a672dba09e5d0dca" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d4ba2532440a93c23a99c41423a765a0cdd47556afa3acf7c318dd1d3d6793e9" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:89743dcee13e943f58b37c7647aff14b5bb24c11c84826376d457acf97586fec" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7bf2cb6167244750e905fbada15b9b25b9487883cc212b9586eee74c455af02a" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:27b7593f236e8cb264b12a1166e59d744af76fdb347b598a9c2665118bc27533" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:083b9361e677a51e3e5632c80d7a1fdee200ecabf787a14cad9f9ebe1bb523d5" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2681f8ddf7ccd89b94906e2e303adee498d1641452ce07b0dd1cc928475b970f" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:bfd03db06f624a7e921f9cc5bb03d4b6afa13b5f9e225610a672dba09e5d0dca" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d4ba2532440a93c23a99c41423a765a0cdd47556afa3acf7c318dd1d3d6793e9" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:89743dcee13e943f58b37c7647aff14b5bb24c11c84826376d457acf97586fec" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7bf2cb6167244750e905fbada15b9b25b9487883cc212b9586eee74c455af02a" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:27b7593f236e8cb264b12a1166e59d744af76fdb347b598a9c2665118bc27533" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:083b9361e677a51e3e5632c80d7a1fdee200ecabf787a14cad9f9ebe1bb523d5" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2681f8ddf7ccd89b94906e2e303adee498d1641452ce07b0dd1cc928475b970f" },
 ]
 
 [[package]]
@@ -2814,20 +2814,20 @@ dependencies = [
     { name = "torch", marker = "python_full_version >= '3.15' or platform_machine != 'aarch64' or platform_python_implementation != 'CPython' or sys_platform != 'linux'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f6e7a6cb4af75dc378fceba8ef78697b6fd8f90feab302790f6755155d0ab7df" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp310-cp310-win_amd64.whl", hash = "sha256:b90101f5ec2125d5bb8c34a61928572ea288cbd918526e1b02564d4c2b8c42e3" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b0cc84c57c1fd54644698a70a74d1ea1eddfa44ee2df3354b7bb2c619a5d2923" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:f564b9fdbc336ac187780931331fb4253f8511deae914dde12dca5bf17b3045f" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6939dd403cc28ab0a46f53e6c86e2e852cf65771c1b0ddd09c44c541a1cdbad9" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:d31ceaded0d9b737471fa680ccd9e1acb6d5f0f70f03ef3a8d786a99c79da7cf" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1cac548fc20d6bd1da437f1bf586bbf9159ca3225222bacaa79b8a672197a535" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp313-cp313-win_amd64.whl", hash = "sha256:d688426d623b8ba763087726faf5b34b1fe404f44741656978d855403dbc7444" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:e342aa662dbd4dcb43a01e697e03f61f615fc34011f13f8c9bfcd1527f8a40c5" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp313-cp313t-win_amd64.whl", hash = "sha256:878ce9b16d2c8797cb846709d31c270e9b985bd7cc59e8c8e5bbb0ed372b31c7" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:461a5f5fdd4b2e9adf972bd4f2e2bd96299fac64b524542c3805bad898438416" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp314-cp314-win_amd64.whl", hash = "sha256:ae9ca2c3e6a517a01625404e72f485d0205463cb7c14f4f1dca8f5f368401be4" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8dbd486b3e73bb21df3734bf06e03664bdbc015c3d97b27ddf17eb7fb99c529f" },
-    { url = "https://download.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp314-cp314t-win_amd64.whl", hash = "sha256:85c4606ff11773627d325f812628c4ea2d9a83b6c8417a344fdc16305ec0a454" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f6e7a6cb4af75dc378fceba8ef78697b6fd8f90feab302790f6755155d0ab7df" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp310-cp310-win_amd64.whl", hash = "sha256:b90101f5ec2125d5bb8c34a61928572ea288cbd918526e1b02564d4c2b8c42e3" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b0cc84c57c1fd54644698a70a74d1ea1eddfa44ee2df3354b7bb2c619a5d2923" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:f564b9fdbc336ac187780931331fb4253f8511deae914dde12dca5bf17b3045f" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6939dd403cc28ab0a46f53e6c86e2e852cf65771c1b0ddd09c44c541a1cdbad9" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp312-cp312-win_amd64.whl", hash = "sha256:d31ceaded0d9b737471fa680ccd9e1acb6d5f0f70f03ef3a8d786a99c79da7cf" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1cac548fc20d6bd1da437f1bf586bbf9159ca3225222bacaa79b8a672197a535" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp313-cp313-win_amd64.whl", hash = "sha256:d688426d623b8ba763087726faf5b34b1fe404f44741656978d855403dbc7444" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:e342aa662dbd4dcb43a01e697e03f61f615fc34011f13f8c9bfcd1527f8a40c5" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp313-cp313t-win_amd64.whl", hash = "sha256:878ce9b16d2c8797cb846709d31c270e9b985bd7cc59e8c8e5bbb0ed372b31c7" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:461a5f5fdd4b2e9adf972bd4f2e2bd96299fac64b524542c3805bad898438416" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp314-cp314-win_amd64.whl", hash = "sha256:ae9ca2c3e6a517a01625404e72f485d0205463cb7c14f4f1dca8f5f368401be4" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8dbd486b3e73bb21df3734bf06e03664bdbc015c3d97b27ddf17eb7fb99c529f" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.24.1%2Bcu130-cp314-cp314t-win_amd64.whl", hash = "sha256:85c4606ff11773627d325f812628c4ea2d9a83b6c8417a344fdc16305ec0a454" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- バージョンを v1.8.0 → v1.8.1 に更新した.
- v1.8.0 の CHANGELOG を `changelogs/1.8.x.md` にアーカイブした.

## Related Issue

無し.

## Changes

- `pyproject.toml`, `pochitrain/__init__.py`, `README.md` のバージョンを `1.8.1` に更新した.
- `CHANGELOG.md` の `[Unreleased]` を `v1.8.1 (2026-03-20)` に確定した.
- `changelogs/1.8.x.md` を作成し, v1.8.0 の履歴をアーカイブした.
- `uv lock` で `uv.lock` を更新した.

## Code Changes

無し.

## Test Plan

- `uv run pytest` で全674テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`