### PR TITLE
fix: InputShapeResolver の無言例外無視を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - なし.
 
 ### Fixed
-- なし.
+- `InputShapeResolver._detect_from_onnx()` の無言例外無視を修正した (`N/A.`).
+  - `except Exception: pass` を `logger.debug()` に変更し, デバッグ時にエラー原因を追跡可能にした.
 
 ### Removed
 - なし.

--- a/pochitrain/cli/commands/convert.py
+++ b/pochitrain/cli/commands/convert.py
@@ -53,7 +53,7 @@ def convert_command(args: argparse.Namespace) -> None:
 
     from pochitrain.tensorrt.input_shape_resolver import InputShapeResolver
 
-    shape_resolver = InputShapeResolver()
+    shape_resolver = InputShapeResolver(logger)
     try:
         input_shape = shape_resolver.resolve(args.input_size, onnx_path)
     except ValueError as e:

--- a/pochitrain/tensorrt/input_shape_resolver.py
+++ b/pochitrain/tensorrt/input_shape_resolver.py
@@ -1,11 +1,20 @@
 """ONNX モデルの入力形状解析と動的シェイプ検出."""
 
+import logging
 from pathlib import Path
 from typing import Optional
 
 
 class InputShapeResolver:
     """ONNX モデルの入力形状を解析し, 動的シェイプを検出する."""
+
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        """入力形状リゾルバを初期化.
+
+        Args:
+            logger: ロガー. None の場合はモジュールロガーを使用.
+        """
+        self._logger = logger or logging.getLogger(__name__)
 
     def resolve(
         self,
@@ -56,7 +65,7 @@ class InputShapeResolver:
         except ValueError:
             raise
         except Exception:
-            pass
+            self._logger.debug("ONNX 入力形状の検出中にエラーが発生", exc_info=True)
 
         return None
 

--- a/pochitrain/tensorrt/int8_config.py
+++ b/pochitrain/tensorrt/int8_config.py
@@ -31,7 +31,7 @@ class INT8CalibrationConfigurer:
             logger: ロガー.
         """
         self._logger = logger
-        self._shape_resolver = InputShapeResolver()
+        self._shape_resolver = InputShapeResolver(logger)
 
     def configure(
         self,


### PR DESCRIPTION
## Summary

- `InputShapeResolver._detect_from_onnx()` の `except Exception: pass` を `logger.debug()` に変更した.
- `InputShapeResolver` に logger を DI で注入する設計にした.

## Related Issue

Closes #348

## Changes

- `pochitrain/tensorrt/input_shape_resolver.py` を修正した.
  - `__init__` に `logger` パラメータを追加した.
  - `except Exception: pass` → `self._logger.debug("...", exc_info=True)` に変更した.
- `pochitrain/cli/commands/convert.py` を修正した.
  - `InputShapeResolver(logger)` で logger を注入するようにした.
- `pochitrain/tensorrt/int8_config.py` を修正した.
  - `InputShapeResolver(logger)` で logger を注入するようにした.

## Code Changes

```python
# pochitrain/tensorrt/input_shape_resolver.py (Before)
except Exception:
    pass

# pochitrain/tensorrt/input_shape_resolver.py (After)
except Exception:
    self._logger.debug("ONNX 入力形状の検出中にエラーが発生", exc_info=True)
```

## Test Plan

- `uv run pytest` で全674テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`