### PR TITLE
refactor: マジックナンバーの定数化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@
 - なし.
 
 ### Changed
-- なし.
+- マジックナンバーを定数化した (`N/A.`).
+  - `pochi_predictor.py`: ウォームアップ反復回数 `_WARMUP_ITERATIONS = 10`.
+  - `epoch_runner.py`: ログ出力バッチ間隔 `_LOG_BATCH_INTERVAL = 100`.
+  - `pochi_dataset.py`: Resize スケール倍率 `_RESIZE_SCALE_FACTOR = 1.14`, ColorJitter パラメータ.
 
 ### Fixed
 - `InputShapeResolver._detect_from_onnx()` の無言例外無視を修正した ([#353](https://github.com/kurorosu/pochitrain/pull/353)).
   - `except Exception: pass` を `logger.debug()` に変更し, デバッグ時にエラー原因を追跡可能にした.
 
 ### Tests
-- `input_shape_resolver.py` と `int8_config.py` のテストを追加した (`N/A.`).
+- `input_shape_resolver.py` と `int8_config.py` のテストを追加した ([#354](https://github.com/kurorosu/pochitrain/pull/354)).
   - `InputShapeResolver`: CLI入力, 静的/動的 ONNX, onnx 未インストール, 破損ファイル, extract_static_shape のテストを追加した.
   - `INT8CalibrationConfigurer`: 明示パス指定, config 自動検出, calib_data 未指定, パス不在, val_transform 未設定, config 読み込みエラー, キャッシュファイルパスのテストを追加した.
 

--- a/pochitrain/pochi_dataset.py
+++ b/pochitrain/pochi_dataset.py
@@ -22,6 +22,12 @@ logger: logging.Logger = LoggerManager().get_logger(__name__)
 
 _PIL_ONLY_TRANSFORMS: tuple[type, ...] = (transforms.ToPILImage,)
 
+_RESIZE_SCALE_FACTOR = 1.14
+_COLOR_JITTER_BRIGHTNESS = 0.2
+_COLOR_JITTER_CONTRAST = 0.2
+_COLOR_JITTER_SATURATION = 0.2
+_COLOR_JITTER_HUE = 0.1
+
 
 def _check_pil_transform(t: Any, dataset_name: str) -> bool:
     """PIL専用transformが含まれているかチェックし, 警告をログ出力する.
@@ -414,7 +420,10 @@ def get_basic_transforms(
                 transforms.RandomResizedCrop(image_size),
                 transforms.RandomHorizontalFlip(p=0.5),
                 transforms.ColorJitter(
-                    brightness=0.2, contrast=0.2, saturation=0.2, hue=0.1
+                    brightness=_COLOR_JITTER_BRIGHTNESS,
+                    contrast=_COLOR_JITTER_CONTRAST,
+                    saturation=_COLOR_JITTER_SATURATION,
+                    hue=_COLOR_JITTER_HUE,
                 ),
                 transforms.ToTensor(),
                 transforms.Normalize(mean=mean, std=std),
@@ -423,7 +432,7 @@ def get_basic_transforms(
     else:
         return transforms.Compose(
             [
-                transforms.Resize(int(image_size * 1.14)),  # 256 for 224
+                transforms.Resize(int(image_size * _RESIZE_SCALE_FACTOR)),
                 transforms.CenterCrop(image_size),
                 transforms.ToTensor(),
                 transforms.Normalize(mean=mean, std=std),

--- a/pochitrain/pochi_predictor.py
+++ b/pochitrain/pochi_predictor.py
@@ -18,6 +18,8 @@ from .models.pochi_models import create_model
 from .utils.inference_utils import post_process_logits
 from .utils.model_loading import load_model_from_checkpoint
 
+_WARMUP_ITERATIONS = 10
+
 
 class PochiPredictor:
     """
@@ -165,7 +167,7 @@ class PochiPredictor:
             warmup_data = torch.tensor(warmup_data)
         warmup_data = warmup_data.unsqueeze(0).to(self.device)
         with torch.inference_mode():
-            for _ in range(10):
+            for _ in range(_WARMUP_ITERATIONS):
                 self.model(warmup_data)
             if use_cuda:
                 torch.cuda.synchronize()

--- a/pochitrain/training/epoch_runner.py
+++ b/pochitrain/training/epoch_runner.py
@@ -8,6 +8,8 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader
 
+_LOG_BATCH_INTERVAL = 100
+
 
 class EpochRunner:
     """1エポック分の訓練処理を実行する.
@@ -63,7 +65,7 @@ class EpochRunner:
             total += batch_size
             correct += predicted.eq(target).sum().item()
 
-            if batch_idx % 100 == 0:
+            if batch_idx % _LOG_BATCH_INTERVAL == 0:
                 self.logger.debug(
                     f"エポック {epoch}, バッチ {batch_idx}/{len(train_loader)}, "
                     f"損失: {loss.item():.4f}, 精度: {100.0 * correct / total:.2f}%"


### PR DESCRIPTION
## Summary

- 3ファイル4箇所のマジックナンバーをモジュールレベル定数に置き換えた.
- ロジック変更なし.

## Related Issue

Closes #349

## Changes

- `pochitrain/pochi_predictor.py`: `_WARMUP_ITERATIONS = 10`
- `pochitrain/training/epoch_runner.py`: `_LOG_BATCH_INTERVAL = 100`
- `pochitrain/pochi_dataset.py`: `_RESIZE_SCALE_FACTOR = 1.14`, `_COLOR_JITTER_BRIGHTNESS = 0.2`, `_COLOR_JITTER_CONTRAST = 0.2`, `_COLOR_JITTER_SATURATION = 0.2`, `_COLOR_JITTER_HUE = 0.1`

## Code Changes

無し.

## Test Plan

- `uv run pytest` で全692テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`