### PR TITLE
refactor: 型アノテーションの補完

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@
 - なし.
 
 ### Changed
-- マジックナンバーを定数化した (`N/A.`).
+- マジックナンバーを定数化した ([#355](https://github.com/kurorosu/pochitrain/pull/355)).
   - `pochi_predictor.py`: ウォームアップ反復回数 `_WARMUP_ITERATIONS = 10`.
   - `epoch_runner.py`: ログ出力バッチ間隔 `_LOG_BATCH_INTERVAL = 100`.
   - `pochi_dataset.py`: Resize スケール倍率 `_RESIZE_SCALE_FACTOR = 1.14`, ColorJitter パラメータ.
+- 型アノテーションを補完した (`N/A.`).
+  - `pochi_dataset.py`: `get_class_counts() -> dict[str, int]`.
+  - `directory_manager.py`: `save_dataset_paths(train_paths: list[str], ...)`.
+  - `param_group_builder.py`: `layer_params: dict[str, list[torch.nn.Parameter]]`.
 
 ### Fixed
 - `InputShapeResolver._detect_from_onnx()` の無言例外無視を修正した ([#353](https://github.com/kurorosu/pochitrain/pull/353)).

--- a/pochitrain/pochi_dataset.py
+++ b/pochitrain/pochi_dataset.py
@@ -134,7 +134,7 @@ class PochiImageDataset(Dataset):
         """クラス名のリストを取得."""
         return self.classes
 
-    def get_class_counts(self) -> dict:
+    def get_class_counts(self) -> dict[str, int]:
         """各クラスの画像数を取得."""
         label_counts = Counter(self.labels)
         return {

--- a/pochitrain/training/layer_wise_lr/param_group_builder.py
+++ b/pochitrain/training/layer_wise_lr/param_group_builder.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any
 
+import torch
 import torch.nn as nn
 
 from .interfaces import ILayerGrouper
@@ -43,7 +44,7 @@ class ParamGroupBuilder:
         """
         layer_rates = layer_wise_lr_config.get("layer_rates", {})
 
-        layer_params: dict[str, list] = {}
+        layer_params: dict[str, list[torch.nn.Parameter]] = {}
         for name, param in model.named_parameters():
             if param.requires_grad:
                 layer_group = self._layer_grouper.get_group(name)

--- a/pochitrain/utils/directory_manager.py
+++ b/pochitrain/utils/directory_manager.py
@@ -151,7 +151,7 @@ class PochiWorkspaceManager:
         return target_path
 
     def save_dataset_paths(
-        self, train_paths: list, val_paths: Optional[list] = None
+        self, train_paths: list[str], val_paths: Optional[list[str]] = None
     ) -> tuple[Path, Optional[Path]]:
         """
         訓練・検証データのパスリストを保存.


### PR DESCRIPTION
## Summary

- 3ファイル4箇所の不完全な型アノテーション (`dict`, `list`) を具体的な値型に補完した.
- ロジック変更なし.

## Related Issue

Closes #350

## Changes

| ファイル | 変更前 | 変更後 |
|---------|--------|--------|
| `pochi_dataset.py` | `-> dict` | `-> dict[str, int]` |
| `directory_manager.py` | `train_paths: list` | `train_paths: list[str]` |
| `directory_manager.py` | `val_paths: Optional[list]` | `val_paths: Optional[list[str]]` |
| `param_group_builder.py` | `dict[str, list]` | `dict[str, list[torch.nn.Parameter]]` |

## Code Changes

無し.

## Test Plan

- `uv run mypy pochitrain` でパスすることを確認.
- `uv run pytest` で全692テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`