### PR TITLE
chore: v1.8.2 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,28 @@
 - なし.
 
 ### Changed
+- なし.
+
+### Fixed
+- なし.
+
+### Removed
+- なし.
+
+## v1.8.2 (2026-03-21)
+
+### 概要
+- コード品質改善 (バグ修正, テスト追加, 定数化, 型補完) を含むパッチリリースです.
+
+### Added
+- なし.
+
+### Changed
 - マジックナンバーを定数化した ([#355](https://github.com/kurorosu/pochitrain/pull/355)).
   - `pochi_predictor.py`: ウォームアップ反復回数 `_WARMUP_ITERATIONS = 10`.
   - `epoch_runner.py`: ログ出力バッチ間隔 `_LOG_BATCH_INTERVAL = 100`.
   - `pochi_dataset.py`: Resize スケール倍率 `_RESIZE_SCALE_FACTOR = 1.14`, ColorJitter パラメータ.
-- 型アノテーションを補完した (`N/A.`).
+- 型アノテーションを補完した ([#356](https://github.com/kurorosu/pochitrain/pull/356)).
   - `pochi_dataset.py`: `get_class_counts() -> dict[str, int]`.
   - `directory_manager.py`: `save_dataset_paths(train_paths: list[str], ...)`.
   - `param_group_builder.py`: `layer_params: dict[str, list[torch.nn.Parameter]]`.
@@ -29,40 +46,6 @@
 
 ### Removed
 - なし.
-
-## v1.8.1 (2026-03-20)
-
-### 概要
-- CLI 構造のリファクタリング, 設計改善, バグ修正を含むパッチリリースです.
-
-### Added
-- なし.
-
-### Changed
-- `TrainingConfigurator` から層別学習率ロジックを分離した ([#337](https://github.com/kurorosu/pochitrain/pull/337)).
-  - `training/layer_wise_lr/` パッケージを新設した (`ILayerGrouper`, `ResNetLayerGrouper`, `ParamGroupBuilder`).
-  - Strategy パターンにより, 将来の非 ResNet モデル対応が拡張のみで可能になった.
-  - `ResNetLayerGrouper`, `ParamGroupBuilder` のユニットテストを追加した.
-- デッドコード・未使用公開メソッドを整理した ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
-  - `CheckpointStore.save_checkpoint()` 等 7メソッドを private 化した.
-  - テストを public API 経由に書き換えた.
-- `pochi.py` をサブコマンドごとに分割した ([#341](https://github.com/kurorosu/pochitrain/pull/341)).
-  - `cli/commands/` に `train.py`, `infer.py`, `optimize.py`, `convert.py` を分離した.
-  - `cli/cli_commons.py` に共有ユーティリティ (`setup_logging`, `create_signal_handler`) を抽出した.
-  - `pochi.py` を 956行から 181行に削減した.
-- `convert_command` のビジネスロジックをサービス層に分離した ([#342](https://github.com/kurorosu/pochitrain/pull/342)).
-  - `tensorrt/input_shape_resolver.py`: ONNX 動的シェイプ検出を CLI から分離した.
-  - `tensorrt/int8_config.py`: INT8 キャリブレーション設定の組み立てを CLI から分離した.
-  - ベンチマーク JSON 出力の重複を `export_benchmark_json()` に共通化した.
-
-### Fixed
-- `metrics_exporter.py` の colormap を層数に応じて自動選択するよう修正した (`N/A.`).
-  - 10層以下は `tab10`, 11層以上は `tab20` を使用する.
-
-### Removed
-- `PochiTrainer.setup_training_from_config()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
-- `find_best_model()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
-- `EarlyStopping.get_status()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
 
 ## Archived Changelogs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pochitrain
 
-[![Version](https://img.shields.io/badge/version-1.8.1-blue.svg)](https://github.com/kurorosu/pochitrain)
+[![Version](https://img.shields.io/badge/version-1.8.2-blue.svg)](https://github.com/kurorosu/pochitrain)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-yellow.svg)](https://www.python.org/)
 [![Jetson](https://img.shields.io/badge/Jetson-JetPack%206.2.1%20%28Python%203.10%29-76B900.svg)](https://developer.nvidia.com/embedded/jetpack)

--- a/changelogs/1.8.x.md
+++ b/changelogs/1.8.x.md
@@ -1,5 +1,39 @@
 # Changelog 1.8.x
 
+## v1.8.1 (2026-03-20)
+
+### 概要
+- CLI 構造のリファクタリング, 設計改善, バグ修正を含むパッチリリースです.
+
+### Added
+- なし.
+
+### Changed
+- `TrainingConfigurator` から層別学習率ロジックを分離した ([#337](https://github.com/kurorosu/pochitrain/pull/337)).
+  - `training/layer_wise_lr/` パッケージを新設した (`ILayerGrouper`, `ResNetLayerGrouper`, `ParamGroupBuilder`).
+  - Strategy パターンにより, 将来の非 ResNet モデル対応が拡張のみで可能になった.
+  - `ResNetLayerGrouper`, `ParamGroupBuilder` のユニットテストを追加した.
+- デッドコード・未使用公開メソッドを整理した ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
+  - `CheckpointStore.save_checkpoint()` 等 7メソッドを private 化した.
+  - テストを public API 経由に書き換えた.
+- `pochi.py` をサブコマンドごとに分割した ([#341](https://github.com/kurorosu/pochitrain/pull/341)).
+  - `cli/commands/` に `train.py`, `infer.py`, `optimize.py`, `convert.py` を分離した.
+  - `cli/cli_commons.py` に共有ユーティリティ (`setup_logging`, `create_signal_handler`) を抽出した.
+  - `pochi.py` を 956行から 181行に削減した.
+- `convert_command` のビジネスロジックをサービス層に分離した ([#342](https://github.com/kurorosu/pochitrain/pull/342)).
+  - `tensorrt/input_shape_resolver.py`: ONNX 動的シェイプ検出を CLI から分離した.
+  - `tensorrt/int8_config.py`: INT8 キャリブレーション設定の組み立てを CLI から分離した.
+  - ベンチマーク JSON 出力の重複を `export_benchmark_json()` に共通化した.
+
+### Fixed
+- `metrics_exporter.py` の colormap を層数に応じて自動選択するよう修正した ([#351](https://github.com/kurorosu/pochitrain/pull/351)).
+  - 10層以下は `tab10`, 11層以上は `tab20` を使用する.
+
+### Removed
+- `PochiTrainer.setup_training_from_config()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
+- `find_best_model()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
+- `EarlyStopping.get_status()` を削除した (呼び出し元なし) ([#339](https://github.com/kurorosu/pochitrain/pull/339)).
+
 ## v1.8.0 (2026-03-16)
 
 ### 概要

--- a/pochitrain/__init__.py
+++ b/pochitrain/__init__.py
@@ -20,7 +20,7 @@ from .pochi_dataset import (
 from .pochi_predictor import PochiPredictor
 from .pochi_trainer import PochiTrainer
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 __author__ = "Pochi Team"
 __email__ = "pochi@example.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochitrain"
-version = "1.8.1"
+version = "1.8.2"
 description = "Simple CNN training framework for image classification"
 readme = "README.md"
 # Jetson (JetPack 6.2.1 / Python 3.10) で pip install -e . するため >=3.10 を維持.

--- a/uv.lock
+++ b/uv.lock
@@ -1848,7 +1848,7 @@ wheels = [
 
 [[package]]
 name = "pochitrain"
-version = "1.8.1"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
## Summary

- バージョン番号を 1.8.1 → 1.8.2 に更新した.
- CHANGELOG.md の `[Unreleased]` を `v1.8.2 (2026-03-21)` に昇格した.
- v1.8.1 の N/A. PR 番号を埋めた.

## Related Issue

無し.

## Changes

- `pyproject.toml`: version を `1.8.2` に更新.
- `pochitrain/__init__.py`: `__version__` を `1.8.2` に更新.
- `README.md`: バージョンバッジを `1.8.2` に更新.
- `uv.lock`: `uv lock` で更新.
- `CHANGELOG.md`: v1.8.2 セクションを作成, N/A. を PR 番号に置換.

## Code Changes

無し.

## Test Plan

- `uv run pytest` で全692テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`