### PR TITLE
refactor: ベンチマーク JSON の env_name 解決パターンを共通化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - なし.
 
 ### Changed
-- なし.
+- ベンチマーク JSON 出力の env_name 解決パターンを共通化した (`N/A.`).
+  - `resolve_benchmark_env_name()` を `result_exporter.py` に追加し, 3箇所の CLI から呼び出すようにした.
 
 ### Fixed
 - なし.

--- a/pochitrain/cli/commands/infer.py
+++ b/pochitrain/cli/commands/infer.py
@@ -11,7 +11,7 @@ from pochitrain.cli.cli_commons import setup_logging
 from pochitrain.inference.benchmark import (
     build_pytorch_benchmark_result,
     export_benchmark_json,
-    resolve_env_name,
+    resolve_benchmark_env_name,
 )
 from pochitrain.inference.services import PyTorchInferenceService
 from pochitrain.inference.types.orchestration_types import (
@@ -156,16 +156,10 @@ def infer_command(args: argparse.Namespace) -> None:
         )
 
         if bool(getattr(args, "benchmark_json", False)):
-            configured_env_name = getattr(
-                args, "benchmark_env_name", None
-            ) or config.get("benchmark_env_name")
-            env_name = resolve_env_name(
+            env_name = resolve_benchmark_env_name(
                 use_gpu=use_gpu,
-                configured_env_name=(
-                    str(configured_env_name)
-                    if configured_env_name is not None
-                    else None
-                ),
+                cli_env_name=getattr(args, "benchmark_env_name", None),
+                config_env_name=config.get("benchmark_env_name"),
             )
             benchmark_result = build_pytorch_benchmark_result(
                 use_gpu=use_gpu,

--- a/pochitrain/cli/infer_onnx.py
+++ b/pochitrain/cli/infer_onnx.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from pochitrain.inference.benchmark import (
     build_onnx_benchmark_result,
     export_benchmark_json,
-    resolve_env_name,
+    resolve_benchmark_env_name,
 )
 from pochitrain.inference.services.onnx_inference_service import OnnxInferenceService
 from pochitrain.inference.types.orchestration_types import InferenceCliRequest
@@ -191,14 +191,10 @@ def main() -> None:
     )
 
     if args.benchmark_json:
-        configured_env_name = args.benchmark_env_name or config.get(
-            "benchmark_env_name"
-        )
-        env_name = resolve_env_name(
+        env_name = resolve_benchmark_env_name(
             use_gpu=actual_use_gpu,
-            configured_env_name=(
-                str(configured_env_name) if configured_env_name is not None else None
-            ),
+            cli_env_name=args.benchmark_env_name,
+            config_env_name=config.get("benchmark_env_name"),
         )
         benchmark_result = build_onnx_benchmark_result(
             use_gpu=actual_use_gpu,

--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from pochitrain.inference.benchmark import (
     build_trt_benchmark_result,
     export_benchmark_json,
-    resolve_env_name,
+    resolve_benchmark_env_name,
 )
 from pochitrain.inference.services.trt_inference_service import TensorRTInferenceService
 from pochitrain.inference.types.orchestration_types import InferenceCliRequest
@@ -191,14 +191,10 @@ def main() -> None:
     )
 
     if args.benchmark_json:
-        configured_env_name = args.benchmark_env_name or config.get(
-            "benchmark_env_name"
-        )
-        env_name = resolve_env_name(
+        env_name = resolve_benchmark_env_name(
             use_gpu=True,
-            configured_env_name=(
-                str(configured_env_name) if configured_env_name is not None else None
-            ),
+            cli_env_name=args.benchmark_env_name,
+            config_env_name=config.get("benchmark_env_name"),
         )
         benchmark_result = build_trt_benchmark_result(
             engine_path=engine_path,

--- a/pochitrain/inference/benchmark/__init__.py
+++ b/pochitrain/inference/benchmark/__init__.py
@@ -6,10 +6,15 @@ from .result_builder import (
     build_pytorch_benchmark_result,
     build_trt_benchmark_result,
 )
-from .result_exporter import export_benchmark_json, write_benchmark_result_json
+from .result_exporter import (
+    export_benchmark_json,
+    resolve_benchmark_env_name,
+    write_benchmark_result_json,
+)
 
 __all__ = [
     "resolve_env_name",
+    "resolve_benchmark_env_name",
     "build_onnx_benchmark_result",
     "build_pytorch_benchmark_result",
     "build_trt_benchmark_result",

--- a/pochitrain/inference/benchmark/result_exporter.py
+++ b/pochitrain/inference/benchmark/result_exporter.py
@@ -2,7 +2,9 @@
 
 import logging
 from pathlib import Path
+from typing import Optional
 
+from pochitrain.inference.benchmark.env_name import resolve_env_name
 from pochitrain.inference.types.benchmark_types import (
     BENCHMARK_RESULT_FILENAME,
     BenchmarkResult,
@@ -27,6 +29,29 @@ def write_benchmark_result_json(
     """
     output_path = output_dir / filename
     return write_json_file(output_path, benchmark_result.to_dict())
+
+
+def resolve_benchmark_env_name(
+    *,
+    use_gpu: bool,
+    cli_env_name: Optional[str],
+    config_env_name: Optional[str],
+) -> str:
+    """CLI 引数と config から環境名を組み立てて resolve_env_name() に委譲する.
+
+    Args:
+        use_gpu: GPU を利用しているかどうか.
+        cli_env_name: CLI の --benchmark-env-name で指定された値.
+        config_env_name: config の benchmark_env_name の値.
+
+    Returns:
+        環境識別文字列.
+    """
+    configured = cli_env_name or config_env_name
+    return resolve_env_name(
+        use_gpu=use_gpu,
+        configured_env_name=str(configured) if configured is not None else None,
+    )
 
 
 def export_benchmark_json(


### PR DESCRIPTION
## Summary

- 3箇所の CLI で重複していた env_name 解決パターン (約15行 x 3) を `resolve_benchmark_env_name()` に共通化した.
- ロジック変更なし.

## Related Issue

Closes #345

## Changes

- `pochitrain/inference/benchmark/result_exporter.py` に `resolve_benchmark_env_name()` を追加した.
  - CLI 引数 > config 値 > 自動検出の優先順位で環境名を解決する.
- `pochitrain/inference/benchmark/__init__.py` にエクスポートを追加した.
- CLI 3箇所を簡素化した.
  - `cli/commands/infer.py`: `resolve_env_name` + `configured_env_name` 解決 → `resolve_benchmark_env_name()` 呼び出しのみ.
  - `cli/infer_onnx.py`: 同上.
  - `cli/infer_trt.py`: 同上.

## Code Changes

```python
# Before (3箇所で重複)
configured_env_name = args.benchmark_env_name or config.get("benchmark_env_name")
env_name = resolve_env_name(
    use_gpu=use_gpu,
    configured_env_name=(
        str(configured_env_name) if configured_env_name is not None else None
    ),
)

# After (1行)
env_name = resolve_benchmark_env_name(
    use_gpu=use_gpu,
    cli_env_name=args.benchmark_env_name,
    config_env_name=config.get("benchmark_env_name"),
)
```

## Test Plan

- `uv run pytest` で全692テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`