### PR TITLE
refactor: infer_onnx.py と infer_trt.py の共通処理を抽出

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@
 - なし.
 
 ### Changed
-- ベンチマーク JSON 出力の env_name 解決パターンを共通化した (`N/A.`).
+- ベンチマーク JSON 出力の env_name 解決パターンを共通化した ([#358](https://github.com/kurorosu/pochitrain/pull/358)).
   - `resolve_benchmark_env_name()` を `result_exporter.py` に追加し, 3箇所の CLI から呼び出すようにした.
+- `infer_onnx.py` と `infer_trt.py` の共通処理を抽出した (`N/A.`).
+  - `cli_commons.py` に `run_inference_pipeline()` を追加し, パス解決からエクスポートまでの共通フローを一元化した.
+  - ログ初期化を `setup_logging()` に統一した.
+  - `infer_onnx.py`: 222行 → 170行, `infer_trt.py`: 222行 → 177行.
 
 ### Fixed
 - なし.

--- a/pochitrain/cli/cli_commons.py
+++ b/pochitrain/cli/cli_commons.py
@@ -3,10 +3,15 @@
 全サブコマンドで共有されるロギング設定やシグナルハンドラーを提供する.
 """
 
+import argparse
 import logging
+from dataclasses import dataclass
+from pathlib import Path
 from types import FrameType
 from typing import Any, Optional
 
+from pochitrain.inference.benchmark import export_benchmark_json
+from pochitrain.inference.types.orchestration_types import InferenceCliRequest
 from pochitrain.logging import LoggerManager
 from pochitrain.logging.logger_manager import LogLevel
 
@@ -53,3 +58,116 @@ def setup_logging(
     for existing_name in logger_manager.get_available_loggers():
         logger_manager.set_logger_level(existing_name, level)
     return logger_manager.get_logger(logger_name, level=level)
+
+
+@dataclass
+class InferencePipelineResult:
+    """run_inference_pipeline() の戻り値."""
+
+    run_result: Any
+    runtime_request: Any
+    runtime_options: Any
+    input_size: Optional[tuple[int, int, int]]
+    output_dir: Path
+    pipeline: str
+
+
+def run_inference_pipeline(
+    *,
+    service: Any,
+    logger: logging.Logger,
+    model_path: Path,
+    config: dict[str, Any],
+    inference: Any,
+    args: argparse.Namespace,
+    use_gpu: bool,
+    val_transform: Any,
+    use_cuda_timing: bool,
+    input_size: Optional[tuple[int, int, int]],
+    results_filename: str,
+    summary_filename: str,
+    extra_info: Optional[dict[str, Any]] = None,
+) -> InferencePipelineResult:
+    """推論 CLI の共通パイプラインを実行する.
+
+    パス解決, データローダー作成, 推論実行, 結果エクスポートを一括処理する.
+    ONNX / TensorRT の両 CLI で共有される.
+
+    Args:
+        service: IInferenceService 実装.
+        logger: ロガー.
+        model_path: モデルファイルパス.
+        config: 設定辞書.
+        inference: ランタイム固有の推論インスタンス.
+        args: CLI 引数 (--data, --output, --pipeline を参照).
+        use_gpu: GPU 推論かどうか.
+        val_transform: 検証用 transform.
+        use_cuda_timing: CUDA タイミング計測を使用するか.
+        input_size: 入力サイズ (C, H, W). None も可.
+        results_filename: 推論結果 CSV ファイル名.
+        summary_filename: サマリーテキストファイル名.
+        extra_info: サマリーに追加する情報.
+
+    Returns:
+        InferencePipelineResult.
+    """
+    cli_request = InferenceCliRequest(
+        model_path=model_path,
+        data_path=Path(args.data) if args.data else None,
+        output_dir=Path(args.output) if args.output else None,
+        requested_pipeline=args.pipeline,
+    )
+    resolved_paths = service.resolve_paths(cli_request, config)
+    data_path = resolved_paths.data_path
+    output_dir = resolved_paths.output_dir
+
+    pipeline = service.resolve_pipeline(args.pipeline, use_gpu=use_gpu)
+    runtime_options = service.resolve_runtime_options(
+        config=config, pipeline=pipeline, use_gpu=use_gpu
+    )
+    data_loader, dataset, pipeline, norm_mean, norm_std = service.create_dataloader(
+        config=config,
+        data_path=data_path,
+        val_transform=val_transform,
+        pipeline=pipeline,
+        runtime_options=runtime_options,
+    )
+
+    logger.info("推論を開始します...")
+    runtime_adapter = service.create_runtime_adapter(inference)
+    runtime_request = service.build_runtime_execution_request(
+        data_loader=data_loader,
+        runtime_adapter=runtime_adapter,
+        use_gpu_pipeline=runtime_options.use_gpu_pipeline,
+        norm_mean=norm_mean,
+        norm_std=norm_std,
+        use_cuda_timing=use_cuda_timing,
+        gpu_non_blocking=bool(config.get("gpu_non_blocking", True)),
+    )
+    run_result = service.run(runtime_request)
+    logger.info("推論完了")
+
+    service.aggregate_and_export(
+        workspace_dir=output_dir,
+        model_path=model_path,
+        data_path=data_path,
+        dataset=dataset,
+        run_result=run_result,
+        input_size=input_size,
+        model_info=None,
+        cm_config=config.get("confusion_matrix_config", None),
+        results_filename=results_filename,
+        summary_filename=summary_filename,
+        extra_info=extra_info,
+    )
+
+    logger.info(f"ワークスペース: {output_dir.name}にサマリーファイルを出力しました")
+
+    return InferencePipelineResult(
+        run_result=run_result,
+        runtime_request=runtime_request,
+        runtime_options=runtime_options,
+        input_size=input_size,
+        output_dir=output_dir,
+        pipeline=pipeline,
+    )

--- a/pochitrain/cli/infer_onnx.py
+++ b/pochitrain/cli/infer_onnx.py
@@ -8,27 +8,61 @@
 """
 
 import argparse
-import logging
 import sys
 from pathlib import Path
 
+from pochitrain.cli.cli_commons import (
+    InferencePipelineResult,
+    run_inference_pipeline,
+    setup_logging,
+)
 from pochitrain.inference.benchmark import (
     build_onnx_benchmark_result,
     export_benchmark_json,
     resolve_benchmark_env_name,
 )
 from pochitrain.inference.services.onnx_inference_service import OnnxInferenceService
-from pochitrain.inference.types.orchestration_types import InferenceCliRequest
-from pochitrain.logging import LoggerManager
-from pochitrain.logging.logger_manager import LogLevel
 from pochitrain.utils import (
     load_config_auto,
     validate_model_path,
 )
 
-logger: logging.Logger = LoggerManager().get_logger(__name__)
-
 PIPELINE_CHOICES = ("auto", "current", "fast", "gpu")
+
+
+def _export_benchmark_if_needed(
+    args: argparse.Namespace,
+    config: dict,
+    result: InferencePipelineResult,
+    model_path: Path,
+    use_gpu: bool,
+    logger: object,
+) -> None:
+    """ONNX ベンチマーク JSON を条件付きでエクスポートする."""
+    if not args.benchmark_json:
+        return
+    env_name = resolve_benchmark_env_name(
+        use_gpu=use_gpu,
+        cli_env_name=args.benchmark_env_name,
+        config_env_name=config.get("benchmark_env_name"),
+    )
+    benchmark_result = build_onnx_benchmark_result(
+        use_gpu=use_gpu,
+        pipeline=result.pipeline,
+        model_name=str(config.get("model_name", model_path.stem)),
+        batch_size=result.runtime_options.batch_size,
+        gpu_non_blocking=result.runtime_request.execution_request.gpu_non_blocking,
+        pin_memory=result.runtime_options.pin_memory,
+        input_size=result.input_size,
+        avg_time_per_image=result.run_result.avg_time_per_image,
+        avg_total_time_per_image=result.run_result.avg_total_time_per_image,
+        num_samples=result.run_result.num_samples,
+        total_samples=result.run_result.total_samples,
+        warmup_samples=result.run_result.warmup_samples,
+        accuracy=result.run_result.accuracy_percent,
+        env_name=env_name,
+    )
+    export_benchmark_json(result.output_dir, benchmark_result, logger)  # type: ignore[arg-type]
 
 
 def main() -> None:
@@ -54,11 +88,7 @@ def main() -> None:
     )
 
     parser.add_argument("model_path", help="ONNXモデルファイルパス")
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="デバッグログを有効化",
-    )
+    parser.add_argument("--debug", action="store_true", help="デバッグログを有効化")
     parser.add_argument(
         "--data",
         help="推論データディレクトリ（省略時はconfigのval_data_rootを使用）",
@@ -86,12 +116,7 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    orchestration_service = OnnxInferenceService()
-
-    manager = LoggerManager()
-    level = LogLevel.DEBUG if args.debug else LogLevel.INFO
-    manager.set_default_level(level)
-    manager.set_logger_level(__name__, level)
+    logger = setup_logging(debug=args.debug)
 
     model_path = Path(args.model_path)
     try:
@@ -106,115 +131,46 @@ def main() -> None:
         logger.error(str(e))
         sys.exit(1)
 
-    cli_request = InferenceCliRequest(
-        model_path=model_path,
-        data_path=Path(args.data) if args.data else None,
-        output_dir=Path(args.output) if args.output else None,
-        requested_pipeline=args.pipeline,
-    )
-    try:
-        resolved_paths = orchestration_service.resolve_paths(cli_request, config)
-    except ValueError as e:
-        logger.error(str(e))
-        sys.exit(1)
-
-    data_path = resolved_paths.data_path
-    output_dir = resolved_paths.output_dir
-
+    # ONNX 固有: セッション作成と実 GPU 利用可否の判定
+    service = OnnxInferenceService()
     requested_use_gpu = config.get("device", "cpu") == "cuda"
-    val_transform = config["val_transform"]
-
-    logger.debug(f"モデル: {model_path}")
-    logger.debug(f"データ: {data_path}")
-    logger.debug(f"出力先: {output_dir}")
-    logger.debug("ONNXセッションを作成中...")
-    inference, actual_use_gpu = orchestration_service.create_onnx_session(
-        model_path=model_path,
-        use_gpu=requested_use_gpu,
+    inference, actual_use_gpu = service.create_onnx_session(
+        model_path=model_path, use_gpu=requested_use_gpu
     )
 
-    pipeline = orchestration_service.resolve_pipeline(args.pipeline, actual_use_gpu)
-    runtime_options = orchestration_service.resolve_runtime_options(
-        config=config,
-        pipeline=pipeline,
-        use_gpu=actual_use_gpu,
-    )
-    data_loader, dataset, pipeline, norm_mean, norm_std = (
-        orchestration_service.create_dataloader(
-            config=config,
-            data_path=data_path,
-            val_transform=val_transform,
-            pipeline=pipeline,
-            runtime_options=runtime_options,
-        )
-    )
-
-    logger.debug(f"バッチサイズ: {runtime_options.batch_size}")
-    logger.debug(f"ワーカー数: {runtime_options.num_workers}")
-    logger.debug(f"GPU使用: {actual_use_gpu}")
-    logger.debug(f"パイプライン: {pipeline}")
-
+    # ONNX 固有: 入力サイズ解決
     input_size = None
     try:
         shape = inference.session.get_inputs()[0].shape
-        input_size = orchestration_service.resolve_input_size(shape)
+        input_size = service.resolve_input_size(shape)
     except Exception:
         pass
 
-    logger.info("推論を開始します...")
-    runtime_adapter = orchestration_service.create_runtime_adapter(inference)
-    runtime_request = orchestration_service.build_runtime_execution_request(
-        data_loader=data_loader,
-        runtime_adapter=runtime_adapter,
-        use_gpu_pipeline=runtime_options.use_gpu_pipeline,
-        norm_mean=norm_mean,
-        norm_std=norm_std,
-        use_cuda_timing=actual_use_gpu,
-        gpu_non_blocking=bool(config.get("gpu_non_blocking", True)),
-    )
-    run_result = orchestration_service.run(runtime_request)
-    logger.info("推論完了")
-
     providers = inference.get_providers()
-    orchestration_service.aggregate_and_export(
-        workspace_dir=output_dir,
-        model_path=model_path,
-        data_path=data_path,
-        dataset=dataset,
-        run_result=run_result,
-        input_size=input_size,
-        model_info=None,
-        cm_config=config.get("confusion_matrix_config", None),
-        results_filename="onnx_inference_results.csv",
-        summary_filename="onnx_inference_summary.txt",
-        extra_info={"プロバイダー": providers, "パイプライン": pipeline},
-    )
 
-    if args.benchmark_json:
-        env_name = resolve_benchmark_env_name(
+    try:
+        result = run_inference_pipeline(
+            service=service,
+            logger=logger,
+            model_path=model_path,
+            config=config,
+            inference=inference,
+            args=args,
             use_gpu=actual_use_gpu,
-            cli_env_name=args.benchmark_env_name,
-            config_env_name=config.get("benchmark_env_name"),
-        )
-        benchmark_result = build_onnx_benchmark_result(
-            use_gpu=actual_use_gpu,
-            pipeline=pipeline,
-            model_name=str(config.get("model_name", model_path.stem)),
-            batch_size=runtime_options.batch_size,
-            gpu_non_blocking=runtime_request.execution_request.gpu_non_blocking,
-            pin_memory=runtime_options.pin_memory,
+            val_transform=config["val_transform"],
+            use_cuda_timing=actual_use_gpu,
             input_size=input_size,
-            avg_time_per_image=run_result.avg_time_per_image,
-            avg_total_time_per_image=run_result.avg_total_time_per_image,
-            num_samples=run_result.num_samples,
-            total_samples=run_result.total_samples,
-            warmup_samples=run_result.warmup_samples,
-            accuracy=run_result.accuracy_percent,
-            env_name=env_name,
+            results_filename="onnx_inference_results.csv",
+            summary_filename="onnx_inference_summary.txt",
+            extra_info={"プロバイダー": providers, "パイプライン": args.pipeline},
         )
-        export_benchmark_json(output_dir, benchmark_result, logger)
+    except (ValueError, Exception) as e:
+        logger.error(str(e))
+        sys.exit(1)
 
-    logger.info(f"ワークスペース: {output_dir.name}にサマリーファイルを出力しました")
+    _export_benchmark_if_needed(
+        args, config, result, model_path, actual_use_gpu, logger
+    )
 
 
 if __name__ == "__main__":

--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -8,27 +8,60 @@
 """
 
 import argparse
-import logging
 import sys
 from pathlib import Path
 
+from pochitrain.cli.cli_commons import (
+    InferencePipelineResult,
+    run_inference_pipeline,
+    setup_logging,
+)
 from pochitrain.inference.benchmark import (
     build_trt_benchmark_result,
     export_benchmark_json,
     resolve_benchmark_env_name,
 )
 from pochitrain.inference.services.trt_inference_service import TensorRTInferenceService
-from pochitrain.inference.types.orchestration_types import InferenceCliRequest
-from pochitrain.logging import LoggerManager
-from pochitrain.logging.logger_manager import LogLevel
 from pochitrain.utils import (
     load_config_auto,
     validate_model_path,
 )
 
-logger: logging.Logger = LoggerManager().get_logger(__name__)
-
 PIPELINE_CHOICES = ("auto", "current", "fast", "gpu")
+
+
+def _export_benchmark_if_needed(
+    args: argparse.Namespace,
+    config: dict,
+    result: InferencePipelineResult,
+    engine_path: Path,
+    logger: object,
+) -> None:
+    """条件付きで TensorRT ベンチマーク JSON をエクスポートする."""
+    if not args.benchmark_json:
+        return
+    env_name = resolve_benchmark_env_name(
+        use_gpu=True,
+        cli_env_name=args.benchmark_env_name,
+        config_env_name=config.get("benchmark_env_name"),
+    )
+    benchmark_result = build_trt_benchmark_result(
+        engine_path=engine_path,
+        pipeline=result.pipeline,
+        model_name=str(config.get("model_name", engine_path.stem)),
+        batch_size=result.runtime_options.batch_size,
+        gpu_non_blocking=result.runtime_request.execution_request.gpu_non_blocking,
+        pin_memory=result.runtime_options.pin_memory,
+        input_size=result.input_size,
+        avg_time_per_image=result.run_result.avg_time_per_image,
+        avg_total_time_per_image=result.run_result.avg_total_time_per_image,
+        num_samples=result.run_result.num_samples,
+        total_samples=result.run_result.total_samples,
+        warmup_samples=result.run_result.warmup_samples,
+        accuracy=result.run_result.accuracy_percent,
+        env_name=env_name,
+    )
+    export_benchmark_json(result.output_dir, benchmark_result, logger)  # type: ignore[arg-type]
 
 
 def main() -> None:
@@ -58,11 +91,7 @@ def main() -> None:
     )
 
     parser.add_argument("engine_path", help="TensorRTエンジンファイルパス (.engine)")
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="デバッグログを有効化",
-    )
+    parser.add_argument("--debug", action="store_true", help="デバッグログを有効化")
     parser.add_argument(
         "--data",
         help="推論データディレクトリ（省略時はconfigのval_data_rootを使用）",
@@ -90,12 +119,7 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    orchestration_service = TensorRTInferenceService()
-
-    manager = LoggerManager()
-    level = LogLevel.DEBUG if args.debug else LogLevel.INFO
-    manager.set_default_level(level)
-    manager.set_logger_level(__name__, level)
+    logger = setup_logging(debug=args.debug)
 
     engine_path = Path(args.engine_path)
     try:
@@ -104,8 +128,10 @@ def main() -> None:
         logger.error(str(e))
         sys.exit(1)
 
+    # TRT 固有: TensorRT 推論インスタンス作成 (config 読み込み前に必要)
+    service = TensorRTInferenceService()
     try:
-        inference = orchestration_service.create_trt_inference(engine_path)
+        inference = service.create_trt_inference(engine_path)
     except ImportError:
         logger.error(
             "TensorRTがインストールされていません. "
@@ -119,102 +145,37 @@ def main() -> None:
         logger.error(str(e))
         sys.exit(1)
 
-    cli_request = InferenceCliRequest(
-        model_path=engine_path,
-        data_path=Path(args.data) if args.data else None,
-        output_dir=Path(args.output) if args.output else None,
-        requested_pipeline=args.pipeline,
-    )
-    try:
-        resolved_paths = orchestration_service.resolve_paths(cli_request, config)
-    except ValueError as e:
-        logger.error(str(e))
-        sys.exit(1)
-
-    data_path = resolved_paths.data_path
-    output_dir = resolved_paths.output_dir
-
-    val_transform = orchestration_service.resolve_val_transform(config, inference)
-
-    pipeline = orchestration_service.resolve_pipeline(args.pipeline, use_gpu=True)
-    runtime_options = orchestration_service.resolve_runtime_options(config, pipeline)
-    data_loader, dataset, pipeline, norm_mean, norm_std = (
-        orchestration_service.create_dataloader(
-            config=config,
-            data_path=data_path,
-            val_transform=val_transform,
-            pipeline=pipeline,
-            runtime_options=runtime_options,
-        )
-    )
-
-    logger.debug(f"エンジン: {engine_path}")
-    logger.debug(f"データ: {data_path}")
-    logger.debug(f"ワーカー数: {runtime_options.num_workers}")
-    logger.debug(f"パイプライン: {pipeline}")
-    logger.debug(f"出力先: {output_dir}")
-
-    logger.info("推論を開始します...")
+    # TRT 固有: val_transform と入力サイズの解決
+    val_transform = service.resolve_val_transform(config, inference)
 
     input_size = None
     try:
         shape = inference.input_shape
-        input_size = orchestration_service.resolve_input_size(shape)
+        input_size = service.resolve_input_size(shape)
     except Exception:
         pass
 
-    runtime_adapter = orchestration_service.create_runtime_adapter(inference)
-    runtime_request = orchestration_service.build_runtime_execution_request(
-        data_loader=data_loader,
-        runtime_adapter=runtime_adapter,
-        use_gpu_pipeline=runtime_options.use_gpu_pipeline,
-        norm_mean=norm_mean,
-        norm_std=norm_std,
-        use_cuda_timing=True,
-        gpu_non_blocking=bool(config.get("gpu_non_blocking", True)),
-    )
-    run_result = orchestration_service.run(runtime_request)
-    logger.info("推論完了")
-
-    orchestration_service.aggregate_and_export(
-        workspace_dir=output_dir,
-        model_path=engine_path,
-        data_path=data_path,
-        dataset=dataset,
-        run_result=run_result,
-        input_size=input_size,
-        model_info=None,
-        cm_config=config.get("confusion_matrix_config", None),
-        results_filename="tensorrt_inference_results.csv",
-        summary_filename="tensorrt_inference_summary.txt",
-        extra_info={"パイプライン": pipeline},
-    )
-
-    if args.benchmark_json:
-        env_name = resolve_benchmark_env_name(
+    try:
+        result = run_inference_pipeline(
+            service=service,
+            logger=logger,
+            model_path=engine_path,
+            config=config,
+            inference=inference,
+            args=args,
             use_gpu=True,
-            cli_env_name=args.benchmark_env_name,
-            config_env_name=config.get("benchmark_env_name"),
-        )
-        benchmark_result = build_trt_benchmark_result(
-            engine_path=engine_path,
-            pipeline=pipeline,
-            model_name=str(config.get("model_name", engine_path.stem)),
-            batch_size=runtime_options.batch_size,
-            gpu_non_blocking=runtime_request.execution_request.gpu_non_blocking,
-            pin_memory=runtime_options.pin_memory,
+            val_transform=val_transform,
+            use_cuda_timing=True,
             input_size=input_size,
-            avg_time_per_image=run_result.avg_time_per_image,
-            avg_total_time_per_image=run_result.avg_total_time_per_image,
-            num_samples=run_result.num_samples,
-            total_samples=run_result.total_samples,
-            warmup_samples=run_result.warmup_samples,
-            accuracy=run_result.accuracy_percent,
-            env_name=env_name,
+            results_filename="tensorrt_inference_results.csv",
+            summary_filename="tensorrt_inference_summary.txt",
+            extra_info={"パイプライン": args.pipeline},
         )
-        export_benchmark_json(output_dir, benchmark_result, logger)
+    except (ValueError, Exception) as e:
+        logger.error(str(e))
+        sys.exit(1)
 
-    logger.info(f"ワークスペース: {output_dir.name}にサマリーファイルを出力しました")
+    _export_benchmark_if_needed(args, config, result, engine_path, logger)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- 約85%同一だった `infer_onnx.py` と `infer_trt.py` の共通フローを `cli_commons.run_inference_pipeline()` に抽出した.
- ログ初期化を `setup_logging()` に統一した.
- ロジック変更なし.

## Related Issue

Closes #343

## Changes

- `cli/cli_commons.py` に `InferencePipelineResult` dataclass と `run_inference_pipeline()` 関数を追加した.
  - パス解決, パイプライン解決, データローダー作成, 推論実行, 結果エクスポートの共通フローを一元化.
- `cli/infer_onnx.py` を 222行 → 170行に削減した.
  - ランタイム固有部分 (セッション作成, GPU 判定, providers 取得) のみ残した.
  - `LoggerManager` 手動設定を `setup_logging()` に置き換えた.
- `cli/infer_trt.py` を 222行 → 177行に削減した.
  - ランタイム固有部分 (TRT 推論作成, ImportError 処理, val_transform 解決) のみ残した.
  - `LoggerManager` 手動設定を `setup_logging()` に置き換えた.

## Code Changes

```python
# Before: 両ファイルで ~50行重複
cli_request = InferenceCliRequest(...)
resolved_paths = service.resolve_paths(cli_request, config)
pipeline = service.resolve_pipeline(...)
runtime_options = service.resolve_runtime_options(...)
data_loader, dataset, pipeline, norm_mean, norm_std = service.create_dataloader(...)
runtime_adapter = service.create_runtime_adapter(inference)
runtime_request = service.build_runtime_execution_request(...)
run_result = service.run(runtime_request)
service.aggregate_and_export(...)

# After: 1行で呼び出し
result = run_inference_pipeline(
    service=service, logger=logger, model_path=model_path,
    config=config, inference=inference, args=args,
    use_gpu=actual_use_gpu, val_transform=val_transform,
    use_cuda_timing=actual_use_gpu, input_size=input_size,
    results_filename="onnx_inference_results.csv",
    summary_filename="onnx_inference_summary.txt",
    extra_info={"プロバイダー": providers, "パイプライン": args.pipeline},
)
```

## Test Plan

- `uv run pytest tests/unit/test_cli/test_infer_onnx.py tests/unit/test_cli/test_infer_trt.py -v` で推論 CLI テスト全パスを確認.
- `uv run pytest` で全692テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`