### PR TITLE
refactor: ベンチマーク結果構築関数を統合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@
 ### Changed
 - ベンチマーク JSON 出力の env_name 解決パターンを共通化した ([#358](https://github.com/kurorosu/pochitrain/pull/358)).
   - `resolve_benchmark_env_name()` を `result_exporter.py` に追加し, 3箇所の CLI から呼び出すようにした.
-- `infer_onnx.py` と `infer_trt.py` の共通処理を抽出した (`N/A.`).
+- `infer_onnx.py` と `infer_trt.py` の共通処理を抽出した ([#359](https://github.com/kurorosu/pochitrain/pull/359)).
   - `cli_commons.py` に `run_inference_pipeline()` を追加し, パス解決からエクスポートまでの共通フローを一元化した.
   - ログ初期化を `setup_logging()` に統一した.
-  - `infer_onnx.py`: 222行 → 170行, `infer_trt.py`: 222行 → 177行.
+  - `infer_onnx.py`: 222行 → 172行, `infer_trt.py`: 222行 → 179行.
+- `result_builder.py` のベンチマーク結果構築関数を統合した (`N/A.`).
+  - `build_onnx/trt/pytorch_benchmark_result()` 3関数を `build_benchmark_result()` 1関数に統合した.
+  - `_resolve_trt_precision()` を `resolve_trt_precision()` としてパブリック化した.
 
 ### Fixed
 - なし.

--- a/pochitrain/cli/commands/infer.py
+++ b/pochitrain/cli/commands/infer.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from pochitrain import PochiConfig
 from pochitrain.cli.cli_commons import setup_logging
 from pochitrain.inference.benchmark import (
-    build_pytorch_benchmark_result,
+    build_benchmark_result,
     export_benchmark_json,
     resolve_benchmark_env_name,
 )
@@ -161,8 +161,10 @@ def infer_command(args: argparse.Namespace) -> None:
                 cli_env_name=getattr(args, "benchmark_env_name", None),
                 config_env_name=config.get("benchmark_env_name"),
             )
-            benchmark_result = build_pytorch_benchmark_result(
-                use_gpu=use_gpu,
+            benchmark_result = build_benchmark_result(
+                runtime="pytorch",
+                precision="fp32",
+                device="cuda" if use_gpu else "cpu",
                 pipeline=pipeline,
                 model_name=str(config.get("model_name", model_path.stem)),
                 batch_size=runtime_options.batch_size,

--- a/pochitrain/cli/infer_onnx.py
+++ b/pochitrain/cli/infer_onnx.py
@@ -17,7 +17,7 @@ from pochitrain.cli.cli_commons import (
     setup_logging,
 )
 from pochitrain.inference.benchmark import (
-    build_onnx_benchmark_result,
+    build_benchmark_result,
     export_benchmark_json,
     resolve_benchmark_env_name,
 )
@@ -46,8 +46,10 @@ def _export_benchmark_if_needed(
         cli_env_name=args.benchmark_env_name,
         config_env_name=config.get("benchmark_env_name"),
     )
-    benchmark_result = build_onnx_benchmark_result(
-        use_gpu=use_gpu,
+    benchmark_result = build_benchmark_result(
+        runtime="onnx",
+        precision="fp32",
+        device="cuda" if use_gpu else "cpu",
         pipeline=result.pipeline,
         model_name=str(config.get("model_name", model_path.stem)),
         batch_size=result.runtime_options.batch_size,

--- a/pochitrain/cli/infer_trt.py
+++ b/pochitrain/cli/infer_trt.py
@@ -17,9 +17,10 @@ from pochitrain.cli.cli_commons import (
     setup_logging,
 )
 from pochitrain.inference.benchmark import (
-    build_trt_benchmark_result,
+    build_benchmark_result,
     export_benchmark_json,
     resolve_benchmark_env_name,
+    resolve_trt_precision,
 )
 from pochitrain.inference.services.trt_inference_service import TensorRTInferenceService
 from pochitrain.utils import (
@@ -45,8 +46,10 @@ def _export_benchmark_if_needed(
         cli_env_name=args.benchmark_env_name,
         config_env_name=config.get("benchmark_env_name"),
     )
-    benchmark_result = build_trt_benchmark_result(
-        engine_path=engine_path,
+    benchmark_result = build_benchmark_result(
+        runtime="tensorrt",
+        precision=resolve_trt_precision(engine_path),
+        device="cuda",
         pipeline=result.pipeline,
         model_name=str(config.get("model_name", engine_path.stem)),
         batch_size=result.runtime_options.batch_size,

--- a/pochitrain/inference/benchmark/__init__.py
+++ b/pochitrain/inference/benchmark/__init__.py
@@ -2,9 +2,8 @@
 
 from .env_name import resolve_env_name
 from .result_builder import (
-    build_onnx_benchmark_result,
-    build_pytorch_benchmark_result,
-    build_trt_benchmark_result,
+    build_benchmark_result,
+    resolve_trt_precision,
 )
 from .result_exporter import (
     export_benchmark_json,
@@ -15,9 +14,8 @@ from .result_exporter import (
 __all__ = [
     "resolve_env_name",
     "resolve_benchmark_env_name",
-    "build_onnx_benchmark_result",
-    "build_pytorch_benchmark_result",
-    "build_trt_benchmark_result",
+    "build_benchmark_result",
+    "resolve_trt_precision",
     "write_benchmark_result_json",
     "export_benchmark_json",
 ]

--- a/pochitrain/inference/benchmark/result_builder.py
+++ b/pochitrain/inference/benchmark/result_builder.py
@@ -31,7 +31,26 @@ def _throughput_from_ms(avg_ms: float) -> float:
     return 1000.0 / avg_ms if avg_ms > 0 else 0.0
 
 
-def _build_benchmark_result(
+def resolve_trt_precision(engine_path: Path) -> Optional[str]:
+    """エンジンファイル名から推定できる精度を返す.
+
+    Args:
+        engine_path: TensorRTエンジンファイル.
+
+    Returns:
+        推定精度文字列. 推定不能な場合はNone.
+    """
+    lowered = engine_path.name.lower()
+    if "int8" in lowered:
+        return "int8"
+    if "fp16" in lowered:
+        return "fp16"
+    if "fp32" in lowered:
+        return "fp32"
+    return None
+
+
+def build_benchmark_result(
     *,
     runtime: str,
     precision: Optional[str],
@@ -50,7 +69,29 @@ def _build_benchmark_result(
     accuracy: float,
     env_name: str,
 ) -> BenchmarkResult:
-    """共通形式のベンチマーク結果を構築する."""
+    """ランタイム共通のベンチマーク結果を構築する.
+
+    Args:
+        runtime: ランタイム種別 ("onnx", "tensorrt", "pytorch").
+        precision: 精度 ("fp32", "fp16", "int8"). None も可.
+        device: デバイス ("cuda", "cpu").
+        pipeline: 使用した前処理パイプライン.
+        model_name: モデル名.
+        batch_size: 実行バッチサイズ.
+        gpu_non_blocking: non_blocking設定値.
+        pin_memory: pin_memory設定値.
+        input_size: 入力サイズ (C, H, W).
+        avg_time_per_image: 純粋推論平均時間 (ms/image).
+        avg_total_time_per_image: E2E平均時間 (ms/image).
+        num_samples: データセット全サンプル数.
+        total_samples: 実測サンプル数.
+        warmup_samples: ウォームアップ除外サンプル数.
+        accuracy: 精度(%).
+        env_name: 環境ラベル.
+
+    Returns:
+        生成したベンチマーク結果.
+    """
     return BenchmarkResult(
         timestamp_jst=_now_jst_timestamp(),
         env_name=env_name,
@@ -77,197 +118,4 @@ def _build_benchmark_result(
             measured_samples=total_samples,
             warmup_samples=warmup_samples,
         ),
-    )
-
-
-def build_onnx_benchmark_result(
-    *,
-    use_gpu: bool,
-    pipeline: str,
-    model_name: str,
-    batch_size: int,
-    gpu_non_blocking: bool,
-    pin_memory: bool,
-    input_size: Optional[tuple[int, int, int]],
-    avg_time_per_image: float,
-    avg_total_time_per_image: float,
-    num_samples: int,
-    total_samples: int,
-    warmup_samples: int,
-    accuracy: float,
-    env_name: str,
-) -> BenchmarkResult:
-    """ONNX推論の集計結果からベンチ結果型を構築する.
-
-    Args:
-        use_gpu: GPU利用有無.
-        pipeline: 使用した前処理パイプライン.
-        model_name: モデル名.
-        batch_size: 実行バッチサイズ.
-        gpu_non_blocking: non_blocking設定値.
-        pin_memory: pin_memory設定値.
-        input_size: 入力サイズ (C, H, W).
-        avg_time_per_image: 純粋推論平均時間 (ms/image).
-        avg_total_time_per_image: E2E平均時間 (ms/image).
-        num_samples: データセット全サンプル数.
-        total_samples: 実測サンプル数.
-        warmup_samples: ウォームアップ除外サンプル数.
-        accuracy: 精度(%).
-        env_name: 環境ラベル.
-
-    Returns:
-        生成したベンチマーク結果.
-    """
-    return _build_benchmark_result(
-        runtime="onnx",
-        precision="fp32",
-        device="cuda" if use_gpu else "cpu",
-        pipeline=pipeline,
-        model_name=model_name,
-        batch_size=batch_size,
-        gpu_non_blocking=gpu_non_blocking,
-        pin_memory=pin_memory,
-        input_size=input_size,
-        avg_time_per_image=avg_time_per_image,
-        avg_total_time_per_image=avg_total_time_per_image,
-        num_samples=num_samples,
-        total_samples=total_samples,
-        warmup_samples=warmup_samples,
-        accuracy=accuracy,
-        env_name=env_name,
-    )
-
-
-def _resolve_trt_precision(engine_path: Path) -> Optional[str]:
-    """エンジンファイル名から推定できる精度を返す.
-
-    Args:
-        engine_path: TensorRTエンジンファイル.
-
-    Returns:
-        推定精度文字列. 推定不能な場合はNone.
-    """
-    lowered = engine_path.name.lower()
-    if "int8" in lowered:
-        return "int8"
-    if "fp16" in lowered:
-        return "fp16"
-    if "fp32" in lowered:
-        return "fp32"
-    return None
-
-
-def build_trt_benchmark_result(
-    *,
-    engine_path: Path,
-    pipeline: str,
-    model_name: str,
-    batch_size: int,
-    gpu_non_blocking: bool,
-    pin_memory: bool,
-    input_size: Optional[tuple[int, int, int]],
-    avg_time_per_image: float,
-    avg_total_time_per_image: float,
-    num_samples: int,
-    total_samples: int,
-    warmup_samples: int,
-    accuracy: float,
-    env_name: str,
-) -> BenchmarkResult:
-    """TensorRT推論の集計結果からベンチ結果型を構築する.
-
-    Args:
-        engine_path: TensorRTエンジンファイル.
-        pipeline: 使用した前処理パイプライン.
-        model_name: モデル名.
-        batch_size: 実行バッチサイズ.
-        gpu_non_blocking: non_blocking設定値.
-        pin_memory: pin_memory設定値.
-        input_size: 入力サイズ (C, H, W).
-        avg_time_per_image: 純粋推論平均時間 (ms/image).
-        avg_total_time_per_image: E2E平均時間 (ms/image).
-        num_samples: データセット全サンプル数.
-        total_samples: 実測サンプル数.
-        warmup_samples: ウォームアップ除外サンプル数.
-        accuracy: 精度(%).
-        env_name: 環境ラベル.
-
-    Returns:
-        生成したベンチマーク結果.
-    """
-    return _build_benchmark_result(
-        runtime="tensorrt",
-        precision=_resolve_trt_precision(engine_path),
-        device="cuda",
-        pipeline=pipeline,
-        model_name=model_name,
-        batch_size=batch_size,
-        gpu_non_blocking=gpu_non_blocking,
-        pin_memory=pin_memory,
-        input_size=input_size,
-        avg_time_per_image=avg_time_per_image,
-        avg_total_time_per_image=avg_total_time_per_image,
-        num_samples=num_samples,
-        total_samples=total_samples,
-        warmup_samples=warmup_samples,
-        accuracy=accuracy,
-        env_name=env_name,
-    )
-
-
-def build_pytorch_benchmark_result(
-    *,
-    use_gpu: bool,
-    pipeline: str,
-    model_name: str,
-    batch_size: int,
-    gpu_non_blocking: bool,
-    pin_memory: bool,
-    input_size: Optional[tuple[int, int, int]],
-    avg_time_per_image: float,
-    avg_total_time_per_image: float,
-    num_samples: int,
-    total_samples: int,
-    warmup_samples: int,
-    accuracy: float,
-    env_name: str,
-) -> BenchmarkResult:
-    """PyTorch推論の集計結果からベンチ結果型を構築する.
-
-    Args:
-        use_gpu: GPU利用有無.
-        pipeline: 使用した前処理パイプライン.
-        model_name: モデル名.
-        batch_size: 実行バッチサイズ.
-        gpu_non_blocking: non_blocking設定値.
-        pin_memory: pin_memory設定値.
-        input_size: 入力サイズ (C, H, W).
-        avg_time_per_image: 純粋推論平均時間 (ms/image).
-        avg_total_time_per_image: E2E平均時間 (ms/image).
-        num_samples: データセット全サンプル数.
-        total_samples: 実測サンプル数.
-        warmup_samples: ウォームアップ除外サンプル数.
-        accuracy: 精度(%).
-        env_name: 環境ラベル.
-
-    Returns:
-        生成したベンチマーク結果.
-    """
-    return _build_benchmark_result(
-        runtime="pytorch",
-        precision="fp32",
-        device="cuda" if use_gpu else "cpu",
-        pipeline=pipeline,
-        model_name=model_name,
-        batch_size=batch_size,
-        gpu_non_blocking=gpu_non_blocking,
-        pin_memory=pin_memory,
-        input_size=input_size,
-        avg_time_per_image=avg_time_per_image,
-        avg_total_time_per_image=avg_total_time_per_image,
-        num_samples=num_samples,
-        total_samples=total_samples,
-        warmup_samples=warmup_samples,
-        accuracy=accuracy,
-        env_name=env_name,
     )


### PR DESCRIPTION
## Summary

- `build_onnx/trt/pytorch_benchmark_result()` 3関数を `build_benchmark_result()` 1関数に統合した.
- `runtime`, `precision`, `device` をパラメータ化し, 新ランタイム追加時にラッパー関数が不要になった.

## Related Issue

Closes #344

## Changes

- `pochitrain/inference/benchmark/result_builder.py` を変更した.
  - `_build_benchmark_result()` を `build_benchmark_result()` としてパブリック化した.
  - `_resolve_trt_precision()` を `resolve_trt_precision()` としてパブリック化した.
  - `build_onnx_benchmark_result()`, `build_trt_benchmark_result()`, `build_pytorch_benchmark_result()` を削除した.
  - 274行 → 116行.
- `pochitrain/inference/benchmark/__init__.py` のエクスポートを更新した.
- CLI 3ファイルの呼び出しを `build_benchmark_result()` に変更した.
  - `cli/infer_onnx.py`: `runtime="onnx", precision="fp32", device="cuda" if use_gpu else "cpu"`.
  - `cli/infer_trt.py`: `runtime="tensorrt", precision=resolve_trt_precision(engine_path), device="cuda"`.
  - `cli/commands/infer.py`: `runtime="pytorch", precision="fp32", device="cuda" if use_gpu else "cpu"`.

## Code Changes

```python
# Before: 3つのラッパー関数 (各 ~50行)
build_onnx_benchmark_result(use_gpu=..., pipeline=..., ...)
build_trt_benchmark_result(engine_path=..., pipeline=..., ...)
build_pytorch_benchmark_result(use_gpu=..., pipeline=..., ...)

# After: 1つの統合関数
build_benchmark_result(
    runtime="onnx",
    precision="fp32",
    device="cuda" if use_gpu else "cpu",
    pipeline=...,
    ...
)
```

## Test Plan

- `uv run pytest` で全692テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`
