### PR TITLE
chore: v1.8.3 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,30 @@
 - なし.
 
 ### Changed
+- なし.
+
+### Fixed
+- なし.
+
+### Removed
+- なし.
+
+## v1.8.3 (2026-03-23)
+
+### 概要
+- CLI 推論モジュールの重複解消とベンチマーク結果構築の統合を含むパッチリリースです.
+
+### Added
+- なし.
+
+### Changed
 - ベンチマーク JSON 出力の env_name 解決パターンを共通化した ([#358](https://github.com/kurorosu/pochitrain/pull/358)).
   - `resolve_benchmark_env_name()` を `result_exporter.py` に追加し, 3箇所の CLI から呼び出すようにした.
 - `infer_onnx.py` と `infer_trt.py` の共通処理を抽出した ([#359](https://github.com/kurorosu/pochitrain/pull/359)).
   - `cli_commons.py` に `run_inference_pipeline()` を追加し, パス解決からエクスポートまでの共通フローを一元化した.
   - ログ初期化を `setup_logging()` に統一した.
   - `infer_onnx.py`: 222行 → 172行, `infer_trt.py`: 222行 → 179行.
-- `result_builder.py` のベンチマーク結果構築関数を統合した (`N/A.`).
+- `result_builder.py` のベンチマーク結果構築関数を統合した ([#360](https://github.com/kurorosu/pochitrain/pull/360)).
   - `build_onnx/trt/pytorch_benchmark_result()` 3関数を `build_benchmark_result()` 1関数に統合した.
   - `_resolve_trt_precision()` を `resolve_trt_precision()` としてパブリック化した.
 
@@ -23,37 +40,7 @@
 - なし.
 
 ### Removed
-- なし.
-
-## v1.8.2 (2026-03-21)
-
-### 概要
-- コード品質改善 (バグ修正, テスト追加, 定数化, 型補完) を含むパッチリリースです.
-
-### Added
-- なし.
-
-### Changed
-- マジックナンバーを定数化した ([#355](https://github.com/kurorosu/pochitrain/pull/355)).
-  - `pochi_predictor.py`: ウォームアップ反復回数 `_WARMUP_ITERATIONS = 10`.
-  - `epoch_runner.py`: ログ出力バッチ間隔 `_LOG_BATCH_INTERVAL = 100`.
-  - `pochi_dataset.py`: Resize スケール倍率 `_RESIZE_SCALE_FACTOR = 1.14`, ColorJitter パラメータ.
-- 型アノテーションを補完した ([#356](https://github.com/kurorosu/pochitrain/pull/356)).
-  - `pochi_dataset.py`: `get_class_counts() -> dict[str, int]`.
-  - `directory_manager.py`: `save_dataset_paths(train_paths: list[str], ...)`.
-  - `param_group_builder.py`: `layer_params: dict[str, list[torch.nn.Parameter]]`.
-
-### Fixed
-- `InputShapeResolver._detect_from_onnx()` の無言例外無視を修正した ([#353](https://github.com/kurorosu/pochitrain/pull/353)).
-  - `except Exception: pass` を `logger.debug()` に変更し, デバッグ時にエラー原因を追跡可能にした.
-
-### Tests
-- `input_shape_resolver.py` と `int8_config.py` のテストを追加した ([#354](https://github.com/kurorosu/pochitrain/pull/354)).
-  - `InputShapeResolver`: CLI入力, 静的/動的 ONNX, onnx 未インストール, 破損ファイル, extract_static_shape のテストを追加した.
-  - `INT8CalibrationConfigurer`: 明示パス指定, config 自動検出, calib_data 未指定, パス不在, val_transform 未設定, config 読み込みエラー, キャッシュファイルパスのテストを追加した.
-
-### Removed
-- なし.
+- `build_onnx_benchmark_result()`, `build_trt_benchmark_result()`, `build_pytorch_benchmark_result()` を削除した ([#360](https://github.com/kurorosu/pochitrain/pull/360)).
 
 ## Archived Changelogs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pochitrain
 
-[![Version](https://img.shields.io/badge/version-1.8.2-blue.svg)](https://github.com/kurorosu/pochitrain)
+[![Version](https://img.shields.io/badge/version-1.8.3-blue.svg)](https://github.com/kurorosu/pochitrain)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-yellow.svg)](https://www.python.org/)
 [![Jetson](https://img.shields.io/badge/Jetson-JetPack%206.2.1%20%28Python%203.10%29-76B900.svg)](https://developer.nvidia.com/embedded/jetpack)

--- a/changelogs/1.8.x.md
+++ b/changelogs/1.8.x.md
@@ -1,5 +1,35 @@
 # Changelog 1.8.x
 
+## v1.8.2 (2026-03-21)
+
+### 概要
+- コード品質改善 (バグ修正, テスト追加, 定数化, 型補完) を含むパッチリリースです.
+
+### Added
+- なし.
+
+### Changed
+- マジックナンバーを定数化した ([#355](https://github.com/kurorosu/pochitrain/pull/355)).
+  - `pochi_predictor.py`: ウォームアップ反復回数 `_WARMUP_ITERATIONS = 10`.
+  - `epoch_runner.py`: ログ出力バッチ間隔 `_LOG_BATCH_INTERVAL = 100`.
+  - `pochi_dataset.py`: Resize スケール倍率 `_RESIZE_SCALE_FACTOR = 1.14`, ColorJitter パラメータ.
+- 型アノテーションを補完した ([#356](https://github.com/kurorosu/pochitrain/pull/356)).
+  - `pochi_dataset.py`: `get_class_counts() -> dict[str, int]`.
+  - `directory_manager.py`: `save_dataset_paths(train_paths: list[str], ...)`.
+  - `param_group_builder.py`: `layer_params: dict[str, list[torch.nn.Parameter]]`.
+
+### Fixed
+- `InputShapeResolver._detect_from_onnx()` の無言例外無視を修正した ([#353](https://github.com/kurorosu/pochitrain/pull/353)).
+  - `except Exception: pass` を `logger.debug()` に変更し, デバッグ時にエラー原因を追跡可能にした.
+
+### Tests
+- `input_shape_resolver.py` と `int8_config.py` のテストを追加した ([#354](https://github.com/kurorosu/pochitrain/pull/354)).
+  - `InputShapeResolver`: CLI入力, 静的/動的 ONNX, onnx 未インストール, 破損ファイル, extract_static_shape のテストを追加した.
+  - `INT8CalibrationConfigurer`: 明示パス指定, config 自動検出, calib_data 未指定, パス不在, val_transform 未設定, config 読み込みエラー, キャッシュファイルパスのテストを追加した.
+
+### Removed
+- なし.
+
 ## v1.8.1 (2026-03-20)
 
 ### 概要

--- a/pochitrain/__init__.py
+++ b/pochitrain/__init__.py
@@ -20,7 +20,7 @@ from .pochi_dataset import (
 from .pochi_predictor import PochiPredictor
 from .pochi_trainer import PochiTrainer
 
-__version__ = "1.8.2"
+__version__ = "1.8.3"
 __author__ = "Pochi Team"
 __email__ = "pochi@example.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochitrain"
-version = "1.8.2"
+version = "1.8.3"
 description = "Simple CNN training framework for image classification"
 readme = "README.md"
 # Jetson (JetPack 6.2.1 / Python 3.10) で pip install -e . するため >=3.10 を維持.

--- a/uv.lock
+++ b/uv.lock
@@ -1848,7 +1848,7 @@ wheels = [
 
 [[package]]
 name = "pochitrain"
-version = "1.8.2"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
## Summary

- バージョンを 1.8.2 → 1.8.3 に更新した.
- v1.8.2 の CHANGELOG を `changelogs/1.8.x.md` にアーカイブした.

## Related Issue

無し

## Changes

- `pyproject.toml`: version を 1.8.3 に更新.
- `pochitrain/__init__.py`: `__version__` を 1.8.3 に更新.
- `README.md`: バージョンバッジを 1.8.3 に更新.
- `uv.lock`: `uv lock` で更新.
- `CHANGELOG.md`: `[Unreleased]` を v1.8.3 に昇格, v1.8.2 をアーカイブへ移動.
- `changelogs/1.8.x.md`: v1.8.2 を追加.

## Test Plan

- `uv run pytest` で全テストがパスすることを確認.

## Checklist

- [x] `uv run pre-commit run --all-files`