### PR TITLE
refactor: pochi serve のログフォーマットを LoggerManager に統一

### DIFF
--- a/pochitrain/cli/commands/serve.py
+++ b/pochitrain/cli/commands/serve.py
@@ -11,26 +11,46 @@ from pochitrain.api.config import ServerConfig
 from pochitrain.cli.cli_commons import setup_logging
 from pochitrain.utils.inference_utils import validate_model_path
 
-_UVICORN_LOG_FORMAT = (
+_UVICORN_COLOR_FORMAT = (
+    "%(asctime)s|%(log_color)s%(levelname)-5.5s%(reset)s|"
+    "%(name)-18s|%(lineno)03d| %(message)s"
+)
+_UVICORN_PLAIN_FORMAT = (
     "%(asctime)s|%(levelname)-5.5s|%(name)-18s|%(lineno)03d| %(message)s"
 )
 _UVICORN_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+_UVICORN_LOG_COLORS = {
+    "DEBUG": "cyan",
+    "INFO": "green",
+    "WARNING": "yellow",
+    "ERROR": "red",
+    "CRITICAL": "red,bg_white",
+}
 
 
 def _build_uvicorn_log_config(log_level: str) -> dict[str, Any]:
     """Uvicorn 用のログ設定を LoggerManager と同一フォーマットで生成する."""
+    try:
+        import colorlog  # noqa: F401
+
+        formatter_config: dict[str, Any] = {
+            "()": "colorlog.ColoredFormatter",
+            "format": _UVICORN_COLOR_FORMAT,
+            "datefmt": _UVICORN_DATE_FORMAT,
+            "log_colors": _UVICORN_LOG_COLORS,
+        }
+    except ImportError:
+        formatter_config = {
+            "format": _UVICORN_PLAIN_FORMAT,
+            "datefmt": _UVICORN_DATE_FORMAT,
+        }
+
     return {
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {
-            "default": {
-                "format": _UVICORN_LOG_FORMAT,
-                "datefmt": _UVICORN_DATE_FORMAT,
-            },
-            "access": {
-                "format": _UVICORN_LOG_FORMAT,
-                "datefmt": _UVICORN_DATE_FORMAT,
-            },
+            "default": formatter_config,
+            "access": formatter_config,
         },
         "handlers": {
             "default": {

--- a/pochitrain/cli/commands/serve.py
+++ b/pochitrain/cli/commands/serve.py
@@ -24,11 +24,11 @@ def _build_uvicorn_log_config(log_level: str) -> dict[str, Any]:
         "disable_existing_loggers": False,
         "formatters": {
             "default": {
-                "fmt": _UVICORN_LOG_FORMAT,
+                "format": _UVICORN_LOG_FORMAT,
                 "datefmt": _UVICORN_DATE_FORMAT,
             },
             "access": {
-                "fmt": _UVICORN_LOG_FORMAT,
+                "format": _UVICORN_LOG_FORMAT,
                 "datefmt": _UVICORN_DATE_FORMAT,
             },
         },

--- a/pochitrain/cli/commands/serve.py
+++ b/pochitrain/cli/commands/serve.py
@@ -2,6 +2,7 @@
 
 import argparse
 from pathlib import Path
+from typing import Any
 
 import uvicorn
 
@@ -9,6 +10,58 @@ from pochitrain.api.app import create_app
 from pochitrain.api.config import ServerConfig
 from pochitrain.cli.cli_commons import setup_logging
 from pochitrain.utils.inference_utils import validate_model_path
+
+_UVICORN_LOG_FORMAT = (
+    "%(asctime)s|%(levelname)-5.5s|%(name)-18s|%(lineno)03d| %(message)s"
+)
+_UVICORN_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def _build_uvicorn_log_config(log_level: str) -> dict[str, Any]:
+    """Uvicorn 用のログ設定を LoggerManager と同一フォーマットで生成する."""
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "fmt": _UVICORN_LOG_FORMAT,
+                "datefmt": _UVICORN_DATE_FORMAT,
+            },
+            "access": {
+                "fmt": _UVICORN_LOG_FORMAT,
+                "datefmt": _UVICORN_DATE_FORMAT,
+            },
+        },
+        "handlers": {
+            "default": {
+                "formatter": "default",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stderr",
+            },
+            "access": {
+                "formatter": "access",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            },
+        },
+        "loggers": {
+            "uvicorn": {
+                "handlers": ["default"],
+                "level": log_level.upper(),
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "level": log_level.upper(),
+                "handlers": ["default"],
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["access"],
+                "level": log_level.upper(),
+                "propagate": False,
+            },
+        },
+    }
 
 
 def serve_command(args: argparse.Namespace) -> None:
@@ -44,9 +97,11 @@ def serve_command(args: argparse.Namespace) -> None:
     )
 
     debug = getattr(args, "debug", False)
+    log_level = "debug" if debug else "info"
     uvicorn.run(
         app,
         host=server_config.host,
         port=server_config.port,
-        log_level="debug" if debug else "info",
+        log_level=log_level,
+        log_config=_build_uvicorn_log_config(log_level),
     )

--- a/pochitrain/cli/commands/serve.py
+++ b/pochitrain/cli/commands/serve.py
@@ -9,8 +9,11 @@ import uvicorn
 from pochitrain.api.app import create_app
 from pochitrain.api.config import ServerConfig
 from pochitrain.cli.cli_commons import setup_logging
+from pochitrain.logging import COLORLOG_AVAILABLE, LOG_COLORS, LOG_DATE_FORMAT
 from pochitrain.utils.inference_utils import validate_model_path
 
+# uvicorn は %(module) だと全て "h11_impl" 等になるため %(name) を使用する.
+# LoggerManager は %(module) (ファイル名) を使用している.
 _UVICORN_COLOR_FORMAT = (
     "%(asctime)s|%(log_color)s%(levelname)-5.5s%(reset)s|"
     "%(name)-18s|%(lineno)03d| %(message)s"
@@ -18,31 +21,21 @@ _UVICORN_COLOR_FORMAT = (
 _UVICORN_PLAIN_FORMAT = (
     "%(asctime)s|%(levelname)-5.5s|%(name)-18s|%(lineno)03d| %(message)s"
 )
-_UVICORN_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
-_UVICORN_LOG_COLORS = {
-    "DEBUG": "cyan",
-    "INFO": "green",
-    "WARNING": "yellow",
-    "ERROR": "red",
-    "CRITICAL": "red,bg_white",
-}
 
 
 def _build_uvicorn_log_config(log_level: str) -> dict[str, Any]:
     """Uvicorn 用のログ設定を LoggerManager と同一フォーマットで生成する."""
-    try:
-        import colorlog  # noqa: F401
-
+    if COLORLOG_AVAILABLE:
         formatter_config: dict[str, Any] = {
             "()": "colorlog.ColoredFormatter",
             "format": _UVICORN_COLOR_FORMAT,
-            "datefmt": _UVICORN_DATE_FORMAT,
-            "log_colors": _UVICORN_LOG_COLORS,
+            "datefmt": LOG_DATE_FORMAT,
+            "log_colors": LOG_COLORS,
         }
-    except ImportError:
+    else:
         formatter_config = {
             "format": _UVICORN_PLAIN_FORMAT,
-            "datefmt": _UVICORN_DATE_FORMAT,
+            "datefmt": LOG_DATE_FORMAT,
         }
 
     return {

--- a/pochitrain/logging/__init__.py
+++ b/pochitrain/logging/__init__.py
@@ -4,6 +4,11 @@ pochitrain.logging: ログ管理モジュール.
 colorlogを使用したオブジェクト指向のログ管理システム
 """
 
-from .logger_manager import LoggerManager
+from .logger_manager import (
+    COLORLOG_AVAILABLE,
+    LOG_COLORS,
+    LOG_DATE_FORMAT,
+    LoggerManager,
+)
 
-__all__ = ["LoggerManager"]
+__all__ = ["COLORLOG_AVAILABLE", "LOG_COLORS", "LOG_DATE_FORMAT", "LoggerManager"]

--- a/pochitrain/logging/logger_manager.py
+++ b/pochitrain/logging/logger_manager.py
@@ -15,6 +15,17 @@ try:
 except ImportError:
     COLORLOG_AVAILABLE = False
 
+LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+LOG_COLORS: dict[str, str] = {
+    "DEBUG": "cyan",
+    "INFO": "green",
+    "WARN": "yellow",
+    "WARNING": "yellow",
+    "ERROR": "red",
+    "CRITICAL": "red,bg_white",
+}
+
 
 class LogLevel(Enum):
     """ログレベル列挙型."""
@@ -57,15 +68,8 @@ class LoggerManager:
             "%(asctime)s|%(log_color)s%(levelname)-5.5s%(reset)s|"
             "%(module)-18s|%(lineno)03d| %(message)s"
         )
-        self._date_format = "%Y-%m-%d %H:%M:%S"
-        self._log_colors = {
-            "DEBUG": "cyan",
-            "INFO": "green",
-            "WARN": "yellow",
-            "WARNING": "yellow",
-            "ERROR": "red",
-            "CRITICAL": "red,bg_white",
-        }
+        self._date_format = LOG_DATE_FORMAT
+        self._log_colors = LOG_COLORS
         self._initialized = True
 
     def get_logger(self, name: str, level: Optional[LogLevel] = None) -> logging.Logger:

--- a/tests/unit/test_cli/test_serve_cli.py
+++ b/tests/unit/test_cli/test_serve_cli.py
@@ -1,0 +1,93 @@
+"""pochi serve CLI のテスト."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pochitrain.cli.commands.serve import _build_uvicorn_log_config
+
+
+class TestBuildUvicornLogConfig:
+    """_build_uvicorn_log_config() のテスト."""
+
+    def test_config_structure(self):
+        """返却される辞書に必須キーが含まれることを確認."""
+        config = _build_uvicorn_log_config("info")
+        assert config["version"] == 1
+        assert "formatters" in config
+        assert "handlers" in config
+        assert "loggers" in config
+        assert "default" in config["formatters"]
+        assert "access" in config["formatters"]
+
+    def test_log_level_info(self):
+        """log_level='info' が大文字変換されてロガーに設定されることを確認."""
+        config = _build_uvicorn_log_config("info")
+        assert config["loggers"]["uvicorn"]["level"] == "INFO"
+        assert config["loggers"]["uvicorn.error"]["level"] == "INFO"
+        assert config["loggers"]["uvicorn.access"]["level"] == "INFO"
+
+    def test_log_level_debug(self):
+        """log_level='debug' が大文字変換されてロガーに設定されることを確認."""
+        config = _build_uvicorn_log_config("debug")
+        assert config["loggers"]["uvicorn"]["level"] == "DEBUG"
+
+    def test_with_colorlog_available(self):
+        """colorlog 利用可能時に ColoredFormatter が設定されることを確認."""
+        config = _build_uvicorn_log_config("info")
+        formatter = config["formatters"]["default"]
+        assert formatter["()"] == "colorlog.ColoredFormatter"
+        assert "log_colors" in formatter
+
+    def test_without_colorlog(self, monkeypatch):
+        """colorlog 未インストール時にプレーンフォーマットが使用されることを確認."""
+        monkeypatch.setattr("pochitrain.cli.commands.serve.COLORLOG_AVAILABLE", False)
+        config = _build_uvicorn_log_config("info")
+        formatter = config["formatters"]["default"]
+        assert "()" not in formatter
+        assert "log_colors" not in formatter
+        assert "format" in formatter
+
+    def test_handlers_stream(self):
+        """default は stderr, access は stdout に出力されることを確認."""
+        config = _build_uvicorn_log_config("info")
+        assert config["handlers"]["default"]["stream"] == "ext://sys.stderr"
+        assert config["handlers"]["access"]["stream"] == "ext://sys.stdout"
+
+
+class TestServeCommand:
+    """serve_command() のテスト."""
+
+    def test_invalid_model_path(self, tmp_path, capsys):
+        """存在しないモデルパスでエラーログが出力されることを確認."""
+        from pochitrain.cli.commands.serve import serve_command
+
+        args = MagicMock()
+        args.model_path = str(tmp_path / "nonexistent.pth")
+        args.debug = False
+
+        serve_command(args)
+        # FileNotFoundError がキャッチされ return するので例外は発生しない
+
+    @patch("pochitrain.cli.commands.serve.uvicorn")
+    @patch("pochitrain.cli.commands.serve.create_app")
+    def test_debug_flag_sets_log_level(self, mock_create_app, mock_uvicorn, tmp_path):
+        """--debug フラグが uvicorn の log_level に反映されることを確認."""
+        from pochitrain.cli.commands.serve import serve_command
+
+        model_path = tmp_path / "model.pth"
+        model_path.touch()
+
+        args = MagicMock()
+        args.model_path = str(model_path)
+        args.config_path = None
+        args.backend = "pytorch"
+        args.host = "127.0.0.1"
+        args.port = 8000
+        args.debug = True
+
+        serve_command(args)
+
+        mock_uvicorn.run.assert_called_once()
+        call_kwargs = mock_uvicorn.run.call_args[1]
+        assert call_kwargs["log_level"] == "debug"


### PR DESCRIPTION
## Summary

- `pochi serve` 起動時の uvicorn ログフォーマットを LoggerManager と統一した.
- colorlog によるカラー出力にも対応し, 全ログが同一フォーマットで表示される.

## Related Issue

Closes #367

## Changes

- `pochitrain/cli/commands/serve.py`: uvicorn の `log_config` にカスタム設定を渡し, `uvicorn.error` / `uvicorn.access` のフォーマッタを LoggerManager と同一にした.
  - colorlog が利用可能な場合は `ColoredFormatter` を使用.
  - colorlog が未インストールの場合はプレーンフォーマットにフォールバック.

```python
# pochitrain/cli/commands/serve.py
def _build_uvicorn_log_config(log_level: str) -> dict[str, Any]:
    """Uvicorn 用のログ設定を LoggerManager と同一フォーマットで生成する."""
    formatter_config = {
        "()": "colorlog.ColoredFormatter",
        "format": _UVICORN_COLOR_FORMAT,
        "datefmt": _UVICORN_DATE_FORMAT,
        "log_colors": _UVICORN_LOG_COLORS,
    }
```

## Test Plan

- [x] `pochi serve` 起動時のログが全て `日時|レベル|モジュール|行番号|メッセージ` フォーマットで出力される
- [x] uvicorn ログの INFO が緑色で表示される
- [x] `uv run pre-commit run --all-files` で全チェックがパスする

## Checklist

- [x] `uv run pre-commit run --all-files`
