### PR TITLE
refactor: 推論 API の time 表記を e2e_time に変更

### DIFF
--- a/pochitrain/api/docs/client_usage.md
+++ b/pochitrain/api/docs/client_usage.md
@@ -33,7 +33,7 @@ result = response.json()
 
 print(f"クラス: {result['class_name']} (ID: {result['class_id']})")
 print(f"信頼度: {result['confidence']:.3f}")
-print(f"推論時間: {result['processing_time_ms']:.1f}ms")
+print(f"E2E処理時間: {result['e2e_time_ms']:.1f}ms")
 ```
 
 ## jpeg 形式 (圧縮転送)
@@ -151,7 +151,7 @@ print(requests.get(f"{BASE}/version").json())
   "class_name": "cat",
   "confidence": 0.95,
   "probabilities": [0.01, 0.04, 0.95, 0.00],
-  "processing_time_ms": 12.3,
+  "e2e_time_ms": 12.3,
   "backend": "pytorch"
 }
 ```

--- a/pochitrain/api/routers/inference.py
+++ b/pochitrain/api/routers/inference.py
@@ -47,7 +47,7 @@ async def predict(request: PredictRequest) -> PredictResponse:
     elapsed_ms = (time.perf_counter() - start) * 1000
 
     logger.info(
-        "推論完了: class=%d, confidence=%.3f, time=%.1fms",
+        "推論完了: class=%d, confidence=%.3f, e2e_time=%.1fms",
         result["class_id"],
         result["confidence"],
         elapsed_ms,
@@ -58,6 +58,6 @@ async def predict(request: PredictRequest) -> PredictResponse:
         class_name=result["class_name"],
         confidence=result["confidence"],
         probabilities=result["probabilities"],
-        processing_time_ms=round(elapsed_ms, 3),
+        e2e_time_ms=round(elapsed_ms, 3),
         backend=engine.backend,
     )

--- a/pochitrain/api/schemas.py
+++ b/pochitrain/api/schemas.py
@@ -54,7 +54,7 @@ class PredictResponse(BaseModel):
     class_name: str = Field(description="予測クラス名")
     confidence: float = Field(ge=0.0, le=1.0, description="信頼度 (0.0-1.0)")
     probabilities: list[float] = Field(description="全クラスの確率")
-    processing_time_ms: float = Field(description="推論時間 (ミリ秒)")
+    e2e_time_ms: float = Field(description="エンドツーエンド処理時間 (ミリ秒)")
     backend: str = Field(description="使用バックエンド")
 
 

--- a/tests/unit/test_api/test_routers.py
+++ b/tests/unit/test_api/test_routers.py
@@ -100,7 +100,7 @@ class TestPredictEndpoint:
         assert data["class_name"] == "cat"
         assert data["confidence"] == 0.9
         assert data["backend"] == "pytorch"
-        assert "processing_time_ms" in data
+        assert "e2e_time_ms" in data
 
     def test_predict_1x1_image(self, client):
         """1x1 の境界値画像で推論が成功することを確認."""

--- a/tests/unit/test_api/test_schemas.py
+++ b/tests/unit/test_api/test_schemas.py
@@ -55,7 +55,7 @@ class TestPredictResponse:
             class_name="cat",
             confidence=0.95,
             probabilities=[0.01, 0.04, 0.95],
-            processing_time_ms=12.3,
+            e2e_time_ms=12.3,
             backend="pytorch",
         )
         assert resp.class_id == 2


### PR DESCRIPTION
## Summary

- 推論 API のログ・レスポンスの `time` / `processing_time_ms` を `e2e_time` / `e2e_time_ms` に変更した.
- 前処理+GPU転送+推論+後処理を含むエンドツーエンド処理時間であることを明確にした.

## Related Issue

Closes #369

## Changes

- `pochitrain/api/schemas.py`: `processing_time_ms` → `e2e_time_ms` にリネーム.
- `pochitrain/api/routers/inference.py`: ログ出力を `time=` → `e2e_time=` に変更, レスポンス生成を `e2e_time_ms` に変更.
- `pochitrain/api/docs/client_usage.md`: レスポンス例とクライアントコードを更新.
- `tests/unit/test_api/test_schemas.py`, `test_routers.py`: フィールド名を更新.

## Test Plan

- [x] `uv run pre-commit run --all-files` で全チェックがパスする
- [x] API レスポンスのフィールドが `e2e_time_ms` になっている
- [x] ログ出力が `e2e_time=` と表示される

## Checklist

- [x] `uv run pre-commit run --all-files`
